### PR TITLE
feat: add osi-bootstrap init script for automatic first-boot ChirpStack provisioning

### DIFF
--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap
@@ -1,0 +1,50 @@
+#!/bin/sh /etc/rc.common
+
+START=85
+
+stamp_valid() {
+	[ -f /etc/osi-bootstrap.done ] || return 1
+	[ -f /srv/node-red/.chirpstack.env ] || return 1
+	grep -q 'CHIRPSTACK_APP_SENSORS=[0-9a-f]\{8\}-' /srv/node-red/.chirpstack.env 2>/dev/null || return 1
+	return 0
+}
+
+boot() {
+	start
+}
+
+start() {
+	if stamp_valid; then
+		return 0
+	fi
+
+	if [ ! -f /srv/node-red/chirpstack-bootstrap.js ]; then
+		logger -t osi-bootstrap "bootstrap script not found, marking done"
+		touch /etc/osi-bootstrap.done
+		return 0
+	fi
+
+	logger -t osi-bootstrap "waiting for ChirpStack gRPC..."
+	local ready=0
+	for i in $(seq 1 12); do
+		if curl -sf --max-time 3 http://localhost:8080 2>/dev/null; then
+			ready=1
+			break
+		fi
+		sleep 5
+	done
+
+	if [ "$ready" = 0 ]; then
+		logger -t osi-bootstrap "ChirpStack not ready after 60s, will retry next boot"
+		return 0
+	fi
+
+	logger -t osi-bootstrap "running chirpstack-bootstrap.js..."
+	if node /srv/node-red/chirpstack-bootstrap.js; then
+		touch /etc/osi-bootstrap.done
+		logger -t osi-bootstrap "bootstrap completed successfully"
+	else
+		logger -t osi-bootstrap "bootstrap failed, will retry next boot"
+	fi
+	return 0
+}

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/sysupgrade.conf
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/sysupgrade.conf
@@ -5,3 +5,4 @@
 /srv
 /etc/tailscale/authkey
 /var/lib/tailscale
+/etc/osi-bootstrap.done

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable
@@ -1,0 +1,2 @@
+#!/bin/sh
+/etc/init.d/osi-bootstrap enable

