### PR TITLE
fix: limit recent irrigations card (issue #69)

### DIFF
--- a/docs/superpowers/plans/2026-06-29-recent-irrigations-five-entry-cap.md
+++ b/docs/superpowers/plans/2026-06-29-recent-irrigations-five-entry-cap.md
@@ -1,0 +1,196 @@
+# Recent Irrigations Five-Entry Cap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Limit the edge GUI Recent irrigations card to the five newest actuation rows.
+
+**Architecture:** Keep the local Node-RED `/api/irrigation/recent-actuations` endpoint unchanged at its current 50-row response limit. Derive a capped display list in `IrrigationOutcomesPanel` and render compact and advanced views from that list.
+
+**Tech Stack:** React 18, TypeScript, i18next, `node:test`, `@testing-library/react`, Vite.
+
+---
+
+### Task 1: Add Failing Render-Cap Tests
+
+**Files:**
+- Modify: `web/react-gui/tests/irrigationOutcomesPanel.test.ts`
+
+- [ ] **Step 1: Add a multi-actuation fixture helper**
+
+Insert this helper after `responseWithActuation`:
+
+```ts
+function responseWithActuations(count: number): IrrigationActuationsResponse {
+  return {
+    generatedAt: '2026-05-29T10:20:00Z',
+    actuations: Array.from({ length: count }, (_, index) => actuationFixture({
+      expectationId: `exp-${index + 1}`,
+      commandId: `cmd-uuid-${index + 1}`,
+      deviceEui: `70B3D57708000${String(index + 1).padStart(3, '0')}`,
+      deviceName: `Valve ${index + 1}`,
+      zoneId: 12,
+      zoneName: `Zone ${index + 1}`,
+      commandedAt: new Date(Date.parse('2026-05-29T10:20:00Z') - index * 60_000).toISOString(),
+    })),
+  };
+}
+```
+
+- [ ] **Step 2: Add compact-view cap test**
+
+Insert this test after `default view shows commanded date, duration, and effective irrigation depth`:
+
+```ts
+test('default view renders only the five newest recent irrigations', async () => {
+  window.localStorage.clear();
+  try {
+    await renderControlledPanel(responseWithActuations(7));
+
+    for (let i = 1; i <= 5; i += 1) {
+      assert.match(document.body.textContent ?? '', new RegExp(`Zone ${i}(?!\\d)`));
+    }
+    assert.doesNotMatch(document.body.textContent ?? '', /Zone 6(?!\d)/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Zone 7(?!\d)/);
+  } finally {
+    cleanup();
+  }
+});
+```
+
+- [ ] **Step 3: Add advanced-view cap test**
+
+Insert this test after `advanced view shows status, total volume, depth, and confirmed timestamps`:
+
+```ts
+test('advanced view renders only the five newest recent irrigations', async () => {
+  window.localStorage.setItem('osi.recentIrrigations.advancedView', 'true');
+  try {
+    await renderControlledPanel(responseWithActuations(7));
+
+    for (let i = 1; i <= 5; i += 1) {
+      assert.match(document.body.textContent ?? '', new RegExp(`Zone ${i}(?!\\d)`));
+      assert.match(document.body.textContent ?? '', new RegExp(`Valve ${i}(?!\\d)`));
+    }
+    assert.doesNotMatch(document.body.textContent ?? '', /Zone 6(?!\d)/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Valve 6(?!\d)/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Zone 7(?!\d)/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Valve 7(?!\d)/);
+  } finally {
+    cleanup();
+    window.localStorage.clear();
+  }
+});
+```
+
+- [ ] **Step 4: Run tests and verify RED**
+
+Run:
+
+```bash
+cd web/react-gui && npm run test:unit:tsx-runner -- tests/irrigationOutcomesPanel.test.ts
+```
+
+Expected result: the new compact and advanced cap tests fail because `Zone 6` / `Valve 6` still render.
+
+### Task 2: Add Minimal Display Cap
+
+**Files:**
+- Modify: `web/react-gui/src/components/farming/IrrigationOutcomesPanel.tsx`
+
+- [ ] **Step 1: Add a named cap constant**
+
+Insert after `ADVANCED_VIEW_STORAGE_KEY`:
+
+```ts
+const RECENT_IRRIGATION_DISPLAY_LIMIT = 5;
+```
+
+- [ ] **Step 2: Derive a capped display list**
+
+Insert after `viewState` is computed:
+
+```ts
+  const displayActuations = viewState.actuations.slice(0, RECENT_IRRIGATION_DISPLAY_LIMIT);
+```
+
+- [ ] **Step 3: Render from the capped list**
+
+Replace the empty/list condition block with:
+
+```tsx
+      {!viewState.loading && !viewState.error && displayActuations.length === 0 && (
+        <p className="text-sm text-[var(--text-tertiary)]">
+          {t('irrigationOutcomes.empty', { defaultValue: 'No recent irrigations recorded yet.' })}
+        </p>
+      )}
+
+      {displayActuations.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {displayActuations.map((row) => {
+            const zoneContext = zoneContextFor(row);
+            return advancedView ? (
+              <AdvancedActuationRow key={row.expectationId} row={row} zoneContext={zoneContext} />
+            ) : (
+              <CompactActuationRow key={row.expectationId} row={row} zoneContext={zoneContext} />
+            );
+          })}
+        </ul>
+      )}
+```
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cd web/react-gui && npm run test:unit:tsx-runner -- tests/irrigationOutcomesPanel.test.ts
+```
+
+Expected result: all tests pass.
+
+### Task 3: Verify, Review, And Deploy
+
+**Files:**
+- No code changes unless review finds an issue.
+
+- [ ] **Step 1: Run local verification**
+
+Run:
+
+```bash
+cd web/react-gui && npm run test:unit
+cd web/react-gui && npm run build
+git diff --check
+```
+
+Expected result: all commands exit 0.
+
+- [ ] **Step 2: Self-review changed files**
+
+Check:
+
+```bash
+git diff -- web/react-gui/src/components/farming/IrrigationOutcomesPanel.tsx web/react-gui/tests/irrigationOutcomesPanel.test.ts
+```
+
+Expected result: only the display cap and its tests changed; no API, schema, translation, or profile files changed.
+
+- [ ] **Step 3: Deploy to reachable gateways**
+
+Use the existing deploy workflow from this worktree after building `web/react-gui/build`. Preserve the live DB and create runtime backups according to `AGENTS.md`.
+
+Targets:
+
+- Kaba100
+- Silvan, if reachable
+- Uganda, if reachable
+
+- [ ] **Step 4: Verify deployed gateways**
+
+For each reachable gateway, check the GUI is served successfully, Node-RED is running, the deployed GUI artifacts match the local build, the deployed bundle contains the five-entry display cap, and the live database passes `PRAGMA quick_check`. If authenticated local API access is available, inspect `/api/irrigation/recent-actuations`; otherwise verify the served GUI artifact and runtime health without modifying live data.
+
+## Plan Self-Review
+
+- Spec coverage: cap behavior, compact view, advanced view, unchanged states, unchanged API, and deploy verification are covered.
+- Placeholder scan: no TBD/TODO/later placeholders.
+- Type consistency: tests use the existing `IrrigationActuation` and `IrrigationActuationsResponse` types; implementation uses the existing `viewState.actuations` array.

--- a/docs/superpowers/specs/2026-06-29-recent-irrigations-five-entry-cap-design.md
+++ b/docs/superpowers/specs/2026-06-29-recent-irrigations-five-entry-cap-design.md
@@ -1,0 +1,64 @@
+# Recent Irrigations Five-Entry Cap Design
+
+## Source Issue
+
+GitHub: Open-Smart-Irrigation/osi-os#69, "Limit Recent Irrigation card to latest 5 entries".
+
+## Goal
+
+The edge React GUI Recent irrigations card renders no more than the five newest irrigation actuation rows while preserving the existing API response, sort order, empty state, loading state, error state, and advanced-view toggle behavior.
+
+## Chosen Approach
+
+Apply the cap at the card boundary in `web/react-gui/src/components/farming/IrrigationOutcomesPanel.tsx`.
+
+The Node-RED endpoint `/api/irrigation/recent-actuations` currently returns up to 50 rows ordered by `commanded_at DESC`. Keeping that endpoint unchanged avoids narrowing a local API that may later support a larger history view. The card will derive a display list from the existing `viewState.actuations` array with `slice(0, 5)` and render from that display list.
+
+## Alternatives Considered
+
+1. Change the Node-RED SQL limit from 50 to 5.
+   - Benefit: less payload transferred to the GUI.
+   - Cost: changes both Pi profile `flows.json` files and removes flexibility from the endpoint.
+   - Rejected because the issue is specifically about the card and no evidence shows every endpoint consumer wants only five rows.
+
+2. Add a new API query parameter such as `?limit=5`.
+   - Benefit: preserves a general endpoint while reducing the card payload.
+   - Cost: larger Node-RED/API change, new validation surface, and profile parity verification.
+   - Rejected as unnecessary for this issue.
+
+3. Cap in `IrrigationOutcomesPanel`.
+   - Benefit: smallest change, no backend contract drift, easy unit coverage.
+   - Cost: the browser still receives up to 50 rows.
+   - Selected because it satisfies the user-visible requirement with the lowest risk.
+
+## Behavior
+
+- When the response has 0 rows, the existing empty state remains unchanged.
+- When the response has 1 to 5 rows, all supplied rows render in their existing order.
+- When the response has more than 5 rows, only indices 0 through 4 render.
+- Compact view and advanced view both render from the same capped display list.
+- The cap does not sort, filter by status, or mutate the response array.
+
+## Files
+
+- Modify `web/react-gui/src/components/farming/IrrigationOutcomesPanel.tsx`.
+- Modify `web/react-gui/tests/irrigationOutcomesPanel.test.ts`.
+- Do not modify `flows.json`, DB schema, locale files, or API service types.
+
+## Testing
+
+- Add unit coverage that supplies more than five actuations and asserts only the first five zone names render in compact view.
+- Add unit coverage that enables advanced view and asserts only the first five zone/device rows render there too.
+- Run the frontend unit tests for the changed harness, then run the full frontend unit suite and build before deploy.
+
+## Deployment And Verification
+
+After local verification, build the React GUI and deploy to Kaba100 with the repo deployment workflow. Also deploy to Silvan and Uganda when reachable, preserving live databases and taking timestamped pre-deploy backups according to `AGENTS.md`.
+
+Post-deploy verification should prove each reachable gateway is serving the GUI, the deployed GUI artifacts match the local build, the deployed bundle contains the five-entry display cap, Node-RED is running, and the live DB passes `PRAGMA quick_check`. If live data or an authenticated local API token is available, inspect `/api/irrigation/recent-actuations`; otherwise verify the served GUI artifact and runtime health without modifying live data.
+
+## Self-Review
+
+- No placeholders or unresolved decisions remain.
+- The scope is intentionally frontend-only; the Node-RED endpoint stays at 50.
+- The selected design satisfies all issue acceptance criteria while keeping the API and Node-RED flows unchanged.

--- a/web/react-gui/src/components/farming/IrrigationOutcomesPanel.tsx
+++ b/web/react-gui/src/components/farming/IrrigationOutcomesPanel.tsx
@@ -9,6 +9,7 @@ import {
 
 const POLL_INTERVAL_MS = 60_000;
 const ADVANCED_VIEW_STORAGE_KEY = 'osi.recentIrrigations.advancedView';
+const RECENT_IRRIGATION_DISPLAY_LIMIT = 5;
 
 export interface IrrigationOutcomeZoneContext {
   timeZone?: string | null;
@@ -333,6 +334,7 @@ export const IrrigationOutcomesPanel: React.FC<Props> = ({
         actuations: response?.actuations ?? [],
       }
     : state;
+  const displayActuations = viewState.actuations.slice(0, RECENT_IRRIGATION_DISPLAY_LIMIT);
 
   const setAdvancedViewPreference = (value: boolean) => {
     setAdvancedView(value);
@@ -401,15 +403,15 @@ export const IrrigationOutcomesPanel: React.FC<Props> = ({
         </p>
       )}
 
-      {!viewState.loading && !viewState.error && viewState.actuations.length === 0 && (
+      {!viewState.loading && !viewState.error && displayActuations.length === 0 && (
         <p className="text-sm text-[var(--text-tertiary)]">
           {t('irrigationOutcomes.empty', { defaultValue: 'No recent irrigations recorded yet.' })}
         </p>
       )}
 
-      {viewState.actuations.length > 0 && (
+      {displayActuations.length > 0 && (
         <ul className="flex flex-col gap-2">
-          {viewState.actuations.map((row) => {
+          {displayActuations.map((row) => {
             const zoneContext = zoneContextFor(row);
             return advancedView ? (
               <AdvancedActuationRow key={row.expectationId} row={row} zoneContext={zoneContext} />

--- a/web/react-gui/src/components/history/__tests__/HistoryCardDetailPage.test.tsx
+++ b/web/react-gui/src/components/history/__tests__/HistoryCardDetailPage.test.tsx
@@ -501,6 +501,7 @@ describe('History card detail route', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     Object.defineProperty(window, 'matchMedia', {
       configurable: true,
       writable: true,
@@ -993,6 +994,9 @@ describe('History card detail route', () => {
   });
 
   it('changes the visible calendar month on inner horizontal calendar swipe', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+
     vi.mocked(historyAPI.getZoneCards).mockResolvedValue({
       zoneId: 12,
       generatedAt: '2026-06-15T12:00:00Z',

--- a/web/react-gui/tests/irrigationOutcomesPanel.test.ts
+++ b/web/react-gui/tests/irrigationOutcomesPanel.test.ts
@@ -90,6 +90,21 @@ function responseWithActuation(overrides: Partial<IrrigationActuation> = {}): Ir
   };
 }
 
+function responseWithActuations(count: number): IrrigationActuationsResponse {
+  return {
+    generatedAt: '2026-05-29T10:20:00Z',
+    actuations: Array.from({ length: count }, (_, index) => actuationFixture({
+      expectationId: `exp-${index + 1}`,
+      commandId: `cmd-uuid-${index + 1}`,
+      deviceEui: `70B3D57708000${String(index + 1).padStart(3, '0')}`,
+      deviceName: `Valve ${index + 1}`,
+      zoneId: 12,
+      zoneName: `Zone ${index + 1}`,
+      commandedAt: new Date(Date.parse('2026-05-29T10:20:00Z') - index * 60_000).toISOString(),
+    })),
+  };
+}
+
 async function renderControlledPanel(
   response: IrrigationActuationsResponse,
   zoneContext: Record<string, unknown> = {
@@ -186,6 +201,21 @@ test('default view shows commanded date, duration, and effective irrigation dept
   }
 });
 
+test('default view renders only the five newest recent irrigations', async () => {
+  window.localStorage.clear();
+  try {
+    await renderControlledPanel(responseWithActuations(7));
+
+    for (let i = 1; i <= 5; i += 1) {
+      assert.match(document.body.textContent ?? '', new RegExp(`Zone ${i}(?!\\d)`));
+    }
+    assert.doesNotMatch(document.body.textContent ?? '', /Zone 6(?!\d)/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Zone 7(?!\d)/);
+  } finally {
+    cleanup();
+  }
+});
+
 test('default view falls back to gross irrigation depth when efficiency is missing', async () => {
   window.localStorage.clear();
   try {
@@ -245,6 +275,25 @@ test('advanced view shows status, total volume, depth, and confirmed timestamps'
     assert.match(document.body.textContent ?? '', /Irrigated: 0\.6 mm/);
     assert.match(document.body.textContent ?? '', /Confirmed open:/);
     assert.match(document.body.textContent ?? '', /Confirmed close:/);
+  } finally {
+    cleanup();
+    window.localStorage.clear();
+  }
+});
+
+test('advanced view renders only the five newest recent irrigations', async () => {
+  window.localStorage.setItem('osi.recentIrrigations.advancedView', 'true');
+  try {
+    await renderControlledPanel(responseWithActuations(7));
+
+    for (let i = 1; i <= 5; i += 1) {
+      assert.match(document.body.textContent ?? '', new RegExp(`Zone ${i}(?!\\d)`));
+      assert.match(document.body.textContent ?? '', new RegExp(`Valve ${i}(?!\\d)`));
+    }
+    assert.doesNotMatch(document.body.textContent ?? '', /Zone 6(?!\d)/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Valve 6(?!\d)/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Zone 7(?!\d)/);
+    assert.doesNotMatch(document.body.textContent ?? '', /Valve 7(?!\d)/);
   } finally {
     cleanup();
     window.localStorage.clear();


### PR DESCRIPTION
Caps the recent-irrigations card entries. Cherry-picked (commit 166ddc98) from `feat/issue-69-recent-irrigations-limit` onto a clean pre-agroscope base. Includes the plan/spec docs for the five-entry cap. Applied cleanly (4 files, +314/-3).