### PR TITLE
[codex] Add wind rose visualization

### DIFF
--- a/docs/superpowers/plans/2026-07-01-wind-rose-visualization.md
+++ b/docs/superpowers/plans/2026-07-01-wind-rose-visualization.md
@@ -245,6 +245,9 @@ function speedBinIndex(speed: number, bins: WindSpeedBin[]): number {
 
 export function computeWindRose(samples: WindSample[], options: WindRoseOptions = {}): WindRose {
   const speedBins = options.speedBins ?? DEFAULT_WIND_SPEED_BINS;
+  if (speedBins.length === 0) {
+    throw new Error('speedBins must contain at least one bin');
+  }
   const calmThreshold = options.calmThreshold ?? DEFAULT_CALM_THRESHOLD;
 
   // counts[sectorIndex][binIndex]

--- a/docs/superpowers/plans/2026-07-01-wind-rose-visualization.md
+++ b/docs/superpowers/plans/2026-07-01-wind-rose-visualization.md
@@ -1,0 +1,643 @@
+# Wind Rose Visualization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the rotated-arrow "Direction history" grid in the S2120 `WindMonitor` modal with a real wind rose (16 directions × speed bins) rendered with echarts.
+
+**Architecture:** A pure, unit-tested aggregator (`computeWindRose`) turns the modal's already-fetched wind history into a direction × speed-bin distribution. A presentational `WindRoseChart` component builds an echarts polar option and renders it through the existing `EChart` wrapper; because that module imports echarts, it is lazy-loaded from `WindMonitor` so echarts stays out of the main bundle.
+
+**Tech Stack:** React + TypeScript, echarts `^5.6.0` (existing, lazy chunk), Vitest, existing `EChart` wrapper.
+
+## Global Constraints
+
+- No backend, schema, API, or history-card changes — reuse the modal's existing `wind_speed_mps` / `wind_direction_deg` fetch.
+- echarts MUST NOT enter the main bundle: the only new module that imports `EChart`/echarts is `WindRoseChart.tsx`, and `WindMonitor` imports it via `React.lazy` inside `<Suspense>` (mirrors `src/pages/AnalysisRoute.tsx`).
+- Reuse existing helpers: `COMPASS_POINTS`, `roundWindDirectionDegrees`, `toCompassDirection` in `src/utils/wind.ts`; the `EChart` wrapper in `src/components/analysis/EChart.tsx`.
+- Meteorological convention: direction = where wind blows **from**; N at top, clockwise. The S2120 decoder is silent on from/to, so record that assumption and verify it by field/vendor sanity-check (Task 3).
+- Frequencies are % of total valid (speed+direction finite) samples; `calmPct` + all petal percentages sum to 100 (within rounding).
+- Calm threshold default: **0.5 m/s**. Speed bins default: `<1, 1–2, 2–3, 3–4, 4–5, 5+ m/s` (top bin is `[5, ∞)`, labelled `5+`).
+- Tests run via `npm run test:unit` (Vitest covers `src/utils/__tests__` and `src/components/farming/__tests__`). Typecheck: `npm run typecheck`. All commands run from `web/react-gui/`.
+
+---
+
+### Task 1: `computeWindRose` pure aggregator
+
+**Files:**
+- Modify: `web/react-gui/src/utils/wind.ts` (append types + function; keep existing helpers)
+- Test: `web/react-gui/src/utils/__tests__/wind.test.ts` (create)
+
+**Interfaces:**
+- Consumes: nothing new (reuses `COMPASS_POINTS`, `toCompassDirection` already in this file).
+- Produces (later tasks rely on these exact names/types):
+
+```ts
+export interface WindSample {
+  wind_speed_mps: number | null;
+  wind_direction_deg: number | null;
+}
+
+export interface WindSpeedBin {
+  label: string;        // e.g. '<1', '1–2', '5+'
+  min: number;          // inclusive lower bound (m/s)
+  max: number | null;   // exclusive upper bound; null = open-ended
+  color: string;        // hex
+}
+
+export interface WindRoseSector {
+  direction: string;    // 'N', 'NNE', ... (COMPASS_POINTS order)
+  bins: number[];       // frequency % per speed bin, aligned to speedBins order
+  totalPct: number;     // sum of bins
+}
+
+export interface WindRose {
+  sectors: WindRoseSector[];   // length 16, COMPASS_POINTS order
+  speedBins: WindSpeedBin[];   // the bins used (echo of input/default)
+  validSamples: number;        // points with both speed & direction finite
+  calmSamples: number;         // valid points with speed < calmThreshold
+  calmPct: number;             // calmSamples / validSamples * 100, or 0
+}
+
+export interface WindRoseOptions {
+  calmThreshold?: number;      // default 0.5
+  speedBins?: WindSpeedBin[];  // default DEFAULT_WIND_SPEED_BINS
+}
+
+export const DEFAULT_WIND_SPEED_BINS: WindSpeedBin[];
+export function computeWindRose(samples: WindSample[], options?: WindRoseOptions): WindRose;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `web/react-gui/src/utils/__tests__/wind.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { computeWindRose, DEFAULT_WIND_SPEED_BINS } from '../wind';
+
+const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0);
+const roseTotalPct = (r: ReturnType<typeof computeWindRose>) =>
+  sum(r.sectors.map((s) => s.totalPct)) + r.calmPct;
+
+describe('computeWindRose', () => {
+  it('returns 16 sectors in COMPASS_POINTS order with default bins', () => {
+    const rose = computeWindRose([]);
+    expect(rose.sectors).toHaveLength(16);
+    expect(rose.sectors[0].direction).toBe('N');
+    expect(rose.sectors[4].direction).toBe('E');
+    expect(rose.speedBins).toEqual(DEFAULT_WIND_SPEED_BINS);
+    expect(rose.validSamples).toBe(0);
+    expect(rose.calmPct).toBe(0);
+  });
+
+  it('ignores samples missing speed or direction', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 3, wind_direction_deg: null },
+      { wind_speed_mps: null, wind_direction_deg: 90 },
+      { wind_speed_mps: Number.NaN, wind_direction_deg: 90 },
+    ]);
+    expect(rose.validSamples).toBe(0);
+  });
+
+  it('buckets a sample into the correct direction sector and speed bin', () => {
+    // 3.5 m/s from due East (90°) -> sector 'E' (index 4), bin '3–4' (index 3)
+    const rose = computeWindRose([{ wind_speed_mps: 3.5, wind_direction_deg: 90 }]);
+    expect(rose.validSamples).toBe(1);
+    const east = rose.sectors[4];
+    expect(east.direction).toBe('E');
+    expect(east.bins[3]).toBeCloseTo(100);
+    expect(east.totalPct).toBeCloseTo(100);
+  });
+
+  it('treats bin boundaries as [min, max): 1.0 -> "1–2", 5.0 -> "5+"', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 1.0, wind_direction_deg: 0 },
+      { wind_speed_mps: 5.0, wind_direction_deg: 0 },
+    ]);
+    const north = rose.sectors[0];
+    expect(north.bins[1]).toBeCloseTo(50); // '1–2'
+    expect(north.bins[5]).toBeCloseTo(50); // '5+'
+  });
+
+  it('ignores null speed/direction even though Number(null) === 0', () => {
+    // Regression guard: Number(null) is 0 (finite) and roundWindDirectionDegrees(null)
+    // is 0, so without an explicit null check these would count as a calm N sample.
+    const rose = computeWindRose([
+      { wind_speed_mps: null, wind_direction_deg: 90 },
+      { wind_speed_mps: 3, wind_direction_deg: null },
+    ]);
+    expect(rose.validSamples).toBe(0);
+    expect(rose.calmSamples).toBe(0);
+  });
+
+  it('counts samples below the calm threshold as calm, excluded from petals', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 0.2, wind_direction_deg: 45 },
+      { wind_speed_mps: 3, wind_direction_deg: 45 },
+    ]);
+    expect(rose.calmSamples).toBe(1);
+    expect(rose.calmPct).toBeCloseTo(50);
+    // the 0.2 sample must NOT contribute to any petal
+    expect(sum(rose.sectors.map((s) => s.totalPct))).toBeCloseTo(50);
+  });
+
+  it('wraps direction at 0/360°: 358° and 2° both land in N', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 3, wind_direction_deg: 358 },
+      { wind_speed_mps: 3, wind_direction_deg: 2 },
+    ]);
+    expect(rose.sectors[0].direction).toBe('N');
+    expect(rose.sectors[0].totalPct).toBeCloseTo(100);
+  });
+
+  it('petal percentages plus calm always sum to 100 for non-empty input', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 0.1, wind_direction_deg: 10 },
+      { wind_speed_mps: 2.5, wind_direction_deg: 100 },
+      { wind_speed_mps: 6, wind_direction_deg: 200 },
+      { wind_speed_mps: 4.2, wind_direction_deg: 280 },
+    ]);
+    expect(roseTotalPct(rose)).toBeCloseTo(100);
+  });
+
+  it('honors a custom calm threshold', () => {
+    const rose = computeWindRose(
+      [{ wind_speed_mps: 0.8, wind_direction_deg: 45 }],
+      { calmThreshold: 1.0 },
+    );
+    expect(rose.calmSamples).toBe(1);
+  });
+
+  it('reports 100% calm and zero petals when every sample is calm', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 0.1, wind_direction_deg: 10 },
+      { wind_speed_mps: 0.3, wind_direction_deg: 200 },
+    ]);
+    expect(rose.validSamples).toBe(2);
+    expect(rose.calmSamples).toBe(2);
+    expect(rose.calmPct).toBeCloseTo(100);
+    expect(sum(rose.sectors.map((s) => s.totalPct))).toBeCloseTo(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web/react-gui && npx vitest run src/utils/__tests__/wind.test.ts`
+Expected: FAIL — `computeWindRose` / `DEFAULT_WIND_SPEED_BINS` are not exported.
+
+- [ ] **Step 3: Implement the aggregator**
+
+Append to `web/react-gui/src/utils/wind.ts` (below the existing helpers; do not remove them):
+
+```ts
+export interface WindSample {
+  wind_speed_mps: number | null;
+  wind_direction_deg: number | null;
+}
+
+export interface WindSpeedBin {
+  label: string;
+  min: number;
+  max: number | null;
+  color: string;
+}
+
+export interface WindRoseSector {
+  direction: string;
+  bins: number[];
+  totalPct: number;
+}
+
+export interface WindRose {
+  sectors: WindRoseSector[];
+  speedBins: WindSpeedBin[];
+  validSamples: number;
+  calmSamples: number;
+  calmPct: number;
+}
+
+export interface WindRoseOptions {
+  calmThreshold?: number;
+  speedBins?: WindSpeedBin[];
+}
+
+// Blue→red ramp mirroring the reference wind-rose legend (theme-friendly).
+export const DEFAULT_WIND_SPEED_BINS: WindSpeedBin[] = [
+  { label: '<1', min: 0, max: 1, color: '#64748b' },
+  { label: '1–2', min: 1, max: 2, color: '#2563eb' },
+  { label: '2–3', min: 2, max: 3, color: '#06b6d4' },
+  { label: '3–4', min: 3, max: 4, color: '#22c55e' },
+  { label: '4–5', min: 4, max: 5, color: '#eab308' },
+  { label: '5+', min: 5, max: null, color: '#dc2626' },
+];
+
+const DEFAULT_CALM_THRESHOLD = 0.5;
+
+function speedBinIndex(speed: number, bins: WindSpeedBin[]): number {
+  for (let i = 0; i < bins.length; i += 1) {
+    const { min, max } = bins[i];
+    if (speed >= min && (max == null || speed < max)) {
+      return i;
+    }
+  }
+  return bins.length - 1; // speeds at/above the last bin's min land in the open bin
+}
+
+export function computeWindRose(samples: WindSample[], options: WindRoseOptions = {}): WindRose {
+  const speedBins = options.speedBins ?? DEFAULT_WIND_SPEED_BINS;
+  const calmThreshold = options.calmThreshold ?? DEFAULT_CALM_THRESHOLD;
+
+  // counts[sectorIndex][binIndex]
+  const counts: number[][] = COMPASS_POINTS.map(() => speedBins.map(() => 0));
+  let validSamples = 0;
+  let calmSamples = 0;
+
+  for (const sample of samples) {
+    // Guard null/undefined explicitly: Number(null) === 0 (finite) and
+    // roundWindDirectionDegrees(null) === 0 would otherwise count as a valid
+    // calm North sample. NaN speeds are still caught by the isFinite check below.
+    if (sample.wind_speed_mps == null || sample.wind_direction_deg == null) {
+      continue;
+    }
+    const speed = Number(sample.wind_speed_mps);
+    const direction = roundWindDirectionDegrees(sample.wind_direction_deg);
+    if (!Number.isFinite(speed) || direction == null) {
+      continue;
+    }
+    validSamples += 1;
+    if (speed < calmThreshold) {
+      calmSamples += 1;
+      continue;
+    }
+    const compass = toCompassDirection(direction);
+    const sectorIndex = compass ? COMPASS_POINTS.indexOf(compass) : -1;
+    if (sectorIndex < 0) {
+      continue;
+    }
+    counts[sectorIndex][speedBinIndex(speed, speedBins)] += 1;
+  }
+
+  const denom = validSamples || 1;
+  const sectors: WindRoseSector[] = COMPASS_POINTS.map((direction, sectorIndex) => {
+    const bins = counts[sectorIndex].map((count) => (count / denom) * 100);
+    return { direction, bins, totalPct: bins.reduce((a, b) => a + b, 0) };
+  });
+
+  return {
+    sectors,
+    speedBins,
+    validSamples,
+    calmSamples,
+    calmPct: validSamples ? (calmSamples / validSamples) * 100 : 0,
+  };
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd web/react-gui && npx vitest run src/utils/__tests__/wind.test.ts`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd web/react-gui && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd web/react-gui
+git add src/utils/wind.ts src/utils/__tests__/wind.test.ts
+git commit -m "feat(wind): add computeWindRose aggregator for wind-rose distribution"
+```
+
+---
+
+### Task 2: `WindRoseChart` component + `buildWindRoseOption`
+
+**Files:**
+- Create: `web/react-gui/src/components/farming/WindRoseChart.tsx`
+- Test: `web/react-gui/src/components/farming/__tests__/WindRoseChart.test.tsx`
+
+**Interfaces:**
+- Consumes: `WindRose`, `WindSpeedBin` from `../../utils/wind` (Task 1); `EChart` from `../analysis/EChart`.
+- Produces:
+
+```ts
+export interface WindRoseTheme {
+  axisLine: string;
+  axisLabel: string;
+  splitLine: string;
+  legendText: string;
+}
+export function buildWindRoseOption(rose: WindRose, theme: WindRoseTheme): Record<string, unknown>;
+export const WindRoseChart: React.FC<{ rose: WindRose }>;
+```
+
+`buildWindRoseOption` is a pure function — it takes the theme colors as an argument (no DOM/echarts access), so it is fully unit-testable. `WindRoseChart` reads the CSS theme vars and passes them in, then renders `<EChart option={...} />`. This module is the echarts lazy boundary — nothing else imports it except via `React.lazy`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/react-gui/src/components/farming/__tests__/WindRoseChart.test.tsx`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildWindRoseOption, type WindRoseTheme } from '../WindRoseChart';
+import { computeWindRose } from '../../../utils/wind';
+
+const THEME: WindRoseTheme = {
+  axisLine: '#111',
+  axisLabel: '#222',
+  splitLine: '#333',
+  legendText: '#444',
+};
+
+describe('buildWindRoseOption', () => {
+  const rose = computeWindRose([
+    { wind_speed_mps: 3.5, wind_direction_deg: 90 },
+    { wind_speed_mps: 6, wind_direction_deg: 200 },
+  ]);
+  const option = buildWindRoseOption(rose, THEME) as any;
+
+  it('produces a polar coordinate system', () => {
+    expect(option.polar).toBeDefined();
+  });
+
+  it('uses the 16 compass directions as the angle axis, N first, clockwise from top', () => {
+    expect(option.angleAxis.type).toBe('category');
+    expect(option.angleAxis.data).toHaveLength(16);
+    expect(option.angleAxis.data[0]).toBe('N');
+    expect(option.angleAxis.startAngle).toBe(90);
+    expect(option.angleAxis.clockwise).toBe(true);
+  });
+
+  it('emits one stacked polar bar series per speed bin', () => {
+    expect(option.series).toHaveLength(rose.speedBins.length);
+    for (const series of option.series) {
+      expect(series.type).toBe('bar');
+      expect(series.coordinateSystem).toBe('polar');
+      expect(series.stack).toBe('total');
+      expect(series.data).toHaveLength(16);
+    }
+  });
+
+  it('colors each series from its speed bin and names it with the bin label', () => {
+    expect(option.series[0].name).toBe(rose.speedBins[0].label);
+    expect(option.series[0].itemStyle.color).toBe(rose.speedBins[0].color);
+  });
+
+  it('lists the speed-bin labels in the legend', () => {
+    expect(option.legend.data).toEqual(rose.speedBins.map((b) => b.label));
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd web/react-gui && npx vitest run src/components/farming/__tests__/WindRoseChart.test.tsx`
+Expected: FAIL — `WindRoseChart`/`buildWindRoseOption` module does not exist.
+
+- [ ] **Step 3: Implement the component**
+
+Create `web/react-gui/src/components/farming/WindRoseChart.tsx`:
+
+```tsx
+import React from 'react';
+import { EChart } from '../analysis/EChart';
+import type { WindRose } from '../../utils/wind';
+
+export interface WindRoseTheme {
+  axisLine: string;
+  axisLabel: string;
+  splitLine: string;
+  legendText: string;
+}
+
+function cssVar(name: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback;
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return value || fallback;
+}
+
+function readTheme(): WindRoseTheme {
+  return {
+    axisLine: cssVar('--border', '#e2e8f0'),
+    axisLabel: cssVar('--text-secondary', '#64748b'),
+    splitLine: cssVar('--border', '#e2e8f0'),
+    legendText: cssVar('--text-secondary', '#64748b'),
+  };
+}
+
+// Pure (theme is passed in): builds the echarts polar wind-rose option.
+// Orientation: N at top (startAngle 90), sectors clockwise NNE→E→S→W.
+export function buildWindRoseOption(rose: WindRose, theme: WindRoseTheme): Record<string, unknown> {
+  const directions = rose.sectors.map((s) => s.direction);
+  return {
+    tooltip: { trigger: 'item' },
+    legend: {
+      data: rose.speedBins.map((b) => b.label),
+      bottom: 0,
+      textStyle: { color: theme.legendText },
+    },
+    polar: {},
+    angleAxis: {
+      type: 'category',
+      data: directions,
+      startAngle: 90,
+      clockwise: true,
+      boundaryGap: true,
+      axisLine: { lineStyle: { color: theme.axisLine } },
+      axisLabel: { color: theme.axisLabel },
+    },
+    radiusAxis: {
+      min: 0,
+      axisLabel: {
+        color: theme.axisLabel,
+        formatter: (v: number) => `${Math.round(v)}%`,
+      },
+      splitLine: { lineStyle: { color: theme.splitLine } },
+    },
+    series: rose.speedBins.map((bin, binIndex) => ({
+      name: bin.label,
+      type: 'bar',
+      coordinateSystem: 'polar',
+      stack: 'total',
+      data: rose.sectors.map((s) => s.bins[binIndex]),
+      itemStyle: { color: bin.color },
+    })),
+  };
+}
+
+export const WindRoseChart: React.FC<{ rose: WindRose }> = ({ rose }) => {
+  const option = React.useMemo(() => buildWindRoseOption(rose, readTheme()), [rose]);
+  return (
+    <div style={{ width: '100%', height: 340 }}>
+      <EChart option={option} className="h-full w-full" />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd web/react-gui && npx vitest run src/components/farming/__tests__/WindRoseChart.test.tsx`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd web/react-gui && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd web/react-gui
+git add src/components/farming/WindRoseChart.tsx src/components/farming/__tests__/WindRoseChart.test.tsx
+git commit -m "feat(wind): add WindRoseChart echarts polar renderer"
+```
+
+---
+
+### Task 3: Integrate the rose into `WindMonitor` (lazy) and remove the arrow grid
+
+**Files:**
+- Modify: `web/react-gui/src/components/farming/WindMonitor.tsx`
+- Reference (read-only, convention check): the S2120 decoder under `conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/sensecap_s2120_decoder.js`
+
+**Interfaces:**
+- Consumes: `computeWindRose`, `WindRose` from `../../utils/wind`; `WindRoseChart` from `./WindRoseChart` (via `React.lazy`).
+- Produces: no new exports; the modal now renders a wind rose in place of the direction-arrow grid.
+
+- [ ] **Step 1: Note the direction convention (no code yet)**
+
+Run: `grep -niE "wind.?dir|direction|4104|from" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/sensecap_s2120_decoder.js | head`
+Expected: the decoder only labels measurement `4104` as "Wind Direction Sensor" — it does **not** state a from/to convention. Do **not** treat the grep as confirmation. "From" (meteorological) remains an *assumption* grounded in the SenseCAP vendor spec, not something the code proves. Carry the assumption into implementation and pin it down in Step 7 by sanity-checking the rendered prevailing direction against known field/site wind (or vendor docs). Keep orientation trivially flippable: the rose uses `startAngle: 90, clockwise: true`; if the prevailing petal is mirrored 180°, the fix is a single direction offset. Record the finding in the commit message.
+
+- [ ] **Step 2: Add lazy import + Suspense scaffolding to `WindMonitor.tsx`**
+
+At the top of `web/react-gui/src/components/farming/WindMonitor.tsx`, change the React import and add the lazy component + rose helper import.
+
+Replace line 1:
+```tsx
+import React, { useEffect, useMemo, useState } from 'react';
+```
+with:
+```tsx
+import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react';
+```
+
+Replace the wind-helper import (line 13):
+```tsx
+import { formatWindDirection, roundWindDirectionDegrees, toCompassDirection } from '../../utils/wind';
+```
+with (drop the now-unused helpers, add the aggregator):
+```tsx
+import { computeWindRose, formatWindDirection } from '../../utils/wind';
+```
+
+Add, immediately after the imports (above `interface Props`):
+```tsx
+const WindRoseChart = lazy(() =>
+  import('./WindRoseChart').then((module) => ({ default: module.WindRoseChart })),
+);
+
+const MIN_ROSE_SAMPLES = 10;
+```
+
+- [ ] **Step 3: Replace the direction-history section with the wind rose**
+
+Delete the `sampledDirectionPoints` memo (lines ~159-169) — it is no longer used.
+
+Compute the rose from the merged `data` (add near the other derived values, after `hasAnyData`):
+```tsx
+  const windRose = useMemo(() => computeWindRose(data), [data]);
+```
+
+Replace the entire "Direction history" `<div>` block (the `<div>` starting `<div className="mb-3 flex items-center justify-between gap-3">`'s parent — i.e. the second child under the charts, lines ~294-330) with:
+```tsx
+              <div>
+                <div className="mb-3 flex items-center justify-between gap-3">
+                  <h3 className="font-bold text-[var(--text)]">Wind rose (direction × speed)</h3>
+                  <p className="text-xs text-[var(--text-tertiary)]">
+                    {windRose.validSamples} samples · {Math.round(windRose.calmPct)}% calm
+                  </p>
+                </div>
+                {windRose.validSamples >= MIN_ROSE_SAMPLES ? (
+                  <Suspense
+                    fallback={
+                      <div className="flex h-[340px] items-center justify-center">
+                        <div className="h-8 w-8 animate-spin rounded-full border-4 border-[var(--primary)] border-t-transparent" />
+                      </div>
+                    }
+                  >
+                    <WindRoseChart rose={windRose} />
+                  </Suspense>
+                ) : (
+                  <div className="rounded-lg bg-[var(--card)] p-4 text-sm text-[var(--text-tertiary)]">
+                    Not enough wind data to plot a rose in this window.
+                  </div>
+                )}
+              </div>
+```
+
+- [ ] **Step 4: Typecheck (catches unused imports / leftover references)**
+
+Run: `cd web/react-gui && npm run typecheck`
+Expected: no errors. In particular, no "declared but never used" for `roundWindDirectionDegrees`, `toCompassDirection`, or `sampledDirectionPoints`. If any appear, remove the offending leftover.
+
+- [ ] **Step 5: Run the full unit suite**
+
+Run: `cd web/react-gui && npm run test:unit`
+Expected: PASS (existing suites unaffected; Task 1 & 2 suites green).
+
+- [ ] **Step 6: Build to confirm the lazy chunk splits cleanly**
+
+Run: `cd web/react-gui && npm run build`
+Expected: build succeeds; the output shows a separate echarts-containing chunk (as it already does for Analysis). echarts must not be folded into the main/index chunk.
+
+- [ ] **Step 7: Manual verification (record result in commit)**
+
+Start the dev server (`npm run dev`), open an S2120 card, click Wind Speed/Direction to open the modal, and confirm:
+- The wind rose renders in place of the old arrow grid, N at top, petals clockwise.
+- The prevailing-direction petal points to the direction wind comes **from** (sanity-check against current `formatWindDirection` reading in the stat tile / known site wind).
+- Switching time windows (12h/24h/7d/30d/90d) re-aggregates the rose.
+- On a narrow viewport the rose resizes without overflow.
+- If prevailing direction is mirrored 180°, revisit the Step 1 convention finding.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd web/react-gui
+git add src/components/farming/WindMonitor.tsx
+git commit -m "feat(wind): show wind rose in WindMonitor, replacing arrow grid (lazy echarts)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Wind rose (dir × speed), replacing arrow grid → Tasks 1–3. ✓
+- Pure, unit-tested aggregator in `utils/wind.ts` → Task 1. ✓
+- echarts via `EChart`, lazy-loaded, out of main bundle → Task 2 (module boundary) + Task 3 (React.lazy) + build check. ✓
+- Calm handling (0.5 m/s), 6-bin speed scale, % of valid samples, calm+petals=100 → Task 1 (tested). ✓
+- 16 sectors, N top clockwise, meteorological "from" assumption + decoder-silence note + field sanity-check → Task 2 option + Task 3 Step 1/7. ✓
+- Low-data state (<10 samples) → Task 3 Step 3. ✓
+- Keep speed/gust chart + stat tiles; card unchanged → Task 3 only touches the direction section. ✓
+- Tests via `npm run test:unit` → all tasks. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; commands have expected output. ✓
+
+**Type consistency:** `WindSample`, `WindSpeedBin`, `WindRose`, `WindRoseSector`, `WindRoseTheme`, `computeWindRose`, `DEFAULT_WIND_SPEED_BINS`, `buildWindRoseOption`, `WindRoseChart` are named identically across Tasks 1→2→3. `buildWindRoseOption(rose, theme)` takes the theme argument consistently in Task 2's impl and test. `WindHistoryPoint` (defined locally in WindMonitor with `wind_speed_mps`/`wind_direction_deg`) structurally satisfies `WindSample`, so `computeWindRose(data)` typechecks. ✓
+
+## Notes / follow-ups (out of scope)
+
+- Direction overlaid on the speed/gust time series (dual-axis).
+- Zone-scoped wind view in the `environment` history card.
+- Beaufort / spray-drift plain-language cues.
+- **Pre-existing latent bug (separate change):** `roundWindDirectionDegrees(null)`
+  returns `0` (because `Number(null) === 0` passes `isFinite`), so
+  `formatWindDirection(null)` renders `"N 0°"` instead of `"—"` on the S2120 card
+  when direction is missing. This plan sidesteps it with an explicit null guard in
+  `computeWindRose` rather than changing the shared helper (which has other
+  callers). Worth a focused fix + regression test on its own.

--- a/docs/superpowers/specs/2026-07-01-wind-rose-visualization-design.md
+++ b/docs/superpowers/specs/2026-07-01-wind-rose-visualization-design.md
@@ -1,0 +1,154 @@
+# Wind Rose Visualization — Design
+
+**Date:** 2026-07-01
+**Status:** Approved (design); implementation plan pending
+**Area:** `web/react-gui` — S2120 weather-station wind view
+
+## Problem
+
+The SenseCAP S2120 weather station already records and serves wind speed, gust,
+and direction. The station-scoped `WindMonitor` modal shows a speed/gust chart
+plus a "Direction history" grid of up to 10 rotated ↑ arrows. That arrow grid is
+a weak representation of direction: it cannot convey the *prevailing* direction
+or the *speed distribution* per direction over a window.
+
+A standard meteorological **wind rose** (polar histogram of direction × speed)
+communicates both at a glance and is the natural upgrade. We have all the data;
+we simply are not aggregating direction × speed into a distribution.
+
+## Goal & scope
+
+Add a wind rose to the `WindMonitor` modal, **replacing** the rotated-arrow
+"Direction history" grid, which it supersedes.
+
+**In scope**
+- Client-side aggregation of the existing wind history into a
+  direction × speed-bin distribution.
+- A polar wind-rose chart rendered with **echarts** (already a dependency),
+  lazy-loaded so it does not enter the main bundle.
+
+**Explicitly out of scope** (deferred; not requested)
+- Direction overlaid on the speed/gust time series (dual-axis).
+- Headline summary stats (prevailing direction, mean/peak) beyond the existing
+  three stat tiles.
+- Beaufort / plain-language descriptors.
+- Any backend, schema, API, or history-card (`environment`) changes.
+
+The existing speed/gust recharts chart, the three header stat tiles, and the
+S2120 card's at-a-glance current-conditions tiles all remain unchanged — the
+card stays the "layered" simple cue; the rose is the deep view.
+
+## Context (verified against current code)
+
+- Data: `WindMonitor` already fetches `wind_speed_mps`, `wind_gust_mps`, and
+  `wind_direction_deg` via `sensorAPI.getHistory` and merges them by timestamp
+  into `WindHistoryPoint[]` (`{ t, wind_speed_mps, wind_gust_mps,
+  wind_direction_deg }`). The rose consumes this existing merged array.
+- Helpers: `web/react-gui/src/utils/wind.ts` holds `roundWindDirectionDegrees`,
+  `toCompassDirection`, `formatWindDirection`, and the `COMPASS_POINTS`
+  16-point list. New aggregation lives beside them.
+- echarts `^5.6.0` is already installed. It is used only by the desktop-only,
+  lazy-loaded Cross-Zone Analysis feature through the shared wrapper
+  `web/react-gui/src/components/analysis/EChart.tsx`, which applies any option
+  via `chart.setOption(option, true)` — a polar chart works through it. echarts
+  is therefore **not** in the main bundle; it ships as an on-demand chunk.
+- Everyday farming/history charts (including the current WindMonitor speed/gust
+  chart) use **recharts**, which is in the main bundle.
+
+## Architecture — three small units
+
+### 1. `computeWindRose(points, options)` — pure aggregator
+Location: `web/react-gui/src/utils/wind.ts` (beside existing helpers).
+
+- **Input:** the merged `WindHistoryPoint[]` and an options object
+  (`calmThreshold`, `speedBins`).
+- **Output:** a plain, serializable structure — for each of the 16 direction
+  sectors, the frequency (% of valid samples) in each speed bin; plus overall
+  totals, valid-sample count, and calm %.
+- No React, no echarts. Fully unit-testable.
+
+**Rules**
+- Consider only points where **both** speed and direction are non-null/finite.
+- **Calm:** samples with speed `< calmThreshold` (default **0.5 m/s**) have
+  meaningless direction → excluded from petals, counted toward **calm %**
+  (shown in the modal's wind-rose section header). Null/undefined speed or
+  direction is excluded entirely (not counted as calm) — note that
+  `Number(null) === 0`, so `computeWindRose` must guard nulls explicitly before
+  numeric conversion.
+- **Direction binning:** 16 sectors aligned to `COMPASS_POINTS`, each spanning
+  ±11.25°, reusing `roundWindDirectionDegrees` for 0/360° wraparound.
+- **Convention:** meteorological — direction is where the wind blows *from*;
+  N at top. The S2120 decoder is silent on from/to (it only labels the
+  measurement "Wind Direction Sensor"), so "from" is an assumption grounded in
+  the SenseCAP vendor spec, not something the code proves. Verify by
+  sanity-checking the rendered prevailing direction against known field wind, and
+  keep orientation trivially flippable if it proves inverted.
+- **Speed bins (default, matching the reference screenshot):**
+  `<1, 1–2, 2–3, 3–4, 4–5, 5+ m/s`, defined as a single config constant
+  (thresholds + colors + labels colocated). The top bin is `[5, ∞)`, so it is
+  labelled `5+` (a `5.0` sample belongs to it).
+- Frequencies are **% of total valid samples**, so petal lengths compare across
+  time windows.
+
+### 2. `WindRoseChart.tsx` — presentational + lazy boundary
+Location: `web/react-gui/src/components/farming/` (near `WindMonitor.tsx`).
+
+- Takes the `computeWindRose` result, builds an echarts `option`, and renders it
+  through the existing `EChart` wrapper.
+- Because this module imports `EChart` (which imports full echarts), it is the
+  **code-split boundary**: echarts lands in a lazy chunk, not the main bundle.
+- **echarts option:** `polar` coordinate system; `angleAxis` = category of the
+  16 directions, **N at top, clockwise**; `radiusAxis` = frequency %. One
+  **stacked `bar` series per speed bin** (6 series) produces the classic stacked
+  petals. A blue→red color ramp and a `legend` for the speed bins. Colors and
+  text read from CSS theme vars (`--text`, `--border`, …) so light/dark match
+  the analysis charts.
+
+### 3. `WindMonitor` integration
+- Import `WindRoseChart` via `React.lazy` and render inside `<Suspense>`
+  (mirroring `AnalysisRoute.tsx`) so the echarts chunk loads only when the modal
+  opens.
+- Remove the rotated-arrow "Direction history" section and its
+  `sampledDirectionPoints` machinery; the rose replaces it. Keep the speed/gust
+  chart and the three stat tiles as-is.
+
+## States
+
+- **Loading:** existing spinner covers data fetch + echarts chunk load.
+- **Low data:** if fewer than ~10 valid paired (speed + direction) samples in the
+  window, show a small "not enough wind data to plot a rose in this window"
+  message (reusing the modal's existing empty-state styling) instead of a
+  misleading near-empty rose.
+- **All-calm:** rose renders empty petals with the calm % shown in the section
+  header. (Center-of-rose placement was considered but rejected: the bottom
+  legend offsets the polar center, so a centered label needs a fragile magic
+  offset; the header conveys the same information unambiguously.)
+- **Responsive:** the drawer is full-width on mobile; the `EChart` wrapper's
+  `ResizeObserver` already handles resize.
+
+## Testing
+
+- **Unit** (`utils/__tests__`, following existing pattern) for `computeWindRose`:
+  bin-boundary values, calm exclusion, direction wraparound at 0/360°, empty
+  input, all-calm input, and % normalization summing correctly.
+- **Render:** a light test for `WindRoseChart` mirroring the existing
+  `EChart.test.tsx` mock (assert a polar option with the expected stacked series
+  is produced), no real echarts render required.
+- Run via `npm run test:unit` (per project convention).
+
+## Risks & assumptions
+
+- **Direction convention** ("from" vs "to"): the decoder cannot prove it, so
+  "from" (meteorological) is a vendor-spec assumption; a wrong convention rotates
+  the rose 180°. Verify with a field sanity-check, not by reading the decoder.
+- **Bundle:** lazy-loading keeps echarts out of the initial farming/mobile
+  bundle; the chunk loads over LAN from the Pi on first modal open and caches.
+- **Consistency:** the modal will mix recharts (speed/gust) and echarts (rose).
+  Acceptable — the rose has no good recharts primitive, and the split is
+  contained to one modal.
+
+## Out-of-scope follow-ups (future)
+
+- Direction on the speed time series (dual-axis, like the reference right panel).
+- A zone-scoped wind view in the `environment` history card.
+- Beaufort / spray-drift plain-language cues for operational decisions.

--- a/web/react-gui/src/components/farming/WindMonitor.tsx
+++ b/web/react-gui/src/components/farming/WindMonitor.tsx
@@ -10,7 +10,7 @@ import {
   YAxis,
 } from 'recharts';
 import { sensorAPI, type SensorHistoryPoint } from '../../services/api';
-import { computeWindRose, formatWindDirection } from '../../utils/wind';
+import { computeWindRose, formatWindDirection, type WindSample } from '../../utils/wind';
 
 const WindRoseChart = lazy(() =>
   import('./WindRoseChart').then((module) => ({ default: module.WindRoseChart })),
@@ -38,6 +38,25 @@ const TIME_WINDOWS = [
   { label: '30 d', hours: 720 },
   { label: '90 d', hours: 2160 },
 ];
+
+class WindRoseErrorBoundary extends React.Component<{ children: React.ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-lg bg-[var(--card)] p-4 text-sm text-[var(--text-tertiary)]">
+          Unable to load wind rose chart.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 function fmtTick(iso: string, hours: number): string {
   const d = new Date(iso);
@@ -88,6 +107,50 @@ function mergeSeries(
   return Array.from(map.values()).sort((left, right) => new Date(left.t).getTime() - new Date(right.t).getTime());
 }
 
+function timestampMs(timestamp: string): number | null {
+  const value = new Date(timestamp).getTime();
+  return Number.isFinite(value) ? value : null;
+}
+
+function finiteRows(rows: SensorHistoryPoint[]): Array<SensorHistoryPoint & { ms: number }> {
+  return rows
+    .map((row) => ({ ...row, ms: timestampMs(row.t) }))
+    .filter((row): row is SensorHistoryPoint & { ms: number } => row.ms != null && Number.isFinite(row.value))
+    .sort((left, right) => left.ms - right.ms);
+}
+
+function pairWindRoseSamples(speedRows: SensorHistoryPoint[], directionRows: SensorHistoryPoint[]): WindSample[] {
+  const speed = finiteRows(speedRows);
+  const direction = finiteRows(directionRows);
+  if (!speed.length || !direction.length) {
+    return [];
+  }
+
+  const directionByTimestamp = new Map(direction.map((row) => [row.t, row]));
+  const lastStep = speed.length > 1 ? Math.max(0, speed[speed.length - 1].ms - speed[speed.length - 2].ms) : 0;
+  let directionIndex = 0;
+
+  return speed.flatMap((speedRow, index): WindSample[] => {
+    const exact = directionByTimestamp.get(speedRow.t);
+    if (exact) {
+      return [{ wind_speed_mps: speedRow.value, wind_direction_deg: exact.value }];
+    }
+
+    const bucketStart = speedRow.ms;
+    const bucketEnd = speed[index + 1]?.ms ?? (lastStep > 0 ? bucketStart + lastStep : bucketStart + 1);
+    while (directionIndex < direction.length && direction[directionIndex].ms < bucketStart) {
+      directionIndex += 1;
+    }
+
+    const bucketDirection = direction[directionIndex];
+    if (!bucketDirection || bucketDirection.ms >= bucketEnd) {
+      return [];
+    }
+
+    return [{ wind_speed_mps: speedRow.value, wind_direction_deg: bucketDirection.value }];
+  });
+}
+
 const WindTooltip = ({ active, payload, label, hours }: any) => {
   if (!active || !payload?.length) return null;
   const point = payload[0]?.payload as WindHistoryPoint | undefined;
@@ -112,6 +175,7 @@ const WindTooltip = ({ active, payload, label, hours }: any) => {
 export const WindMonitor: React.FC<Props> = ({ deveui, deviceName, onClose }) => {
   const [hours, setHours] = useState(24);
   const [data, setData] = useState<WindHistoryPoint[]>([]);
+  const [windRoseSamples, setWindRoseSamples] = useState<WindSample[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -128,6 +192,7 @@ export const WindMonitor: React.FC<Props> = ({ deveui, deviceName, onClose }) =>
       .then(([speedRows, gustRows, directionRows]) => {
         if (!cancelled) {
           setData(mergeSeries(speedRows, gustRows, directionRows));
+          setWindRoseSamples(pairWindRoseSamples(speedRows, directionRows));
           setLoading(false);
         }
       })
@@ -161,7 +226,7 @@ export const WindMonitor: React.FC<Props> = ({ deveui, deviceName, onClose }) =>
   const currentDirection = directionPoints.length ? directionPoints[directionPoints.length - 1].wind_direction_deg : null;
   const hasChartData = speedValues.length > 0 || gustValues.length > 0;
   const hasAnyData = hasChartData || directionPoints.length > 0;
-  const windRose = useMemo(() => computeWindRose(data), [data]);
+  const windRose = useMemo(() => computeWindRose(windRoseSamples), [windRoseSamples]);
 
   return (
     <div
@@ -294,15 +359,17 @@ export const WindMonitor: React.FC<Props> = ({ deveui, deviceName, onClose }) =>
                   </p>
                 </div>
                 {windRose.validSamples >= MIN_ROSE_SAMPLES ? (
-                  <Suspense
-                    fallback={
-                      <div className="flex h-[340px] items-center justify-center">
-                        <div className="h-8 w-8 animate-spin rounded-full border-4 border-[var(--primary)] border-t-transparent" />
-                      </div>
-                    }
-                  >
-                    <WindRoseChart rose={windRose} />
-                  </Suspense>
+                  <WindRoseErrorBoundary key={`${hours}-${windRose.validSamples}`}>
+                    <Suspense
+                      fallback={
+                        <div className="flex h-[340px] items-center justify-center">
+                          <div className="h-8 w-8 animate-spin rounded-full border-4 border-[var(--primary)] border-t-transparent" />
+                        </div>
+                      }
+                    >
+                      <WindRoseChart rose={windRose} />
+                    </Suspense>
+                  </WindRoseErrorBoundary>
                 ) : (
                   <div className="rounded-lg bg-[var(--card)] p-4 text-sm text-[var(--text-tertiary)]">
                     Not enough wind data to plot a rose in this window.

--- a/web/react-gui/src/components/farming/WindMonitor.tsx
+++ b/web/react-gui/src/components/farming/WindMonitor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import {
   Area,
   CartesianGrid,
@@ -10,7 +10,13 @@ import {
   YAxis,
 } from 'recharts';
 import { sensorAPI, type SensorHistoryPoint } from '../../services/api';
-import { formatWindDirection, roundWindDirectionDegrees, toCompassDirection } from '../../utils/wind';
+import { computeWindRose, formatWindDirection } from '../../utils/wind';
+
+const WindRoseChart = lazy(() =>
+  import('./WindRoseChart').then((module) => ({ default: module.WindRoseChart })),
+);
+
+const MIN_ROSE_SAMPLES = 10;
 
 interface Props {
   deveui: string;
@@ -155,18 +161,7 @@ export const WindMonitor: React.FC<Props> = ({ deveui, deviceName, onClose }) =>
   const currentDirection = directionPoints.length ? directionPoints[directionPoints.length - 1].wind_direction_deg : null;
   const hasChartData = speedValues.length > 0 || gustValues.length > 0;
   const hasAnyData = hasChartData || directionPoints.length > 0;
-
-  const sampledDirectionPoints = useMemo(() => {
-    if (!directionPoints.length) return [];
-    const maxSamples = 10;
-    const step = Math.max(1, Math.ceil(directionPoints.length / maxSamples));
-    const sampled = directionPoints.filter((_, index) => index % step === 0);
-    const lastPoint = directionPoints[directionPoints.length - 1];
-    if (sampled[sampled.length - 1]?.t !== lastPoint.t) {
-      sampled.push(lastPoint);
-    }
-    return sampled;
-  }, [directionPoints]);
+  const windRose = useMemo(() => computeWindRose(data), [data]);
 
   return (
     <div
@@ -293,38 +288,24 @@ export const WindMonitor: React.FC<Props> = ({ deveui, deviceName, onClose }) =>
 
               <div>
                 <div className="mb-3 flex items-center justify-between gap-3">
-                  <h3 className="font-bold text-[var(--text)]">Direction history</h3>
-                  <p className="text-xs text-[var(--text-tertiary)]">{directionPoints.length} samples</p>
+                  <h3 className="font-bold text-[var(--text)]">Wind rose (direction × speed)</h3>
+                  <p className="text-xs text-[var(--text-tertiary)]">
+                    {windRose.validSamples} samples · {Math.round(windRose.calmPct)}% calm
+                  </p>
                 </div>
-                {sampledDirectionPoints.length > 0 ? (
-                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-                    {sampledDirectionPoints.map((point) => {
-                      const rounded = roundWindDirectionDegrees(point.wind_direction_deg);
-                      const compass = toCompassDirection(point.wind_direction_deg);
-                      return (
-                        <div key={point.t} className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-3">
-                          <div className="mb-2 flex items-center gap-3">
-                            <span
-                              className="inline-block text-2xl text-[var(--primary)]"
-                              style={{ transform: `rotate(${rounded ?? 0}deg)` }}
-                            >
-                              ↑
-                            </span>
-                            <div>
-                              <p className="font-semibold text-[var(--text)]">{compass ?? '—'}</p>
-                              <p className="text-xs text-[var(--text-tertiary)]">
-                                {rounded != null ? `${rounded}°` : '—'}
-                              </p>
-                            </div>
-                          </div>
-                          <p className="text-xs text-[var(--text-tertiary)]">{fmtTick(point.t, hours)}</p>
-                        </div>
-                      );
-                    })}
-                  </div>
+                {windRose.validSamples >= MIN_ROSE_SAMPLES ? (
+                  <Suspense
+                    fallback={
+                      <div className="flex h-[340px] items-center justify-center">
+                        <div className="h-8 w-8 animate-spin rounded-full border-4 border-[var(--primary)] border-t-transparent" />
+                      </div>
+                    }
+                  >
+                    <WindRoseChart rose={windRose} />
+                  </Suspense>
                 ) : (
                   <div className="rounded-lg bg-[var(--card)] p-4 text-sm text-[var(--text-tertiary)]">
-                    No wind-direction samples are available in this window.
+                    Not enough wind data to plot a rose in this window.
                   </div>
                 )}
               </div>

--- a/web/react-gui/src/components/farming/WindRoseChart.tsx
+++ b/web/react-gui/src/components/farming/WindRoseChart.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { EChart } from '../analysis/EChart';
+import type { WindRose } from '../../utils/wind';
+
+export interface WindRoseTheme {
+  axisLine: string;
+  axisLabel: string;
+  splitLine: string;
+  legendText: string;
+}
+
+function cssVar(name: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback;
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return value || fallback;
+}
+
+function readTheme(): WindRoseTheme {
+  return {
+    axisLine: cssVar('--border', '#e2e8f0'),
+    axisLabel: cssVar('--text-secondary', '#64748b'),
+    splitLine: cssVar('--border', '#e2e8f0'),
+    legendText: cssVar('--text-secondary', '#64748b'),
+  };
+}
+
+// Orientation: N at top (startAngle 90), sectors clockwise NNE -> E -> S -> W.
+export function buildWindRoseOption(rose: WindRose, theme: WindRoseTheme): Record<string, unknown> {
+  const directions = rose.sectors.map((sector) => sector.direction);
+
+  return {
+    tooltip: { trigger: 'item' },
+    legend: {
+      data: rose.speedBins.map((bin) => bin.label),
+      bottom: 0,
+      textStyle: { color: theme.legendText },
+    },
+    polar: {},
+    angleAxis: {
+      type: 'category',
+      data: directions,
+      startAngle: 90,
+      clockwise: true,
+      boundaryGap: true,
+      axisLine: { lineStyle: { color: theme.axisLine } },
+      axisLabel: { color: theme.axisLabel },
+    },
+    radiusAxis: {
+      min: 0,
+      axisLabel: {
+        color: theme.axisLabel,
+        formatter: (value: number) => `${Math.round(value)}%`,
+      },
+      splitLine: { lineStyle: { color: theme.splitLine } },
+    },
+    series: rose.speedBins.map((bin, binIndex) => ({
+      name: bin.label,
+      type: 'bar',
+      coordinateSystem: 'polar',
+      stack: 'total',
+      data: rose.sectors.map((sector) => sector.bins[binIndex]),
+      itemStyle: { color: bin.color },
+    })),
+  };
+}
+
+export const WindRoseChart: React.FC<{ rose: WindRose }> = ({ rose }) => {
+  const option = React.useMemo(() => buildWindRoseOption(rose, readTheme()), [rose]);
+
+  return (
+    <div style={{ width: '100%', height: 340 }}>
+      <EChart option={option} className="h-full w-full" />
+    </div>
+  );
+};

--- a/web/react-gui/src/components/farming/WindRoseChart.tsx
+++ b/web/react-gui/src/components/farming/WindRoseChart.tsx
@@ -24,6 +24,27 @@ function readTheme(): WindRoseTheme {
   };
 }
 
+function useWindRoseTheme(): WindRoseTheme {
+  const [theme, setTheme] = React.useState<WindRoseTheme>(() => readTheme());
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || typeof MutationObserver === 'undefined') {
+      return undefined;
+    }
+
+    const refreshTheme = () => setTheme(readTheme());
+    const observer = new MutationObserver(refreshTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'data-theme', 'style'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}
+
 // Orientation: N at top (startAngle 90), sectors clockwise NNE -> E -> S -> W.
 export function buildWindRoseOption(rose: WindRose, theme: WindRoseTheme): Record<string, unknown> {
   const directions = rose.sectors.map((sector) => sector.direction);
@@ -65,7 +86,11 @@ export function buildWindRoseOption(rose: WindRose, theme: WindRoseTheme): Recor
 }
 
 export const WindRoseChart: React.FC<{ rose: WindRose }> = ({ rose }) => {
-  const option = React.useMemo(() => buildWindRoseOption(rose, readTheme()), [rose]);
+  const theme = useWindRoseTheme();
+  const option = React.useMemo(
+    () => buildWindRoseOption(rose, theme),
+    [rose, theme.axisLabel, theme.axisLine, theme.legendText, theme.splitLine],
+  );
 
   return (
     <div style={{ width: '100%', height: 340 }}>

--- a/web/react-gui/src/components/farming/__tests__/WindMonitor.test.tsx
+++ b/web/react-gui/src/components/farming/__tests__/WindMonitor.test.tsx
@@ -1,0 +1,63 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sensorAPI, type SensorHistoryPoint } from '../../../services/api';
+import type { WindRose } from '../../../utils/wind';
+import { WindMonitor } from '../WindMonitor';
+
+vi.mock('../../../services/api', () => ({
+  sensorAPI: {
+    getHistory: vi.fn(),
+  },
+}));
+
+vi.mock('../WindRoseChart', () => ({
+  WindRoseChart: ({ rose }: { rose: WindRose }) => (
+    <div data-testid="wind-rose-chart">{rose.validSamples} samples · {Math.round(rose.calmPct)}% calm</div>
+  ),
+}));
+
+vi.mock('recharts', () => {
+  const Container = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  const Leaf = () => null;
+
+  return {
+    Area: Leaf,
+    CartesianGrid: Leaf,
+    ComposedChart: () => <div data-testid="wind-speed-chart" />,
+    Line: Leaf,
+    ResponsiveContainer: Container,
+    Tooltip: Leaf,
+    XAxis: Leaf,
+    YAxis: Leaf,
+  };
+});
+
+function rows(field: 'speed' | 'gust' | 'direction', count: number): SensorHistoryPoint[] {
+  return Array.from({ length: count }, (_, index) => ({
+    t: `2026-07-02T${String(index).padStart(2, '0')}:00:00Z`,
+    value: field === 'direction' ? (index * 30) % 360 : field === 'gust' ? 4 + index * 0.1 : 2 + index * 0.1,
+  }));
+}
+
+describe('WindMonitor', () => {
+  beforeEach(() => {
+    vi.mocked(sensorAPI.getHistory).mockReset();
+    vi.mocked(sensorAPI.getHistory).mockImplementation((_deveui, field, hours) => {
+      const count = hours === 24 ? 12 : 0;
+      if (field === 'wind_speed_mps') return Promise.resolve(rows('speed', count));
+      if (field === 'wind_gust_mps') return Promise.resolve(rows('gust', count));
+      if (field === 'wind_direction_deg') return Promise.resolve(rows('direction', count));
+      return Promise.resolve([]);
+    });
+  });
+
+  it('renders a wind rose instead of the direction-history arrow grid when enough wind samples load', async () => {
+    render(<WindMonitor deveui="70B3D57ED0060123" deviceName="North weather station" onClose={vi.fn()} />);
+
+    expect(await screen.findByText('Wind rose (direction × speed)')).toBeInTheDocument();
+    expect(await screen.findByTestId('wind-rose-chart')).toHaveTextContent('12 samples · 0% calm');
+    expect(screen.queryByText('Direction history')).not.toBeInTheDocument();
+  });
+});

--- a/web/react-gui/src/components/farming/__tests__/WindMonitor.test.tsx
+++ b/web/react-gui/src/components/farming/__tests__/WindMonitor.test.tsx
@@ -1,10 +1,14 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { sensorAPI, type SensorHistoryPoint } from '../../../services/api';
 import type { WindRose } from '../../../utils/wind';
 import { WindMonitor } from '../WindMonitor';
+
+const { windRoseChartShouldThrow } = vi.hoisted(() => ({
+  windRoseChartShouldThrow: { current: false },
+}));
 
 vi.mock('../../../services/api', () => ({
   sensorAPI: {
@@ -13,9 +17,12 @@ vi.mock('../../../services/api', () => ({
 }));
 
 vi.mock('../WindRoseChart', () => ({
-  WindRoseChart: ({ rose }: { rose: WindRose }) => (
-    <div data-testid="wind-rose-chart">{rose.validSamples} samples · {Math.round(rose.calmPct)}% calm</div>
-  ),
+  WindRoseChart: ({ rose }: { rose: WindRose }) => {
+    if (windRoseChartShouldThrow.current) {
+      throw new Error('chart chunk failed');
+    }
+    return <div data-testid="wind-rose-chart">{rose.validSamples} samples · {Math.round(rose.calmPct)}% calm</div>;
+  },
 }));
 
 vi.mock('recharts', () => {
@@ -41,8 +48,16 @@ function rows(field: 'speed' | 'gust' | 'direction', count: number): SensorHisto
   }));
 }
 
+function offsetRows(field: 'speed' | 'gust' | 'direction', count: number): SensorHistoryPoint[] {
+  return Array.from({ length: count }, (_, index) => ({
+    t: `2026-07-02T${String(index).padStart(2, '0')}:30:00Z`,
+    value: field === 'direction' ? (index * 30) % 360 : field === 'gust' ? 4 + index * 0.1 : 2 + index * 0.1,
+  }));
+}
+
 describe('WindMonitor', () => {
   beforeEach(() => {
+    windRoseChartShouldThrow.current = false;
     vi.mocked(sensorAPI.getHistory).mockReset();
     vi.mocked(sensorAPI.getHistory).mockImplementation((_deveui, field, hours) => {
       const count = hours === 24 ? 12 : 0;
@@ -59,5 +74,65 @@ describe('WindMonitor', () => {
     expect(await screen.findByText('Wind rose (direction × speed)')).toBeInTheDocument();
     expect(await screen.findByTestId('wind-rose-chart')).toHaveTextContent('12 samples · 0% calm');
     expect(screen.queryByText('Direction history')).not.toBeInTheDocument();
+  });
+
+  it('shows a fallback when fewer than ten paired wind samples load', async () => {
+    vi.mocked(sensorAPI.getHistory).mockImplementation((_deveui, field) => {
+      if (field === 'wind_speed_mps') return Promise.resolve(rows('speed', 9));
+      if (field === 'wind_gust_mps') return Promise.resolve(rows('gust', 9));
+      if (field === 'wind_direction_deg') return Promise.resolve(rows('direction', 9));
+      return Promise.resolve([]);
+    });
+
+    render(<WindMonitor deveui="70B3D57ED0060123" deviceName="North weather station" onClose={vi.fn()} />);
+
+    expect(await screen.findByText('Not enough wind data to plot a rose in this window.')).toBeInTheDocument();
+    expect(screen.queryByTestId('wind-rose-chart')).not.toBeInTheDocument();
+  });
+
+  it('renders the wind rose at the ten-sample boundary', async () => {
+    vi.mocked(sensorAPI.getHistory).mockImplementation((_deveui, field) => {
+      if (field === 'wind_speed_mps') return Promise.resolve(rows('speed', 10));
+      if (field === 'wind_gust_mps') return Promise.resolve(rows('gust', 10));
+      if (field === 'wind_direction_deg') return Promise.resolve(rows('direction', 10));
+      return Promise.resolve([]);
+    });
+
+    render(<WindMonitor deveui="70B3D57ED0060123" deviceName="North weather station" onClose={vi.fn()} />);
+
+    expect(await screen.findByTestId('wind-rose-chart')).toHaveTextContent('10 samples · 0% calm');
+    expect(screen.queryByText('Not enough wind data to plot a rose in this window.')).not.toBeInTheDocument();
+  });
+
+  it('pairs long-window speed buckets with direction samples inside the same buckets', async () => {
+    vi.mocked(sensorAPI.getHistory).mockImplementation((_deveui, field, hours) => {
+      if (hours === 168 && field === 'wind_speed_mps') return Promise.resolve(rows('speed', 12));
+      if (hours === 168 && field === 'wind_gust_mps') return Promise.resolve(rows('gust', 12));
+      if (hours === 168 && field === 'wind_direction_deg') return Promise.resolve(offsetRows('direction', 12));
+      return Promise.resolve([]);
+    });
+
+    render(<WindMonitor deveui="70B3D57ED0060123" deviceName="North weather station" onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: '7 d' }));
+
+    expect(await screen.findByTestId('wind-rose-chart')).toHaveTextContent('12 samples · 0% calm');
+  });
+
+  it('keeps the modal usable when the lazy wind rose chart fails to render', async () => {
+    const preventErrorReport = (event: ErrorEvent) => event.preventDefault();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    window.addEventListener('error', preventErrorReport);
+
+    try {
+      windRoseChartShouldThrow.current = true;
+
+      render(<WindMonitor deveui="70B3D57ED0060123" deviceName="North weather station" onClose={vi.fn()} />);
+
+      expect(await screen.findByText('Unable to load wind rose chart.')).toBeInTheDocument();
+      expect(screen.getByText('Speed and gust (m/s)')).toBeInTheDocument();
+    } finally {
+      window.removeEventListener('error', preventErrorReport);
+      consoleError.mockRestore();
+    }
   });
 });

--- a/web/react-gui/src/components/farming/__tests__/WindRoseChart.test.tsx
+++ b/web/react-gui/src/components/farming/__tests__/WindRoseChart.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildWindRoseOption, type WindRoseTheme } from '../WindRoseChart';
+import { computeWindRose } from '../../../utils/wind';
+
+vi.mock('../../analysis/EChart', () => ({ EChart: () => null }));
+
+const THEME: WindRoseTheme = {
+  axisLine: '#111',
+  axisLabel: '#222',
+  splitLine: '#333',
+  legendText: '#444',
+};
+
+describe('buildWindRoseOption', () => {
+  const rose = computeWindRose([
+    { wind_speed_mps: 3.5, wind_direction_deg: 90 },
+    { wind_speed_mps: 6, wind_direction_deg: 200 },
+  ]);
+  const option = buildWindRoseOption(rose, THEME) as any;
+
+  it('produces a polar coordinate system', () => {
+    expect(option.polar).toEqual({});
+  });
+
+  it('uses the 16 compass directions as the angle axis, N first, clockwise from top', () => {
+    expect(option.angleAxis.type).toBe('category');
+    expect(option.angleAxis.data).toHaveLength(16);
+    expect(option.angleAxis.data[0]).toBe('N');
+    expect(option.angleAxis.startAngle).toBe(90);
+    expect(option.angleAxis.clockwise).toBe(true);
+  });
+
+  it('emits one stacked polar bar series per speed bin', () => {
+    expect(option.series).toHaveLength(rose.speedBins.length);
+    for (const series of option.series) {
+      expect(series.type).toBe('bar');
+      expect(series.coordinateSystem).toBe('polar');
+      expect(series.stack).toBe('total');
+      expect(series.data).toHaveLength(16);
+    }
+  });
+
+  it('colors each series from its speed bin and names it with the bin label', () => {
+    expect(option.series[0].name).toBe(rose.speedBins[0].label);
+    expect(option.series[0].itemStyle.color).toBe(rose.speedBins[0].color);
+  });
+
+  it('lists the speed-bin labels in the legend', () => {
+    expect(option.legend.data).toEqual(rose.speedBins.map((b) => b.label));
+  });
+});

--- a/web/react-gui/src/components/farming/__tests__/WindRoseChart.test.tsx
+++ b/web/react-gui/src/components/farming/__tests__/WindRoseChart.test.tsx
@@ -1,8 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
-import { buildWindRoseOption, type WindRoseTheme } from '../WindRoseChart';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildWindRoseOption, WindRoseChart, type WindRoseTheme } from '../WindRoseChart';
 import { computeWindRose } from '../../../utils/wind';
 
-vi.mock('../../analysis/EChart', () => ({ EChart: () => null }));
+const { echartOptionSpy } = vi.hoisted(() => ({
+  echartOptionSpy: vi.fn(),
+}));
+
+vi.mock('../../analysis/EChart', () => ({
+  EChart: ({ option }: { option: Record<string, unknown> }) => {
+    echartOptionSpy(option);
+    return <div data-testid="wind-rose-echart" />;
+  },
+}));
 
 const THEME: WindRoseTheme = {
   axisLine: '#111',
@@ -11,11 +21,22 @@ const THEME: WindRoseTheme = {
   legendText: '#444',
 };
 
+const rose = computeWindRose([
+  { wind_speed_mps: 3.5, wind_direction_deg: 90 },
+  { wind_speed_mps: 6, wind_direction_deg: 200 },
+]);
+
+beforeEach(() => {
+  echartOptionSpy.mockClear();
+  document.documentElement.removeAttribute('style');
+});
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.removeAttribute('style');
+});
+
 describe('buildWindRoseOption', () => {
-  const rose = computeWindRose([
-    { wind_speed_mps: 3.5, wind_direction_deg: 90 },
-    { wind_speed_mps: 6, wind_direction_deg: 200 },
-  ]);
   const option = buildWindRoseOption(rose, THEME) as any;
 
   it('produces a polar coordinate system', () => {
@@ -47,5 +68,33 @@ describe('buildWindRoseOption', () => {
 
   it('lists the speed-bin labels in the legend', () => {
     expect(option.legend.data).toEqual(rose.speedBins.map((b) => b.label));
+  });
+});
+
+describe('WindRoseChart', () => {
+  function latestOption(): any {
+    const calls = echartOptionSpy.mock.calls;
+    return calls[calls.length - 1]?.[0];
+  }
+
+  it('refreshes chart theme colors when CSS variables change without new rose data', async () => {
+    document.documentElement.style.setProperty('--border', '#111111');
+    document.documentElement.style.setProperty('--text-secondary', '#222222');
+
+    render(<WindRoseChart rose={rose} />);
+
+    await waitFor(() => {
+      expect(latestOption()?.legend.textStyle.color).toBe('#222222');
+    });
+
+    act(() => {
+      document.documentElement.style.setProperty('--border', '#333333');
+      document.documentElement.style.setProperty('--text-secondary', '#444444');
+    });
+
+    await waitFor(() => {
+      expect(latestOption()?.legend.textStyle.color).toBe('#444444');
+      expect(latestOption()?.angleAxis.axisLine.lineStyle.color).toBe('#333333');
+    });
   });
 });

--- a/web/react-gui/src/utils/__tests__/wind.test.ts
+++ b/web/react-gui/src/utils/__tests__/wind.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { computeWindRose, DEFAULT_WIND_SPEED_BINS } from '../wind';
+
+const sum = (xs: number[]) => xs.reduce((a, b) => a + b, 0);
+const roseTotalPct = (r: ReturnType<typeof computeWindRose>) =>
+  sum(r.sectors.map((s) => s.totalPct)) + r.calmPct;
+
+describe('computeWindRose', () => {
+  it('returns 16 sectors in COMPASS_POINTS order with default bins', () => {
+    const rose = computeWindRose([]);
+    expect(rose.sectors).toHaveLength(16);
+    expect(rose.sectors[0].direction).toBe('N');
+    expect(rose.sectors[4].direction).toBe('E');
+    expect(rose.speedBins).toEqual(DEFAULT_WIND_SPEED_BINS);
+    expect(rose.validSamples).toBe(0);
+    expect(rose.calmPct).toBe(0);
+  });
+
+  it('ignores samples missing speed or direction', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 3, wind_direction_deg: null },
+      { wind_speed_mps: null, wind_direction_deg: 90 },
+      { wind_speed_mps: Number.NaN, wind_direction_deg: 90 },
+    ]);
+    expect(rose.validSamples).toBe(0);
+  });
+
+  it('buckets a sample into the correct direction sector and speed bin', () => {
+    const rose = computeWindRose([{ wind_speed_mps: 3.5, wind_direction_deg: 90 }]);
+    expect(rose.validSamples).toBe(1);
+    const east = rose.sectors[4];
+    expect(east.direction).toBe('E');
+    expect(east.bins[3]).toBeCloseTo(100);
+    expect(east.totalPct).toBeCloseTo(100);
+  });
+
+  it('treats bin boundaries as [min, max): 1.0 -> "1–2", 5.0 -> "5+"', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 1.0, wind_direction_deg: 0 },
+      { wind_speed_mps: 5.0, wind_direction_deg: 0 },
+    ]);
+    const north = rose.sectors[0];
+    expect(north.bins[1]).toBeCloseTo(50);
+    expect(north.bins[5]).toBeCloseTo(50);
+  });
+
+  it('ignores null speed/direction even though Number(null) === 0', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: null, wind_direction_deg: 90 },
+      { wind_speed_mps: 3, wind_direction_deg: null },
+    ]);
+    expect(rose.validSamples).toBe(0);
+    expect(rose.calmSamples).toBe(0);
+  });
+
+  it('counts samples below the calm threshold as calm, excluded from petals', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 0.2, wind_direction_deg: 45 },
+      { wind_speed_mps: 3, wind_direction_deg: 45 },
+    ]);
+    expect(rose.calmSamples).toBe(1);
+    expect(rose.calmPct).toBeCloseTo(50);
+    expect(sum(rose.sectors.map((s) => s.totalPct))).toBeCloseTo(50);
+  });
+
+  it('wraps direction at 0/360 degrees: 358 and 2 both land in N', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 3, wind_direction_deg: 358 },
+      { wind_speed_mps: 3, wind_direction_deg: 2 },
+    ]);
+    expect(rose.sectors[0].direction).toBe('N');
+    expect(rose.sectors[0].totalPct).toBeCloseTo(100);
+  });
+
+  it('petal percentages plus calm always sum to 100 for non-empty input', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 0.1, wind_direction_deg: 10 },
+      { wind_speed_mps: 2.5, wind_direction_deg: 100 },
+      { wind_speed_mps: 6, wind_direction_deg: 200 },
+      { wind_speed_mps: 4.2, wind_direction_deg: 280 },
+    ]);
+    expect(roseTotalPct(rose)).toBeCloseTo(100);
+  });
+
+  it('honors a custom calm threshold', () => {
+    const rose = computeWindRose(
+      [{ wind_speed_mps: 0.8, wind_direction_deg: 45 }],
+      { calmThreshold: 1.0 },
+    );
+    expect(rose.calmSamples).toBe(1);
+  });
+
+  it('reports 100% calm and zero petals when every sample is calm', () => {
+    const rose = computeWindRose([
+      { wind_speed_mps: 0.1, wind_direction_deg: 10 },
+      { wind_speed_mps: 0.3, wind_direction_deg: 200 },
+    ]);
+    expect(rose.validSamples).toBe(2);
+    expect(rose.calmSamples).toBe(2);
+    expect(rose.calmPct).toBeCloseTo(100);
+    expect(sum(rose.sectors.map((s) => s.totalPct))).toBeCloseTo(0);
+  });
+});

--- a/web/react-gui/src/utils/__tests__/wind.test.ts
+++ b/web/react-gui/src/utils/__tests__/wind.test.ts
@@ -90,6 +90,13 @@ describe('computeWindRose', () => {
     expect(rose.calmSamples).toBe(1);
   });
 
+  it('rejects an empty custom speed-bin set', () => {
+    expect(() => computeWindRose(
+      [{ wind_speed_mps: 3, wind_direction_deg: 90 }],
+      { speedBins: [] },
+    )).toThrow('speedBins must contain at least one bin');
+  });
+
   it('reports 100% calm and zero petals when every sample is calm', () => {
     const rose = computeWindRose([
       { wind_speed_mps: 0.1, wind_direction_deg: 10 },

--- a/web/react-gui/src/utils/wind.ts
+++ b/web/react-gui/src/utils/wind.ts
@@ -25,3 +25,108 @@ export function formatWindDirection(value: number | null | undefined, fallback =
   }
   return `${compass} ${rounded}°`;
 }
+
+export interface WindSample {
+  wind_speed_mps: number | null;
+  wind_direction_deg: number | null;
+}
+
+export interface WindSpeedBin {
+  label: string;
+  min: number;
+  max: number | null;
+  color: string;
+}
+
+export interface WindRoseSector {
+  direction: string;
+  bins: number[];
+  totalPct: number;
+}
+
+export interface WindRose {
+  sectors: WindRoseSector[];
+  speedBins: WindSpeedBin[];
+  validSamples: number;
+  calmSamples: number;
+  calmPct: number;
+}
+
+export interface WindRoseOptions {
+  calmThreshold?: number;
+  speedBins?: WindSpeedBin[];
+}
+
+export const DEFAULT_WIND_SPEED_BINS: WindSpeedBin[] = [
+  { label: '<1', min: 0, max: 1, color: '#64748b' },
+  { label: '1–2', min: 1, max: 2, color: '#2563eb' },
+  { label: '2–3', min: 2, max: 3, color: '#06b6d4' },
+  { label: '3–4', min: 3, max: 4, color: '#22c55e' },
+  { label: '4–5', min: 4, max: 5, color: '#eab308' },
+  { label: '5+', min: 5, max: null, color: '#dc2626' },
+];
+
+const DEFAULT_CALM_THRESHOLD = 0.5;
+
+function speedBinIndex(speed: number, bins: WindSpeedBin[]): number {
+  for (let i = 0; i < bins.length; i += 1) {
+    const { min, max } = bins[i];
+    if (speed >= min && (max == null || speed < max)) {
+      return i;
+    }
+  }
+  return bins.length - 1;
+}
+
+export function computeWindRose(samples: WindSample[], options: WindRoseOptions = {}): WindRose {
+  const speedBins = options.speedBins ?? DEFAULT_WIND_SPEED_BINS;
+  const calmThreshold = options.calmThreshold ?? DEFAULT_CALM_THRESHOLD;
+
+  const counts: number[][] = COMPASS_POINTS.map(() => speedBins.map(() => 0));
+  let validSamples = 0;
+  let calmSamples = 0;
+
+  for (const sample of samples) {
+    if (sample.wind_speed_mps == null || sample.wind_direction_deg == null) {
+      continue;
+    }
+
+    const speed = Number(sample.wind_speed_mps);
+    const direction = roundWindDirectionDegrees(sample.wind_direction_deg);
+    if (!Number.isFinite(speed) || direction == null) {
+      continue;
+    }
+
+    validSamples += 1;
+    if (speed < calmThreshold) {
+      calmSamples += 1;
+      continue;
+    }
+
+    const compass = toCompassDirection(direction);
+    const sectorIndex = compass ? COMPASS_POINTS.indexOf(compass) : -1;
+    const binIndex = speedBinIndex(speed, speedBins);
+    if (sectorIndex < 0 || binIndex < 0) {
+      continue;
+    }
+    counts[sectorIndex][binIndex] += 1;
+  }
+
+  const denom = validSamples || 1;
+  const sectors: WindRoseSector[] = COMPASS_POINTS.map((direction, sectorIndex) => {
+    const bins = counts[sectorIndex].map((count) => (count / denom) * 100);
+    return {
+      direction,
+      bins,
+      totalPct: bins.reduce((total, value) => total + value, 0),
+    };
+  });
+
+  return {
+    sectors,
+    speedBins,
+    validSamples,
+    calmSamples,
+    calmPct: validSamples ? (calmSamples / validSamples) * 100 : 0,
+  };
+}

--- a/web/react-gui/src/utils/wind.ts
+++ b/web/react-gui/src/utils/wind.ts
@@ -82,6 +82,10 @@ export function computeWindRose(samples: WindSample[], options: WindRoseOptions 
   const speedBins = options.speedBins ?? DEFAULT_WIND_SPEED_BINS;
   const calmThreshold = options.calmThreshold ?? DEFAULT_CALM_THRESHOLD;
 
+  if (speedBins.length === 0) {
+    throw new Error('speedBins must contain at least one bin');
+  }
+
   const counts: number[][] = COMPASS_POINTS.map(() => speedBins.map(() => 0));
   let validSamples = 0;
   let calmSamples = 0;


### PR DESCRIPTION
## Summary

- Adds the wind rose implementation plan and design spec for the edge GUI.
- Adds wind rose aggregation utilities with null-safe paired speed/direction handling.
- Adds a lazy-loaded ECharts polar wind rose to the SenseCap wind monitor, replacing the old sampled direction-history grid while preserving speed/gust history.
- Adds focused tests for aggregation, chart option orientation, theme refresh, and WindMonitor integration.

## Validation

- `git diff --check`
- `cd web/react-gui && npm run test:unit` (84 Node test-runner tests, 443 Vitest tests)
- `cd web/react-gui && npm run typecheck`
- `cd web/react-gui && npm run build`

## Notes

- The build emits existing Browserslist/baseline-browser-mapping freshness warnings and a Vite large-chunk warning, but exits 0.
- Runtime wind rose behavior was already checked on the Silvan edge GUI before opening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the wind “direction history” grid with a wind rose chart showing direction × speed distribution.
  * Added clearer wind-rose loading/error states, including a minimum-sample gate and calm statistics.
  * Improved chart responsiveness to theme/style changes.
* **Documentation**
  * Added wind-rose implementation and design documentation.
* **Tests**
  * Added unit and UI tests covering wind-rose calculations, chart configuration/theme updates, and modal rendering/fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->