### PR TITLE
fix(gui): handle 'unknown' dendrometer stress level without render crash

### DIFF
--- a/web/react-gui/src/components/farming/dendrometer/DendrometerMonitor.tsx
+++ b/web/react-gui/src/components/farming/dendrometer/DendrometerMonitor.tsx
@@ -78,7 +78,7 @@ const IndicatorsTable: React.FC<{ rows: DendroDaily[] }> = ({ rows }) => {
         </thead>
         <tbody>
           {ordered.map(row => {
-            const cfg = STRESS_CONFIG[row.stress_level];
+            const cfg = STRESS_CONFIG[row.stress_level] ?? STRESS_CONFIG.unknown;
             return (
               <tr key={row.date} className="border-b border-[var(--border)] hover:bg-[var(--surface)]">
                 <td className="py-2 pr-4 text-[var(--text-secondary)] whitespace-nowrap">{fmtDate(row.date)}</td>
@@ -338,7 +338,7 @@ const ErrorMsg = ({ msg }: { msg: string }) => (
 export const DendrometerMonitor: React.FC<Props> = ({ device, daily, onClose }) => {
   const [tab, setTab] = useState<Tab>('indicators');
   const stress = daily[0]?.stress_level ?? 'none';
-  const cfg    = STRESS_CONFIG[stress];
+  const cfg    = STRESS_CONFIG[stress] ?? STRESS_CONFIG.unknown;
 
   return (
     <div className="fixed inset-0 z-50 flex">

--- a/web/react-gui/src/components/farming/dendrometer/DendrometerSection.tsx
+++ b/web/react-gui/src/components/farming/dendrometer/DendrometerSection.tsx
@@ -244,7 +244,7 @@ interface ZoneSummaryProps {
 }
 
 const ZoneSummaryRow: React.FC<ZoneSummaryProps> = ({ stress, rainfall, water, deviceCount }) => {
-  const cfg = STRESS_CONFIG[stress as keyof typeof STRESS_CONFIG] ?? STRESS_CONFIG.none;
+  const cfg = STRESS_CONFIG[stress as keyof typeof STRESS_CONFIG] ?? STRESS_CONFIG.unknown;
   return (
     <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-[var(--text-tertiary)]">
       <span>

--- a/web/react-gui/src/components/farming/dendrometer/DendrometerTreeCard.tsx
+++ b/web/react-gui/src/components/farming/dendrometer/DendrometerTreeCard.tsx
@@ -79,7 +79,7 @@ const RecoveryRatioBar: React.FC<{ value: number }> = ({ value }) => {
 export const DendrometerTreeCard: React.FC<Props> = ({ device, today, history, onOpenMonitor }) => {
   const baselineComplete = today?.baseline_complete === 1;
   const stress = today?.tree_state_v5 ?? today?.stress_level ?? 'none';
-  const cfg = STRESS_CONFIG[stress] ?? STRESS_CONFIG.none;
+  const cfg = STRESS_CONFIG[stress] ?? STRESS_CONFIG.unknown;
   const hasData = today != null;
   const borderClass = !hasData || !baselineComplete ? 'border-l-gray-300' : cfg.border;
 

--- a/web/react-gui/src/components/farming/dendrometer/StressBadge.tsx
+++ b/web/react-gui/src/components/farming/dendrometer/StressBadge.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 export const StressBadge: React.FC<Props> = ({ level, size = 'md' }) => {
-  const cfg = STRESS_CONFIG[level];
+  const cfg = STRESS_CONFIG[level] ?? STRESS_CONFIG.unknown;
   const dots = '●'.repeat(cfg.dots) + '○'.repeat(5 - cfg.dots);
   const textSize = size === 'sm' ? 'text-xs' : 'text-sm';
   const padding  = size === 'sm' ? 'px-2 py-0.5' : 'px-2.5 py-1';

--- a/web/react-gui/src/components/farming/dendrometer/stressConfig.ts
+++ b/web/react-gui/src/components/farming/dendrometer/stressConfig.ts
@@ -61,6 +61,16 @@ export const STRESS_CONFIG: Record<StressLevel, StressConfig> = {
     hex: '#7f1d1d',
     hexLight: '#fecaca',
   },
+  // Low-confidence / insufficient-data day — neutral grey, not a graded stress level.
+  unknown: {
+    label: 'Unknown',
+    dots: 0,
+    border: 'border-l-gray-400',
+    badgeBg: 'bg-gray-100',
+    badgeText: 'text-gray-700',
+    hex: '#6b7280',
+    hexLight: '#f3f4f6',
+  },
 };
 
 export interface ActionConfig {

--- a/web/react-gui/src/types/farming.ts
+++ b/web/react-gui/src/types/farming.ts
@@ -263,7 +263,9 @@ export interface CreateZoneRequest {
 
 // ---- Dendrometer analytics types ----
 
-export type StressLevel = 'none' | 'mild' | 'moderate' | 'significant' | 'severe';
+// 'unknown' is emitted by the backend for low-confidence / insufficient-data days
+// (e.g. sparse first days). Renderers must handle it, not just the five graded levels.
+export type StressLevel = 'none' | 'mild' | 'moderate' | 'significant' | 'severe' | 'unknown';
 export type IrrigationAction =
   | 'decrease_20'
   | 'decrease_10'


### PR DESCRIPTION
## Summary

The dendrometer analytics can emit an `unknown` stress level for low-confidence / insufficient-data days (e.g. a sparse first day) — and the v6 changes (raised sample floor, sub-60-sample low-confidence gating) make `unknown` more frequent. The frontend `StressLevel` type omitted `unknown` and several `STRESS_CONFIG[level]` lookups had no fallback, so an `unknown` value yielded `undefined` and could crash the dendrometer monitor/card on render.

- Add `'unknown'` to the `StressLevel` union and a neutral grey `STRESS_CONFIG.unknown` entry ("Unknown", 0 dots).
- Route every `STRESS_CONFIG[...]` lookup through `?? STRESS_CONFIG.unknown` — including the previously-unguarded sites (`StressBadge`, `DendrometerMonitor` table + header) and standardising the two already-guarded sites off `.none` (showing green "No Stress" for an unrenderable value was misleading).

Pre-existing latent crash (`unknown` predates v6); this hardens the dendro UI against it.

## Test Plan
- [x] `tsc` clean for the changed files (the `Record<StressLevel>` is exhaustive again with the new key).
- [ ] Render the dendrometer monitor/card for a device whose latest day is `unknown` (sparse/low-confidence) and confirm a grey "Unknown" badge instead of a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stress level display robustness across dendrometer monitoring components to gracefully handle unrecognized or insufficient data.
  * Added support for "unknown" stress status, displayed when confidence is low or data is unavailable, ensuring consistent UI presentation across all monitoring views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->