### PR TITLE
fix(history): mark sparse soil recovery points

### DIFF
--- a/web/react-gui/src/components/history/__tests__/SoilLineChartView.test.tsx
+++ b/web/react-gui/src/components/history/__tests__/SoilLineChartView.test.tsx
@@ -2,7 +2,12 @@ import '@testing-library/jest-dom';
 import { render, screen, within } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { buildNumericRows, SoilLineChartView, soilSeriesDisplayLabel } from '../visualizations/SoilLineChartView';
+import {
+  buildNumericRows,
+  SoilLineChartView,
+  soilSeriesDisplayLabel,
+  soilSeriesShouldShowDots,
+} from '../visualizations/SoilLineChartView';
 import type { HistoryCardDataResponse } from '../../../history/types';
 
 class ResizeObserverStub {
@@ -98,6 +103,34 @@ describe('SoilLineChartView', () => {
     ]);
 
     expect(rows[0].tMs).toBe(Date.parse('2026-06-01T00:00:00Z'));
+  });
+
+  it('marks sparse recovery segments so points after outages remain visible', () => {
+    expect(soilSeriesShouldShowDots({
+      key: 'swt_1',
+      label: 'Layer 1',
+      unit: 'kPa',
+      depthCm: null,
+      points: [
+        { t: '2026-06-24T06:00:00Z', value: 5 },
+        { t: '2026-06-29T20:00:00Z', value: 20 },
+        { t: '2026-06-29T21:00:00Z', value: 21 },
+      ],
+    })).toBe(true);
+  });
+
+  it('keeps dots hidden for continuous hourly soil series', () => {
+    expect(soilSeriesShouldShowDots({
+      key: 'swt_1',
+      label: 'Layer 1',
+      unit: 'kPa',
+      depthCm: null,
+      points: [
+        { t: '2026-06-24T06:00:00Z', value: 5 },
+        { t: '2026-06-24T07:00:00Z', value: 6 },
+        { t: '2026-06-24T08:00:00Z', value: 7 },
+      ],
+    })).toBe(false);
   });
 
   it('prefers soil depth labels and disambiguates duplicate depths', () => {

--- a/web/react-gui/src/components/history/visualizations/SoilLineChartView.tsx
+++ b/web/react-gui/src/components/history/visualizations/SoilLineChartView.tsx
@@ -20,7 +20,7 @@ interface SoilLineChartViewProps {
 type HistoryTranslate = (key: string, options?: Record<string, unknown>) => string;
 type ChartRow = { timestamp: string; tMs: number } & Record<string, number | string | null>;
 type ChartWindow = { fromMs: number; toMs: number };
-type RenderSeries = {
+export type RenderSeries = {
   key: string;
   label: string;
   unit: string;
@@ -29,6 +29,7 @@ type RenderSeries = {
 };
 
 const SERIES_COLORS = ['#2563eb', '#059669', '#d97706', '#7c3aed'];
+const MAX_CONTINUOUS_GAP_MS = 90 * 60 * 1000;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -155,6 +156,30 @@ function hasVisiblePoints(series: RenderSeries): boolean {
   return series.points.some((point) => point.value !== null);
 }
 
+export function soilSeriesShouldShowDots(series: RenderSeries): boolean {
+  let previousVisibleIndex: number | null = null;
+  let previousVisibleMs: number | null = null;
+  let visibleCount = 0;
+
+  for (let index = 0; index < series.points.length; index += 1) {
+    const point = series.points[index];
+    if (point.value === null) continue;
+    const currentMs = Date.parse(point.t);
+    if (!Number.isFinite(currentMs)) continue;
+
+    visibleCount += 1;
+    if (previousVisibleIndex !== null && previousVisibleMs !== null) {
+      if (index - previousVisibleIndex > 1) return true;
+      if (currentMs - previousVisibleMs > MAX_CONTINUOUS_GAP_MS) return true;
+    }
+
+    previousVisibleIndex = index;
+    previousVisibleMs = currentMs;
+  }
+
+  return visibleCount === 1;
+}
+
 export function buildNumericRows(seriesList: RenderSeries[]): ChartRow[] {
   const rows = new Map<string, ChartRow>();
   seriesList.forEach((series) => {
@@ -248,7 +273,7 @@ const SoilLineChartViewComponent: React.FC<SoilLineChartViewProps> = ({ data, wi
                 name={series.label}
                 stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
                 strokeWidth={2}
-                dot={false}
+                dot={soilSeriesShouldShowDots(series) ? { r: 3, strokeWidth: 1 } : false}
                 isAnimationActive={false}
                 connectNulls={false}
               />


### PR DESCRIPTION
Cherry-pick of 585582df — the one commit from fix/edge-sync-link-state-rollout that had not landed on main (its seed rewrite, history-sync-helper, and devices-CHECK work are already on main). Marks sparse soil recovery points in SoilLineChartView. 2 files, +61/-3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Soil line charts now show point markers only when the data has noticeable gaps, improving readability after outages or sparse updates.
  * Continuous hourly soil data keeps markers hidden, reducing clutter on dense charts.
* **Tests**
  * Added coverage for both sparse and continuous soil-series display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->