--- a/docs/superpowers/plans/2026-05-17-osi-bootstrap-init.md
+++ b/docs/superpowers/plans/2026-05-17-osi-bootstrap-init.md
@@ -1,0 +1,342 @@
+# osi-bootstrap Init Script Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an auto-bootstrapping init script that eliminates the manual `node /srv/node-red/chirpstack-bootstrap.js` step when flashing a golden image to a new Pi.
+
+**Architecture:** An OpenWrt init script at START=85 (between ChirpStack and Node-RED) checks stamp+env validity, waits for ChirpStack gRPC, runs chirpstack-bootstrap.js, then writes a completion stamp. A uci-defaults script enables the init on first boot. On subsequent boots the stamp is found and the script returns instantly.
+
+**Tech Stack:** Shell (BusyBox ash), OpenWrt init framework (`/etc/rc.common`), `curl` for gRPC health check
+
+**Spec:** [2026-05-17-osi-bootstrap-init-design.md](/home/phil/Repos/osi-os/docs/superpowers/specs/2026-05-17-osi-bootstrap-init-design.md)
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable` | First-boot activation: creates rc.d symlink, self-deletes |
+| Create | `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap` | Main init: stamp check, gRPC wait, bootstrap run |
+| Modify | `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/sysupgrade.conf` | Add `/etc/osi-bootstrap.done` to preserve list |
+| Modify | `scripts/verify-sync-flow.js` | Add repo-level verification of new files |
+
+---
+
+### Task 1: Create uci-defaults activation script
+
+**Files:**
+- Create: `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable`
+
+- [ ] **Step 1: Write the activation script**
+
+```sh
+#!/bin/sh
+/etc/init.d/osi-bootstrap enable
+```
+
+Use Write tool to create the file at `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable` with the content above.
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod 755 conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+ls -la conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable
+# Expected: -rwxr-xr-x ... 95_osi_bootstrap_enable
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable
+git commit -m "feat: add uci-defaults script to enable osi-bootstrap init on first boot"
+```
+
+---
+
+### Task 2: Create osi-bootstrap init script
+
+**Files:**
+- Create: `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap`
+
+- [ ] **Step 1: Write the init script**
+
+```sh
+#!/bin/sh /etc/rc.common
+
+START=85
+
+stamp_valid() {
+	[ -f /etc/osi-bootstrap.done ] || return 1
+	[ -f /srv/node-red/.chirpstack.env ] || return 1
+	grep -q 'CHIRPSTACK_APP_SENSORS=[0-9a-f]\{8\}-' /srv/node-red/.chirpstack.env 2>/dev/null || return 1
+	return 0
+}
+
+boot() {
+	start
+}
+
+start() {
+	if stamp_valid; then
+		return 0
+	fi
+
+	if [ ! -f /srv/node-red/chirpstack-bootstrap.js ]; then
+		logger -t osi-bootstrap "bootstrap script not found, marking done"
+		touch /etc/osi-bootstrap.done
+		return 0
+	fi
+
+	logger -t osi-bootstrap "waiting for ChirpStack gRPC..."
+	local ready=0
+	for i in $(seq 1 12); do
+		if curl -sf --max-time 3 http://localhost:8080 2>/dev/null; then
+			ready=1
+			break
+		fi
+		sleep 5
+	done
+
+	if [ "$ready" = 0 ]; then
+		logger -t osi-bootstrap "ChirpStack not ready after 60s, will retry next boot"
+		return 0
+	fi
+
+	logger -t osi-bootstrap "running chirpstack-bootstrap.js..."
+	if node /srv/node-red/chirpstack-bootstrap.js; then
+		touch /etc/osi-bootstrap.done
+		logger -t osi-bootstrap "bootstrap completed successfully"
+	else
+		logger -t osi-bootstrap "bootstrap failed, will retry next boot"
+	fi
+	return 0
+}
+```
+
+Use Write tool to create the file at `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap` with the content above.
+
+- [ ] **Step 2: Make it executable**
+
+```bash
+chmod 755 conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap
+```
+
+- [ ] **Step 3: Verify syntax statically**
+
+```bash
+# Check the shebang line and START= line
+head -3 conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap
+# Expected: #!/bin/sh /etc/rc.common\n\nSTART=85
+
+# Verify key functions are present
+grep -c 'stamp_valid\|boot()\|start()' conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap
+# Expected: 3 (three function definitions)
+
+# Verify no STOP= is set (one-shot script, no shutdown behavior)
+grep -c 'STOP=' conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap
+# Expected: 0
+
+# Verify logger uses the correct tag throughout
+grep 'logger.*osi-bootstrap' conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap | wc -l
+# Expected: 5
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap
+git commit -m "feat: add osi-bootstrap init script for automatic first-boot ChirpStack provisioning"
+```
+
+---
+
+### Task 3: Add stamp file to sysupgrade.conf
+
+**Files:**
+- Modify: `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/sysupgrade.conf`
+
+- [ ] **Step 1: Add the stamp file path**
+
+Read the current `sysupgrade.conf` and append `/etc/osi-bootstrap.done` before the final line. The file currently reads:
+
+```
+## This file contains files and directories that should
+## be preserved during an upgrade.
+# /etc/example.conf
+# /etc/openvpn/
+/srv
+/etc/tailscale/authkey
+/var/lib/tailscale
+```
+
+Use Edit tool to replace the last line (`/var/lib/tailscale`) with:
+
+```
+/var/lib/tailscale
+/etc/osi-bootstrap.done
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+tail -3 conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/sysupgrade.conf
+# Expected:
+# /etc/tailscale/authkey
+# /var/lib/tailscale
+# /etc/osi-bootstrap.done
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/sysupgrade.conf
+git commit -m "feat: preserve osi-bootstrap stamp file across sysupgrade"
+```
+
+---
+
+### Task 4: Add verification to verify-sync-flow.js
+
+**Files:**
+- Modify: `scripts/verify-sync-flow.js` (append checks near end, before the `Promise.all(pendingChecks)` block)
+
+- [ ] **Step 1: Define file paths for new files**
+
+Find the existing file path declarations at lines 13-16 (near `osiServerDefaultsPath`, `sx1301GatewayDefaultPath`, etc.). Add two new paths after line 16 (`const chirpstackBootstrapPath`):
+
+```javascript
+const osiBootstrapInitPath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'etc', 'init.d', 'osi-bootstrap');
+const osiBootstrapEnablePath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'etc', 'uci-defaults', '95_osi_bootstrap_enable');
+const sysupgradeConfPath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'etc', 'sysupgrade.conf');
+```
+
+Use Edit tool to insert these three lines right after line 16 (`const chirpstackBootstrapPath = path.resolve(__dirname, 'chirpstack-bootstrap.js');`).
+
+- [ ] **Step 2: Read the new files and add verification checks**
+
+Find a good insertion point near the end of the file, before the `Promise.all(pendingChecks)` block at line 2353. Add the following verification block before it (after the last `expectFileIncludes` / `expectFileExcludes` call, around line 1769):
+
+```javascript
+// --- osi-bootstrap init script verification ---
+
+let osiBootstrapInitScript = '';
+if (fs.existsSync(osiBootstrapInitPath)) {
+  osiBootstrapInitScript = fs.readFileSync(osiBootstrapInitPath, 'utf8');
+  console.log('OK osi-bootstrap init script present');
+} else {
+  fail(`missing osi-bootstrap init script at ${osiBootstrapInitPath}`);
+}
+
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'START=85', 'init script declares correct boot priority');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'stamp_valid()', 'init script defines stamp validity check');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, '/etc/osi-bootstrap.done', 'init script uses the canonical stamp file path');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, '/srv/node-red/.chirpstack.env', 'init script checks env file existence');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, "grep -q 'CHIRPSTACK_APP_SENSORS=[0-9a-f]\\{8\\}-'", 'init script validates env file contains valid app UUIDs');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'chirpstack-bootstrap.js', 'init script references the bootstrap script');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'curl -sf --max-time 3 http://localhost:8080', 'init script waits for ChirpStack gRPC via curl');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'seq 1 12', 'init script retries gRPC health check up to 12 times');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'logger -t osi-bootstrap', 'init script logs all events with the correct tag');
+expectFileExcludes('osi-bootstrap', osiBootstrapInitScript, 'STOP=', 'init script does not set a shutdown priority (one-shot)');
+
+// uci-defaults activation script
+let osiBootstrapEnableScript = '';
+if (fs.existsSync(osiBootstrapEnablePath)) {
+  osiBootstrapEnableScript = fs.readFileSync(osiBootstrapEnablePath, 'utf8');
+  console.log('OK osi-bootstrap uci-defaults activation script present');
+} else {
+  fail(`missing osi-bootstrap uci-defaults activation script at ${osiBootstrapEnablePath}`);
+}
+
+expectFileIncludes('95_osi_bootstrap_enable', osiBootstrapEnableScript, '/etc/init.d/osi-bootstrap enable', 'activation script enables the osi-bootstrap init on first boot');
+
+// sysupgrade.conf preservation
+let sysupgradeConf = '';
+if (fs.existsSync(sysupgradeConfPath)) {
+  sysupgradeConf = fs.readFileSync(sysupgradeConfPath, 'utf8');
+  console.log('OK sysupgrade.conf present');
+} else {
+  fail(`missing sysupgrade.conf at ${sysupgradeConfPath}`);
+}
+
+expectFileIncludes('sysupgrade.conf', sysupgradeConf, '/etc/osi-bootstrap.done', 'sysupgrade.conf preserves the osi-bootstrap stamp file');
+```
+
+Use Edit tool to insert this block right before the existing `Promise.all(pendingChecks)` line (currently `Promise.all(pendingChecks).finally(() => {`).
+
+- [ ] **Step 3: Run the verification script**
+
+```bash
+node scripts/verify-sync-flow.js
+```
+
+Expected: All checks pass, including the new osi-bootstrap checks. Final line: `Sync flow verification passed`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/verify-sync-flow.js
+git commit -m "feat: add osi-bootstrap init script verification to sync flow checks"
+```
+
+---
+
+### Task 5: Final verification and summary
+
+- [ ] **Step 1: Run full verification**
+
+```bash
+node scripts/verify-sync-flow.js
+```
+
+Expected output includes:
+```
+OK osi-bootstrap init script present
+OK osi-bootstrap init script declares correct boot priority
+OK osi-bootstrap init script defines stamp validity check
+OK osi-bootstrap init script uses the canonical stamp file path
+OK osi-bootstrap init script checks env file existence
+OK osi-bootstrap init script validates env file contains valid app UUIDs
+OK osi-bootstrap init script references the bootstrap script
+OK osi-bootstrap init script waits for ChirpStack gRPC via curl
+OK osi-bootstrap init script retries gRPC health check up to 12 times
+OK osi-bootstrap init script logs all events with the correct tag
+OK osi-bootstrap init script does not set a shutdown priority (one-shot)
+OK osi-bootstrap uci-defaults activation script present
+OK activation script enables the osi-bootstrap init on first boot
+OK sysupgrade.conf present
+OK sysupgrade.conf preserves the osi-bootstrap stamp file
+Sync flow verification passed
+```
+
+- [ ] **Step 2: List all files changed**
+
+```bash
+git log --oneline -4
+```
+
+Expected: Four commits in this order:
+1. `feat: add uci-defaults script to enable osi-bootstrap init on first boot`
+2. `feat: add osi-bootstrap init script for automatic first-boot ChirpStack provisioning`
+3. `feat: preserve osi-bootstrap stamp file across sysupgrade`
+4. `feat: add osi-bootstrap init script verification to sync flow checks`
+
+---
+
+## Hardware Smoke Test (separate, not in this plan)
+
+After building a golden image with these changes:
+
+1. Flash golden image to SD card
+2. Boot on Pi 5; wait 2 min
+3. Verify: `ls /etc/rc.d/S85osi-bootstrap` — symlink exists (uci-defaults created it)
+4. Verify: `cat /etc/osi-bootstrap.done` — exists (bootstrap succeeded)
+5. Verify: `grep CHIRPSTACK_APP_SENSORS /srv/node-red/.chirpstack.env` — valid UUID
+6. Verify: `uci get osi-server.cloud.chirpstack_app_sensors` — matching UUID
+7. Reboot; verify bootstrap is a no-op (no duplicate log messages)
+8. Delete `.chirpstack.env`; reboot; verify bootstrap re-runs and recreates it

--- a/docs/superpowers/specs/2026-05-17-osi-bootstrap-init-design.md
+++ b/docs/superpowers/specs/2026-05-17-osi-bootstrap-init-design.md
@@ -1,0 +1,216 @@
+# osi-bootstrap: automatic first-boot ChirpStack provisioning init script
+
+**Status:** draft
+**Date:** 2026-05-17
+**Scope:** New `/etc/init.d/osi-bootstrap` init script + golden image build integration
+
+---
+
+## 1. Purpose
+
+Eliminate the manual `node /srv/node-red/chirpstack-bootstrap.js` step after flashing a golden image. On first boot, the init script detects an unprovisioned system, waits for ChirpStack, runs the idempotent bootstrap, and exits. On subsequent boots it is a no-op. The end user flashes the golden image, powers on, and OSI OS is fully configured with zero manual steps.
+
+## 2. Design
+
+### 2.1 Init ordering
+
+```
+START=80   chirpstack              (CGOS package)
+START=85   osi-bootstrap           ← NEW
+START=95   redis                   (OSI OS overlay)
+START=99   node-red                (OSI OS overlay)
+```
+
+Bootstrap runs after ChirpStack starts but before Node-RED. On success, Node-RED starts with fresh `.chirpstack.env` and UCI config already in place — no restart needed on first boot.
+
+### 2.2 Control flow
+
+```
+boot() / start()
+  │
+  ├─[1] stamp_valid()? ────── yes ──→ exit 0        (already provisioned)
+  │
+  ├─[2] bootstrap.js exists? ── no ──→ touch stamp → exit 0
+  │
+  ├─[3] Wait for ChirpStack gRPC (60s max, 12 × 5s)
+  │      curl -sf --max-time 3 http://localhost:8080
+  │
+  │      timeout? ──→ logger warn → exit 0          (retry next boot)
+  │
+  ├─[4] node /srv/node-red/chirpstack-bootstrap.js
+  │
+  │      success? ──→ touch stamp → exit 0          (Node-RED picks up env at START=99)
+  │
+  │      failure? ──→ logger err → exit 0           (retry next boot)
+  │                   (never blocks system boot)
+```
+
+### 2.3 Stamp validity
+
+A stamp file alone is insufficient — the env file can be deleted or corrupted after provisioning. The validity check is:
+
+```sh
+stamp_valid() {
+    [ -f /etc/osi-bootstrap.done ] || return 1
+    [ -f /srv/node-red/.chirpstack.env ] || return 1
+    grep -q 'CHIRPSTACK_APP_SENSORS=[0-9a-f]\{8\}-' /srv/node-red/.chirpstack.env 2>/dev/null || return 1
+    return 0
+}
+```
+
+If the env file is missing or its UUIDs look invalid (no sensor app UUID), the stamp is treated as stale and bootstrap re-runs.
+
+### 2.4 Script location and activation
+
+Two files are placed in the overlay:
+
+| Source (repo) | Destination (image) | Purpose |
+|---|---|---|
+| `files/etc/init.d/osi-bootstrap` | `/etc/init.d/osi-bootstrap` | Main init script (mode 755) |
+| `files/etc/uci-defaults/95_osi_bootstrap_enable` | `/etc/uci-defaults/95_osi_bootstrap_enable` | First-boot activation (mode 755) |
+
+**Why two files?** Init scripts in the overlay directory are NOT auto-enabled by the OpenWrt image builder (no package postinst creates rc.d symlinks for overlay files). The `uci-defaults` script runs on first boot before any init scripts, creates `/etc/rc.d/S85osi-bootstrap → ../init.d/osi-bootstrap`, then self-deletes. The init script then runs during that same first boot when the init system reaches START=85.
+
+No `STOP=` is set on the init script — it is a one-shot provisioning step with no shutdown behavior.
+
+**uci-defaults script** (`95_osi_bootstrap_enable`):
+
+```sh
+#!/bin/sh
+/etc/init.d/osi-bootstrap enable
+```
+
+### 2.5 Sysupgrade preservation
+
+Add `/etc/osi-bootstrap.done` to `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/sysupgrade.conf` so OTA sysupgrades preserve the stamp. Without this, every OTA upgrade re-triggers bootstrap (idempotent, so safe but wasteful).
+
+### 2.6 API key creation
+
+No change. Bootstrap continues to create the `osi-nodered` API key via `chirpstack -c /var/etc/chirpstack create-api-key --name osi-nodered`. Pre-seeding was considered and rejected (requires build-time ChirpStack DB injection; fragile across ChirpStack versions).
+
+## 3. Failure point analysis
+
+### F1: ChirpStack not installed
+- **Trigger:** image missing ChirpStack package
+- **Behavior:** step [3] times out after 60s; stamp not created; retries every boot
+- **Severity:** low — missing ChirpStack is a build error caught by CI
+
+### F2: ChirpStack slow first-boot DB init
+- **Trigger:** factory image first boot; ChirpStack creates SQLite DB, runs migrations (30–45s on Pi 5)
+- **Behavior:** port responds but gRPC calls may fail during init; bootstrap fails; stamp not created; retries next boot
+- **Result:** two-boot scenario — ChirpStack DB exists from first boot, starts in ~2s on second boot, bootstrap succeeds
+- **Severity:** low — rare (slow SD only); user sees dashboard without ChirpStack integration for one boot cycle
+
+### F3: Node.js binary missing
+- **Trigger:** Node-RED package corrupted or not installed
+- **Behavior:** step [4] fails immediately (`node` not found); stamp not created
+- **Severity:** low — if Node.js is missing, Node-RED cannot start; system is broken beyond bootstrap
+
+### F4: chirpstack CLI unavailable
+- **Trigger:** CLI binary missing, wrong permissions, or ChirpStack auth not ready
+- **Behavior:** bootstrap step 1/5 fails ("CLI create-api-key failed"); stamp not created; retries next boot
+- **Severity:** medium — if CLI consistently fails (ChirpStack v4 changes setup-mode behavior), system never provisions; requires CGOS compatibility fix
+
+### F5: Partial bootstrap — ChirpStack creates but env write fails
+- **Trigger:** disk full or permissions error during env file write or UCI commit
+- **Behavior:** tenant/apps/profiles exist in ChirpStack but not in `.chirpstack.env` or UCI; bootstrap exits non-zero; stamp not created
+- **Result:** retry reuses existing ChirpStack resources (idempotent by name); only file writes are re-attempted; no duplicate resources
+- **Severity:** low — idempotent design self-heals
+
+### F6: Disk full
+- **Trigger:** overlay filesystem at capacity (extremely unlikely on first boot with auto-expanded overlay)
+- **Behavior:** `fs.writeFileSync` in bootstrap fails with ENOSPC; stamp not created; retries every boot
+- **Severity:** low — disk full is a fatal system state; bootstrap failing is a symptom, not a cause
+
+### F7: Concurrent execution
+- **Trigger:** theoretical only — OpenWrt init runs sequentially
+- **Risk:** none; no mitigation needed
+
+### F8: Power loss during bootstrap
+- **State scenarios:**
+  - Before any gRPC calls: ChirpStack unchanged, no damage
+  - After tenant, before apps: tenant exists, apps don't; retry reuses tenant, creates missing apps
+  - After apps, before profiles: apps exist, profiles don't; retry reuses all, creates profiles
+  - After all ChirpStack calls, before env write: all resources exist; retry reuses everything (fast), writes env
+  - During env file write: partial/corrupt `.chirpstack.env`; retry overwrites
+  - During UCI commit: UCI may be partially written; retry overwrites
+- **Conclusion:** safe in all scenarios; `getOrCreate` + file-overwrite semantics are power-loss tolerant
+
+### F9: Stamp file exists but env file is corrupt/missing
+- **Trigger:** user manually deletes `.chirpstack.env` or it is corrupted
+- **Detection:** stamp validity check (2.3) catches this; env file missing → stamp treated as stale → re-bootstrap
+- **Severity:** mitigated by stamp validity check
+
+### F10: Bootstrap runs on manually configured system
+- **Trigger:** golden image flashed to Pi previously configured with custom ChirpStack app names
+- **Behavior:** bootstrap creates standard "OSI Sensors" etc. apps alongside existing custom apps; no name collision; Node-RED uses standard apps
+- **Severity:** low — golden image implies clean install
+
+### F11: gRPC health check false positive
+- **Trigger:** `curl http://localhost:8080` returns HTTP 200 but gRPC not fully ready (DB connection pool not initialized)
+- **Behavior:** step [3] passes; step [4] fails with gRPC error; stamp not created; retries next boot
+- **Result:** by next boot ChirpStack is fully ready
+- **Severity:** low — the health check is a "probably ready" heuristic; actual readiness determined by gRPC call succeeding
+
+### F12: Node-RED not installed
+- **Trigger:** Node-RED package missing from image; chirpstack-bootstrap.js itself runs fine (Node.js may or may not be present)
+- **Behavior:** bootstrap succeeds, stamp created, but Node-RED at START=99 can't start
+- **Note:** this is a build error, not a runtime concern; CI verifies Node-RED package presence
+
+### F13: System clock not synchronized
+- **Trigger:** Pi has no RTC and no network time on first boot; clock is Jan 1 1970
+- **Behavior:** ChirpStack gRPC calls may reject requests with bad timestamps; bootstrap fails; retries next boot
+- **Result:** by second boot, NTP has usually synced; if no internet, clock remains wrong and ChirpStack may reject all operations
+- **Severity:** low — Pi 5 typically gets NTP quickly; if offline permanently, bootstrap will retry indefinitely; user must sync clock
+
+## 4. Build integration
+
+### 4.1 Files to add
+
+```
+conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap           (new, 755)
+conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/95_osi_bootstrap_enable  (new, 755)
+```
+
+### 4.2 Files to modify
+
+```
+conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/sysupgrade.conf
+    + /etc/osi-bootstrap.done
+```
+
+### 4.3 Verification (CI / manual)
+
+```bash
+# After image build, check init script and uci-defaults script are present
+ls -la <root>/etc/init.d/osi-bootstrap                  # exists, mode 755
+ls -la <root>/etc/uci-defaults/95_osi_bootstrap_enable   # exists, mode 755
+# Note: rc.d symlink is created at RUNTIME on first boot, not at build time
+
+# Check sysupgrade.conf includes stamp file
+grep 'osi-bootstrap.done' <root>/etc/sysupgrade.conf
+
+# Smoke test on Pi 5 hardware
+# 1. Flash golden image
+# 2. Boot; wait 2 min
+# 3. Check: /etc/rc.d/S85osi-bootstrap exists (uci-defaults created it)
+# 4. Check: /etc/osi-bootstrap.done exists
+# 5. Check: /srv/node-red/.chirpstack.env has valid UUIDs
+# 6. Check: uci get osi-server.cloud.chirpstack_app_sensors returns a UUID
+# 7. Reboot; verify stamp_valid returns immediately (no re-bootstrap)
+# 8. Delete .chirpstack.env; reboot; verify bootstrap re-runs and recreates
+```
+
+## 5. Non-goals
+
+- Pre-seeding the ChirpStack API key (rejected; see 2.6)
+- Integrating the bootstrap logic into node-red.init (separate init = cleaner ownership)
+- Backgrounding the bootstrap work (synchronous wait ≤60s on first boot only is acceptable)
+- Handling the case where ChirpStack is not installed at all (build error; CI gate)
+
+## 6. Dependencies
+
+- `chirpstack-bootstrap.js` at `/srv/node-red/chirpstack-bootstrap.js` (deployed by `deploy.sh` or golden image build)
+- `osi-chirpstack-helper` at `/usr/share/node-red/osi-chirpstack-helper/` or `/srv/node-red/osi-chirpstack-helper/` (required by bootstrap.js)
+- ChirpStack gRPC API on `localhost:8080` (required for bootstrap.js to provision apps/profiles)
+- `curl` for gRPC health check (present in all CGOS builds)

