### PR TITLE
feat(gui): default dendrometer LSN50 5V warm-up to 3000 ms

### DIFF
--- a/web/react-gui/src/components/farming/DraginoSettingsModal.tsx
+++ b/web/react-gui/src/components/farming/DraginoSettingsModal.tsx
@@ -151,6 +151,8 @@ export const DraginoSettingsModal: React.FC<DraginoSettingsModalProps> = ({
   const [intervalMinutesInput, setIntervalMinutesInput] = useState('');
   const [intervalInfo, setIntervalInfo] = useState<string | null>(null);
   const [interruptModeInput, setInterruptModeInput] = useState('0');
+  // Warm-up default is applied in two phases: (1) here on mount if dendrometer is already enabled,
+  // and (2) via the effect below if dendrometer gets enabled while the modal stays open.
   const [warmupMillisecondsInput, setWarmupMillisecondsInput] = useState(
     device.dendro_enabled === 1 ? String(DEFAULT_DENDRO_WARMUP_MS) : ''
   );

--- a/web/react-gui/src/components/farming/DraginoSettingsModal.tsx
+++ b/web/react-gui/src/components/farming/DraginoSettingsModal.tsx
@@ -39,6 +39,7 @@ const LSN50_INTERRUPT_MODE_OPTIONS = [
 
 const MAX_LSN50_INTERVAL_MINUTES = Math.floor(0xffffff / 60);
 const MAX_LSN50_5V_WARMUP_MS = 65535;
+const DEFAULT_DENDRO_WARMUP_MS = 3000;
 
 function requiredModeForSensor(key: SensorKey): Lsn50Mode | null {
   if (key === 'chameleon_enabled') {
@@ -150,7 +151,9 @@ export const DraginoSettingsModal: React.FC<DraginoSettingsModalProps> = ({
   const [intervalMinutesInput, setIntervalMinutesInput] = useState('');
   const [intervalInfo, setIntervalInfo] = useState<string | null>(null);
   const [interruptModeInput, setInterruptModeInput] = useState('0');
-  const [warmupMillisecondsInput, setWarmupMillisecondsInput] = useState('');
+  const [warmupMillisecondsInput, setWarmupMillisecondsInput] = useState(
+    device.dendro_enabled === 1 ? String(DEFAULT_DENDRO_WARMUP_MS) : ''
+  );
   const [externalSensorInfo, setExternalSensorInfo] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const dialogRef = useRef<HTMLDivElement | null>(null);

--- a/web/react-gui/src/components/farming/DraginoSettingsModal.tsx
+++ b/web/react-gui/src/components/farming/DraginoSettingsModal.tsx
@@ -154,6 +154,8 @@ export const DraginoSettingsModal: React.FC<DraginoSettingsModalProps> = ({
   const [warmupMillisecondsInput, setWarmupMillisecondsInput] = useState(
     device.dendro_enabled === 1 ? String(DEFAULT_DENDRO_WARMUP_MS) : ''
   );
+  // Tracks whether the operator has edited the warm-up field, so auto-defaulting never clobbers input.
+  const warmupTouchedRef = useRef(false);
   const [externalSensorInfo, setExternalSensorInfo] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const dialogRef = useRef<HTMLDivElement | null>(null);
@@ -179,6 +181,14 @@ export const DraginoSettingsModal: React.FC<DraginoSettingsModalProps> = ({
   useEffect(() => {
     onCloseRef.current = onClose;
   }, [onClose]);
+
+  // If dendrometer gets enabled while the modal is open, seed the recommended 3 s warm-up —
+  // but only when the field is still empty and the operator hasn't edited it.
+  useEffect(() => {
+    if (device.dendro_enabled === 1 && !warmupTouchedRef.current) {
+      setWarmupMillisecondsInput((prev) => (prev === '' ? String(DEFAULT_DENDRO_WARMUP_MS) : prev));
+    }
+  }, [device.dendro_enabled]);
 
   useEffect(() => {
     openerRef.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -556,7 +566,10 @@ export const DraginoSettingsModal: React.FC<DraginoSettingsModalProps> = ({
                     inputMode="numeric"
                     value={warmupMillisecondsInput}
                     disabled={busy === 'warmup'}
-                    onChange={(event) => setWarmupMillisecondsInput(event.target.value)}
+                    onChange={(event) => {
+                      warmupTouchedRef.current = true;
+                      setWarmupMillisecondsInput(event.target.value);
+                    }}
                     placeholder="1000"
                     className={`w-full rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text)] ${FOCUS_VISIBLE_RING}`}
                   />


### PR DESCRIPTION
## Summary

Pre-fills the existing LSN50 "5V warm-up time" field with **3000 ms** for dendrometer-mode devices (`device.dendro_enabled === 1`) in the device settings modal, so operators don't leave the ratiometric dendrometer excitation at 0 ms. Powering the sensor and letting it settle for ~3 s before the ADC samples reduces the step/noise artifacts the cloud analytics' 200 µm jump-removal otherwise has to correct.

No firmware change and no new API — this only changes the default value of an input that already drives the existing `lsn50API.setFiveVoltWarmup` downlink. Companion to osi-server dendrometer analytics v6.

## Test Plan
- [x] `tsc` clean for the changed file (pre-existing unrelated errors elsewhere).
- [ ] Open the device settings modal for a dendrometer LSN50 and confirm the warm-up field pre-fills 3000 ms; non-dendrometer devices remain blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dragino Settings Modal now pre-populates the warmup milliseconds field with a default value of 3 seconds when dendro mode is enabled, streamlining the configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->