### PR TITLE
chore: land pending WIP (chameleon docs, session-closeout, enable parted)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,10 +83,12 @@ project — see the ADR trigger conditions.
 - `chameleon_calibrations` — keyed by `array_id` (uppercase 16-char hex). Source via.farm; bundled into firmware seed before release.
 - `chameleon_calibration_misses` — negative cache (24h TTL) for unknown array_ids.
 - `chameleon_readings.calibration_status` — `'calibrated'`, `'pending'`, or `'unknown'`.
+- **LSN50 Chameleon wiring:** when SDA/SCL are connected directly to the LSN50 STM32 I2C pins, power the VIA Chameleon I2C reader from LSN50 `VDD` (same 3.3-3.6 V rail as the bus). Do **not** power it from switched 5 V unless a proper bidirectional I2C level shifter and power isolation are added; the reader pull-ups follow VCC and switched-off 5 V can leave the board back-powered through SDA/SCL. See [docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md](docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md).
 - **Edge endpoints:** `POST /api/devices/:deveui/chameleon/refresh-calibration` (sync worker fetches from cloud), `PUT /api/devices/:deveui/chameleon/depth` (depth-only save, replaces old chameleon-config).
 - **Node-RED sync worker** queries missing calibrations every 30s alongside pending commands, fetches from `/api/v1/sync/chameleon/calibrations/lookup`, persists locally, and runs local backfill.
 - **Removed:** `PUT /api/devices/:deveui/chameleon-config` endpoint and the 9 per-device coefficient columns (`chameleon_swt[123]_[abc]`). Depth columns (`chameleon_swt[123]_depth_cm`) stay.
 - Per-device calibration values entered by hand are discarded in the 2026-05-19 migration. Operators verify post-upgrade that each live array_id has a row in `chameleon_calibrations`.
+- Chameleon SWT analysis reads canonical kPa values from `device_data.swt_1`, `swt_2`, and `swt_3`. `chameleon_readings` is the raw/diagnostic mirror. If historical SWT values are repaired from `chameleon_readings` plus `chameleon_calibrations`, update `device_data` too and enqueue corrected `DEVICE_DATA_APPENDED` sync events because the live sync trigger fires on `INSERT`, not historical `UPDATE`.
 - **Release script:** `OSI_ADMIN_TOKEN=… node scripts/refresh-chameleon-calibrations.js` before cutting a release.
 - Apply the generated release seed with `node scripts/apply-chameleon-calibration-seed.js`; it updates every bundled DB copy and fails on an empty calibration snapshot.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,7 @@ Primary target: Raspberry Pi 5 (`full_raspberrypi_bcm27xx_bcm2712`).
 5. `web/react-gui/src/` — dashboard source
 6. [docs/build/building-firmware.md](docs/build/building-firmware.md) — firmware build (only if rebuilding the OS)
 7. [docs/versioning-workflow.md](docs/versioning-workflow.md) — release checklist
+
+## Session Closeout
+
+When the user says `finish the session`, follow [AGENTS.md](AGENTS.md) session closeout and run `scripts/session-closeout.sh`.

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/.config
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/.config
@@ -4618,7 +4618,7 @@ CONFIG_PACKAGE_libnl-tiny=y
 # CONFIG_PACKAGE_libp11 is not set
 # CONFIG_PACKAGE_libpagekite is not set
 # CONFIG_PACKAGE_libpam is not set
-# CONFIG_PACKAGE_libparted is not set
+CONFIG_PACKAGE_libparted=y
 # CONFIG_PACKAGE_libpbc is not set
 # CONFIG_PACKAGE_libpcap is not set
 # CONFIG_PACKAGE_libpci is not set
@@ -6560,6 +6560,14 @@ CONFIG_PACKAGE_uclient-fetch=y
 # CONFIG_PACKAGE_mtools is not set
 # CONFIG_PACKAGE_nvme-cli is not set
 CONFIG_PACKAGE_parted=y
+
+#
+# Configuration
+#
+CONFIG_PARTED_READLINE=y
+# CONFIG_PARTED_LVM2 is not set
+# end of Configuration
+
 CONFIG_PACKAGE_partx-utils=y
 # CONFIG_PACKAGE_sfdisk is not set
 # CONFIG_PACKAGE_sgdisk is not set


### PR DESCRIPTION
Recovering pre-existing uncommitted local edits (were sitting in a stash):
- **AGENTS.md** — LSN50/Chameleon I2C wiring rule (power reader from LSN50 VDD, not switched 5V) + note that `chameleon_readings` is the raw/diagnostic mirror and `device_data.swt_*` is canonical.
- **CLAUDE.md** — Session Closeout convention.
- **conf/full_raspberrypi_bcm27xx_bcm2712/.config** — enables `parted`/`libparted` in the bcm2712 image (disk-partition tooling). ⚠️ build-config change — confirm this is wanted before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded setup and operational guidance for Chameleon calibration, including wiring/power recommendations, sync behavior notes, migration reminders, and recovery steps for corrected historical data.
  * Added clearer session closeout instructions for finishing work consistently.

* **Chores**
  * Updated build configuration to include additional partitioning support for the Raspberry Pi OpenWrt image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->