--- a/scripts/verify-sync-flow.js
+++ b/scripts/verify-sync-flow.js
@@ -14,6 +14,9 @@ const osiServerDefaultsPath = path.resolve(__dirname, '..', 'conf', 'full_raspbe
 const sx1301GatewayDefaultPath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'etc', 'uci-defaults', '99_set_sx1301_gateway_id');
 const gatewayIdentityHelperPath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'usr', 'libexec', 'osi-gateway-identity.sh');
 const chirpstackBootstrapPath = path.resolve(__dirname, 'chirpstack-bootstrap.js');
+const osiBootstrapInitPath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'etc', 'init.d', 'osi-bootstrap');
+const osiBootstrapEnablePath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'etc', 'uci-defaults', '95_osi_bootstrap_enable');
+const sysupgradeConfPath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'etc', 'sysupgrade.conf');
 const stregaCodecPath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'usr', 'share', 'node-red', 'codecs', 'strega_gen1_decoder.js');
 const lsn50CodecPath = path.resolve(__dirname, '..', 'conf', 'full_raspberrypi_bcm27xx_bcm2712', 'files', 'usr', 'share', 'node-red', 'codecs', 'dragino_lsn50_decoder.js');
 const seedDatabasePaths = [
@@ -1985,6 +1988,49 @@ expectFileIncludes('99_set_sx1301_gateway_id', sx1301GatewayDefaultScript, 'gate
 expectFileIncludes('99_set_sx1301_gateway_id', sx1301GatewayDefaultScript, 'resolve_fallback_gateway_id()', 'keeps a single MAC-derived fallback path for first-boot concentratord seeding');
 expectFileExcludes('99_set_sx1301_gateway_id', sx1301GatewayDefaultScript, "SECTION='chirpstack-concentratord.@sx1302[0]'", 'hard-coded sx1302 seeding outside active-chipset-aware logic');
 expectFileExcludes('99_set_sx1301_gateway_id', sx1301GatewayDefaultScript, "SECTION='chirpstack-concentratord.@sx1301[0]'", 'hard-coded sx1301 seeding outside active-chipset-aware logic');
+
+// --- osi-bootstrap init script verification ---
+
+let osiBootstrapInitScript = '';
+if (fs.existsSync(osiBootstrapInitPath)) {
+  osiBootstrapInitScript = fs.readFileSync(osiBootstrapInitPath, 'utf8');
+  console.log('OK osi-bootstrap init script present');
+} else {
+  fail(`missing osi-bootstrap init script at ${osiBootstrapInitPath}`);
+}
+
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'START=85', 'init script declares correct boot priority');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'stamp_valid()', 'init script defines stamp validity check');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, '/etc/osi-bootstrap.done', 'init script uses the canonical stamp file path');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, '/srv/node-red/.chirpstack.env', 'init script checks env file existence');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, "grep -q 'CHIRPSTACK_APP_SENSORS=[0-9a-f]\\{8\\}-'", 'init script validates env file contains valid app UUIDs');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'chirpstack-bootstrap.js', 'init script references the bootstrap script');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'curl -sf --max-time 3 http://localhost:8080', 'init script waits for ChirpStack gRPC via curl');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'seq 1 12', 'init script retries gRPC health check up to 12 times');
+expectFileIncludes('osi-bootstrap', osiBootstrapInitScript, 'logger -t osi-bootstrap', 'init script logs all events with the correct tag');
+expectFileExcludes('osi-bootstrap', osiBootstrapInitScript, 'STOP=', 'init script does not set a shutdown priority (one-shot)');
+
+// uci-defaults activation script
+let osiBootstrapEnableScript = '';
+if (fs.existsSync(osiBootstrapEnablePath)) {
+  osiBootstrapEnableScript = fs.readFileSync(osiBootstrapEnablePath, 'utf8');
+  console.log('OK osi-bootstrap uci-defaults activation script present');
+} else {
+  fail(`missing osi-bootstrap uci-defaults activation script at ${osiBootstrapEnablePath}`);
+}
+
+expectFileIncludes('95_osi_bootstrap_enable', osiBootstrapEnableScript, '/etc/init.d/osi-bootstrap enable', 'activation script enables the osi-bootstrap init on first boot');
+
+// sysupgrade.conf preservation
+let sysupgradeConf = '';
+if (fs.existsSync(sysupgradeConfPath)) {
+  sysupgradeConf = fs.readFileSync(sysupgradeConfPath, 'utf8');
+  console.log('OK sysupgrade.conf present');
+} else {
+  fail(`missing sysupgrade.conf at ${sysupgradeConfPath}`);
+}
+
+expectFileIncludes('sysupgrade.conf', sysupgradeConf, '/etc/osi-bootstrap.done', 'sysupgrade.conf preserves the osi-bootstrap stamp file');
 
 const authNodes = flows.filter((node) => typeof node.func === 'string' && node.func.includes('function getAuthSecret()'));
 for (const insecureNeedle of ['osi-os-default-auth-secret', "env.get('CHIRPSTACK_API_KEY')"]) {


### PR DESCRIPTION
## Summary

Adds an automatic first-boot auto-bootstrapping init script that eliminates the manual `node /srv/node-red/chirpstack-bootstrap.js` step when flashing a golden image to a new Pi.

- **`/etc/init.d/osi-bootstrap`** (START=85) — Checks stamp+env validity, waits for ChirpStack gRPC (60s timeout), runs `chirpstack-bootstrap.js`, writes completion stamp. No-op on subsequent boots.
- **`/etc/uci-defaults/95_osi_bootstrap_enable`** — Enables the init on first boot (overlay files aren't auto-enabled by OpenWrt image builder).
- **Sysupgrade preservation** — `/etc/osi-bootstrap.done` added to `sysupgrade.conf`.
- **Verification** — 15 new checks in `verify-sync-flow.js`.

Init ordering: chirpstack (80) → osi-bootstrap (85) → redis (95) → node-red (99). Bootstrap completes before Node-RED starts on first boot.

Spec: `docs/superpowers/specs/2026-05-17-osi-bootstrap-init-design.md`
Plan: `docs/superpowers/plans/2026-05-17-osi-bootstrap-init.md`

## Test Plan
- [ ] `node scripts/verify-sync-flow.js` passes (15 new checks)
- [ ] Hardware smoke test: flash golden image, boot Pi 5, verify stamp file + env file + UCI, reboot to confirm no-op, delete env file to confirm re-bootstrap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic bootstrap service that initializes on system startup with idempotent behavior and retry logic for failed initialization attempts.

* **Documentation**
  * Added design specification and implementation plan for the new bootstrap initialization flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Open-Smart-Irrigation/osi-os/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->