### PR TITLE
docs: engineering playbook — workflow, thinking tools, and paid-for failure modes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!-- Definition of done — from docs/engineering-playbook.md §8. Delete lines that
+     genuinely don't apply; don't delete lines that are merely inconvenient. -->
+
+## What & why
+
+<!-- Root cause (for fixes) or motivation (for features). Link the issue:
+     "Fixes #NNN". If the issue's claim differed from reality, say what you
+     actually found. -->
+
+## Design decisions & tradeoffs
+
+<!-- The choices a reviewer would question, each with its rationale. Deliberate
+     deviations and accepted limitations belong here, not in silence. -->
+
+## Checklist
+
+- [ ] Issue/claim **re-verified against current `main`** before work started
+- [ ] Plan + review live in `docs/superpowers/plans/` (non-trivial changes)
+- [ ] Tests exist that **fail without this change** (TDD or regression pins)
+- [ ] All gates green, **re-run by someone/something other than the author**
+      (`verify-sync-flow.js`, migration verifiers, GUI typecheck + test:unit + build — as applicable)
+- [ ] bcm2712 payload changes mirrored **byte-identically** to bcm2709
+- [ ] No fabricated defaults: missing data renders as missing, never as a plausible value
+- [ ] Schema changes via **ordered migrations only** (boot-DDL node untouched); seed/bundled-DB parity held
+- [ ] Stale docs/AGENTS.md touched by this change corrected in the same PR
+- [ ] Follow-ups I chose not to do are **filed as issues** and linked below
+
+## Verification evidence
+
+<!-- Paste the actual gate outputs / test counts. "It works" without output is
+     a claim, not evidence. -->
+
+## Follow-ups
+
+<!-- Issue links, or "none". -->

--- a/.github/workflows/verify-sync-flow.yml
+++ b/.github/workflows/verify-sync-flow.yml
@@ -1,0 +1,31 @@
+name: Sync Flow Verifier
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  verify-sync-flow:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          # full history: test-sync-history-schema.js resolves the pinned
+          # pre-history-sync baseline SHA (issue #84) via `git show <sha>:...`;
+          # a shallow clone would silently SKIP the upgrade-path leg.
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install sqlite3 CLI
+        run: sudo apt-get update && sudo apt-get install -y sqlite3
+      # The repo's main local gate, promoted to CI after issue #84 proved it can
+      # break on main invisibly (it chains comm-contract, DB-schema consistency,
+      # history schema/worker tests, history API contract, helper tests, and
+      # profile parity). Must end with "All parity checks passed."
+      - run: node scripts/verify-sync-flow.js
+      - name: Guard against silent upgrade-leg skip
+        run: node scripts/test-sync-history-schema.js 2>&1 | tee /tmp/schema.out && grep -q "base seed + history migration" /tmp/schema.out

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Operational source of truth for `osi-os`. The edge is canonical; `osi-server` mi
 
 Sister repo: [`osi-server`](../osi-server/AGENTS.md).
 
+> **How to work here:** [docs/engineering-playbook.md](docs/engineering-playbook.md) — the working loop (verify reality → written plan → adversarial review → exact execution → independent verification), the thinking tools, and the failure modes this repo has already paid for. Read it before your first non-trivial change; hold every PR to its §8 definition of done.
+
 ---
 
 ## Architecture
@@ -253,4 +255,9 @@ Keep closeout updates factual. Never delete ambiguous files without asking.
 
 ## Issues
 
-Tracked at https://github.com/Open-Smart-Irrigation/osi-os/issues. Open areas: S2120 history (#33), LSN50 ADC display (#34), i18n (#47).
+Tracked at https://github.com/Open-Smart-Irrigation/osi-os/issues. Don't trust this
+list or any issue body blindly — re-verify against current `main` before planning
+(several issues have turned out already-fixed or mostly stale). Long-running open
+areas as of 2026-07-05: i18n (#47), lossless edge→cloud backup (#56), rootfs
+auto-grow (#50), Uganda live-ops (#55, #64, #87), dendro scheduling (#22), Mclimate
+valve (#18), and the schema-hardening roadmap (#88–#90, gated — see its plan docs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,13 @@ Primary target: Raspberry Pi 5 (`full_raspberrypi_bcm27xx_bcm2712`).
 ## Recommended reading order
 
 1. [AGENTS.md](AGENTS.md) — architecture, sync model, file locations, conventions
-2. [README.md](README.md) — user-facing setup and deployment
-3. `conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json` — Node-RED backend logic
-4. `scripts/verify-sync-flow.js` — sync implementation reference
-5. `web/react-gui/src/` — dashboard source
-6. [docs/build/building-firmware.md](docs/build/building-firmware.md) — firmware build (only if rebuilding the OS)
-7. [docs/versioning-workflow.md](docs/versioning-workflow.md) — release checklist
+2. [docs/engineering-playbook.md](docs/engineering-playbook.md) — how to work: the plan→review→execute→verify loop, thinking tools, hard-won failure modes
+3. [README.md](README.md) — user-facing setup and deployment
+4. `conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json` — Node-RED backend logic
+5. `scripts/verify-sync-flow.js` — sync implementation reference
+6. `web/react-gui/src/` — dashboard source
+7. [docs/build/building-firmware.md](docs/build/building-firmware.md) — firmware build (only if rebuilding the OS)
+8. [docs/versioning-workflow.md](docs/versioning-workflow.md) — release checklist
 
 ## Session Closeout
 

--- a/docs/agents/workflow-prompts.md
+++ b/docs/agents/workflow-prompts.md
@@ -1,0 +1,98 @@
+# Agent Workflow Prompts
+
+Reusable prompt skeletons for the four roles in the [engineering playbook](../engineering-playbook.md)
+loop. These ran the 2026-07 issue sweeps (12 issues, 10 PRs, zero post-merge reverts).
+Fill the `«»` slots; keep the clauses in **bold** verbatim — each one exists because
+its absence produced a real failure.
+
+Capability matching: PLANNER, REVIEWER, and VERIFIER need the strongest available
+model. EXECUTOR is where a sonnet-class model excels — *if* the plan has zero
+placeholders. Author, reviewer, and verifier must be different contexts.
+
+---
+
+## 1. PLANNER
+
+> You are a senior architect writing an implementation plan. Do NOT implement —
+> produce a plan document only. Write for an engineer with zero repo context and
+> questionable taste: exact file paths, complete code in every step, exact commands
+> with expected output, TDD order, bite-sized checkbox steps, commit sequence.
+> **No placeholders** («TBD», «add appropriate handling», «similar to task N» are
+> planning failures).
+>
+> Repo: «path». Issue: «number + full text». **First verify the issue is still true
+> on the current base** — reproduce the failure / grep the claimed code; if reality
+> differs from the issue, record the corrected diagnosis in the plan header.
+> Known constraints: «frozen surfaces, parity rules, parallel workstreams».
+> Design decisions you own (record rationale): «list».
+> Verification gates that must be in the plan: «repo gate commands».
+> Save to `docs/superpowers/plans/YYYY-MM-DD-«slug».md`, self-review against the
+> issue (coverage, placeholder scan, type consistency), fix inline.
+> Final message: 10-line summary of design decisions + the file path.
+
+## 2. ADVERSARIAL REVIEWER
+
+> You are a senior reviewer performing an adversarial review of a plan written by
+> another architect (who cannot defend it — it must stand on its own). **Hunt for
+> flaws. Do NOT implement.**
+>
+> Plan: «path». **Verify every load-bearing claim independently against the code**
+> — line numbers, quoted excerpts, test-count expectations, «claims list». The base
+> may have moved since drafting: check anchors against `origin/main`, not the
+> author's assumptions. Questions you own: «design alternatives, edge cases,
+> collision surfaces with parallel work».
+> Deliver: verdict per area; **REQUIRED changes vs OPTIONAL suggestions, each with
+> rationale**; state whether the plan is executable after amendments or needs a
+> rewrite. If sound as-is, say exactly: «NO REQUIRED CHANGES».
+
+Iterate: apply REQUIRED (and cheap OPTIONAL) amendments to the plan, re-review if
+the amendments were themselves designs rather than the reviewer's own prescriptions.
+
+## 3. EXECUTOR (sonnet-class)
+
+> You are an implementation worker. Execute the plan at «path» exactly, step by
+> step. Read it fully first.
+>
+> Environment: work ONLY in «worktree/branch, cut from origin/main»; do not touch
+> «user checkouts, unrelated untracked files». Shell is «fish — use `env VAR=v cmd`».
+> Rules: **follow TDD steps in order — watch each failing test fail for the stated
+> reason before implementing**; **if any step's actual output differs from the
+> plan's Expected, STOP and report the discrepancy rather than improvising**
+> (trivial line drift: locate by content); «file-editing mechanism constraints,
+> e.g. flows.json only via roundtrip-verified script». Commit exactly as the plan
+> specifies, plan doc first. **Do not push, do not open a PR.**
+> Report: each step's command + condensed result, gate outputs, final
+> `git log --oneline origin/main..HEAD` and `git status -sb`.
+
+## 4. INDEPENDENT VERIFIER
+
+> You are a verification reviewer. Verify executed work is correct, complete, and
+> safe to ship. Be adversarial; **independently re-run every check — do not trust
+> the worker's report**. Read-only + verification commands; modify nothing.
+>
+> Branch: «branch, N commits». Plan: «path» (read it). Verify: (1) `git diff
+> origin/main...HEAD` matches the plan hunk-by-hunk, **no unplanned changes**;
+> (2) re-run all gates fresh («commands + expected outputs»); (3) semantics audit —
+> «invariants to probe adversarially; for security surfaces, enumerate bypass
+> classes and test them against the actual code, asserting on raw outputs, not
+> re-parsed ones»; (4) commit hygiene, clean tree, nothing pushed.
+> Deliver: **VERDICT: GREEN or RED** (blocking problems listed), non-blocking
+> observations, and if GREEN a PR title + body carrying root cause, design
+> rationale, deliberate tradeoffs, and the verification evidence.
+
+RED → fix (small fixes inline by the orchestrator, larger ones via a new executor
+pass) → **targeted re-verification of the fix by a fresh verifier** → then ship.
+
+---
+
+## Orchestrator notes
+
+- Plans are contracts: if an executor would need conversation history, the plan is
+  incomplete — fix the plan, not the prompt.
+- Verify agent *reports* against the *repo* (clean tree, expected commits, gates you
+  can re-run). Agents sincerely report successes that didn't happen.
+- Expect interruption (quota walls, network flaps): keep plans on disk, commit
+  early, inspect leftover state against the plan before resuming or respawning.
+- Stacked PRs: merge the base **without** deleting its branch, rebase the child
+  `--onto origin/main <old-base-sha>`, retarget, merge, then delete the base branch
+  — GitHub auto-closes children on base deletion and they cannot be reopened.

--- a/docs/engineering-playbook.md
+++ b/docs/engineering-playbook.md
@@ -1,0 +1,210 @@
+# OSI Engineering Playbook
+
+How to work on OSI OS and OSI Server without breaking farms. Written by the outgoing
+senior engineer for whoever comes next — human or agent. AGENTS.md tells you *what*
+the system is; this document tells you *how to think* while changing it.
+
+Everything here was paid for. Each rule traces to a real incident or a bug caught in
+review. When a rule seems pedantic, assume it once cost a day of debugging or a night
+of Ugandan sensor data.
+
+---
+
+## 1. Prime directives
+
+1. **Live farms outrank everything.** A wrong chart annoys someone; a wiped
+   `farming.db` destroys months of irreplaceable field data. Every decision inherits
+   this asymmetry. Never reseed a provisioned Pi. Fail closed: when a guard cannot
+   prove an operation is safe, the operation must not run.
+2. **Evidence before assertions.** "It works" means: you ran the command, you read
+   the output, and the output is in your report. A test you didn't run is a test that
+   fails. A pipeline exit code can lie (`git push | tail -1` returns tail's status —
+   a push once "succeeded" this way while GitHub was unreachable).
+3. **Missing data must look missing.** Never substitute a plausible default for an
+   absent measurement. We shipped `-42 kPa` and `rootVwcPct ?? 24` fallbacks; both
+   looked like real agronomy and misled operators. Propagate `null` end to end and
+   render an explicit unavailable state. Corollary: a rain day with zero *samples* is
+   "no data", not "0.0 mm dry" — the ingest writes real zeros when it is dry.
+4. **One source of truth per fact.** Two definitions of the same schema, depth, or
+   contract WILL drift (deploy.sh vs runtime DDL did; selector vs save-path did).
+   When you find duplication, either unify it or add a verifier that fails on
+   divergence — never leave silent duplicates.
+
+## 2. The working loop
+
+Every non-trivial change follows the same loop. Do not skip stages because a change
+"looks small" — the smallest diffs of 2026-07 (a one-line cap check, a URL guard)
+were the ones reviews caught real bugs in.
+
+```
+VERIFY REALITY → PLAN (written) → ADVERSARIAL REVIEW → EXECUTE (TDD, exact)
+      → INDEPENDENT VERIFICATION → SHIP (PR + evidence) → RECORD
+```
+
+**Verify reality first.** Issues and docs go stale; code moves under you. Before
+planning, prove the problem still exists on the current base: reproduce the failure,
+grep for the claimed code, run the failing command. Recent examples: two issues were
+already fixed on main (closed with evidence instead of re-fixed); an "add four
+weather charts" issue was three-quarters shipped — the real gap was rain plus a
+subtle aggregation bug nobody had reported.
+
+**Plan in writing, with zero placeholders.** A plan an unfamiliar engineer cannot
+execute verbatim is not a plan. Exact file paths, complete code in every step, exact
+commands with expected output, and the commit sequence. "Add appropriate error
+handling" is a planning failure. Plans live in `docs/superpowers/plans/` and get
+committed with the work — they are the reviewable design record.
+
+**Adversarial review before execution.** A second mind (a fresh agent or colleague,
+never the author) reads the plan with the mandate *hunt for flaws*, verifying every
+claim against the code. This stage has caught: an open-redirect bypass class the
+author's tests masked, a plan that would have re-broken the panel-overlap bug it was
+fixing, a classification that told a live farm to "assign a device" it already had,
+and a heartbeat tee that would have collided with a parallel workstream. Review
+output is a list of REQUIRED changes (apply all, then re-check) and OPTIONAL ones
+(apply the cheap ones). "Looks good" is not a review.
+
+**Execute exactly; stop on divergence.** The executor follows the amended plan
+step-by-step, TDD order: write the failing test, *watch it fail for the stated
+reason*, implement, watch it pass. If actual output differs from the plan's
+Expected, STOP and report — do not improvise a different fix mid-execution. (Trivial
+line-number drift is fine; find code by content.)
+
+**Independent verification, never by the author.** Before any PR: a verifier who did
+not write the code re-runs every gate fresh, diffs the branch hunk-by-hunk against
+the plan, and adversarially probes the semantics (not just "tests pass" — "what
+input breaks this?"). The dot-segment `/.//evil.example` redirect survived the
+author, the executor, and the tests; only the independent probe found it. GREEN from
+this stage is the ship criterion; RED means fix and re-verify the fix.
+
+**Ship with the evidence in the PR body.** Root cause, the fix, the deliberate
+tradeoffs, and the verification outputs. A reviewer six months from now must be able
+to audit why without archaeology.
+
+**Record.** Durable repo facts → AGENTS.md. Operational/cross-session context →
+memory. Incidents → `docs/operations/`. If you learned it the hard way, write it
+down where the next person will trip.
+
+## 3. Thinking tools (use these before writing code)
+
+- **Find the invariant, then enforce it.** The best fixes replace point-patches with
+  a structural guarantee. "The probe selector must offer exactly what the save path
+  accepts" turned three symptoms into one loop rebuilt around the shared resolver.
+  If you can state the invariant in one sentence, you can usually test it in one.
+- **Blast radius before edit.** Before touching a shared surface (`flows.json`
+  heartbeat cluster, the frozen boot-DDL node, a record constructor, a pinned CSS
+  grid), enumerate who else reads/writes it: `grep` the repo, check open plans and
+  branches, check parallel workstreams. Prefer additive, self-contained designs
+  (own inject + own node) over teeing into someone else's node — two plans then land
+  in either order with at most adjacency conflicts.
+- **Boundaries are exact complements.** When a read path says `expiresAt.isAfter(now)`,
+  the eviction path must say `!expiresAt.isAfter(now)` — not `isBefore`. Off-by-one
+  at boundaries is where cache and retention bugs live. Also hour-align time cutoffs:
+  a mid-hour prune boundary silently degraded a re-aggregated rollup.
+- **Validate with the parser that will consume the value.** String prefix checks on
+  URLs are bypassable (WHATWG strips tab/LF/CR; dot-segments re-serialize to `//`).
+  Parse with `new URL`, check the origin, then **re-check the serialized output** —
+  and write bypass tests that assert on the *raw returned string*, because
+  re-parsing in the test hides exactly the bug class you are hunting.
+- **Concurrency: reason about the interleaving, not the happy path.** A cap checked
+  before a `put` lets N concurrent misses all pass; enforce after the write. On
+  ConcurrentHashMap, `entrySet().removeIf` is value-conditional and safe; `size()`
+  is an estimate — design so slack is harmless.
+- **When two subsystems disagree, find which one production trusts.** The upgrade
+  test broke because it tested against `main`'s seed while production Pis upgrade
+  from a *historical* schema — pin the baseline production actually has, not the
+  moving target.
+
+## 4. Avoiding issues in the first place
+
+- **Schema changes:** ordered migrations only (`database/migrations/ordered/`,
+  runner in `lib/osi-migrate`, risk class header). The boot-DDL node is FROZEN.
+  Seed, bundled DBs, and runtime must stay in fingerprint parity — the verifiers
+  exist because they have each caught a real drift.
+- **Both Pi profiles, byte-identical.** Any payload edit under bcm2712 `files/`
+  must be mirrored to bcm2709; `verify-profile-parity.js` enforces it.
+- **`flows.json` is edited by script, never by hand.** One-shot Node editor in the
+  scratchpad: parse → mutate → `JSON.stringify(flows, null, 2) + '\n'` → verify the
+  no-op roundtrip is byte-identical first. Function nodes: bind guarded modules via
+  `libs` + `global.get` locals, always `.close(` the DB handle (linted), wrap every
+  sysfs/IO read in its own try/catch → null. A sampler must never crash the flow.
+- **Guard tests pin contracts.** When a design decision matters (a node's wiring, a
+  mobile grid, an auth block), write a static guard test that fails when someone
+  changes it casually. When you *intend* the change, update the pin in the same
+  commit with a message saying why.
+- **Never assert success on text you didn't produce.** Check exit codes directly;
+  in pipelines the last command wins. In fish, `$status`; in scripts, `set -eu` and
+  explicit `ls-remote --exit-code`-style confirmation for remote effects.
+- **Stacked PRs:** merge the base *without* deleting its branch (GitHub auto-CLOSES
+  children on base-branch deletion and they cannot be reopened) → rebase the child
+  `--onto origin/main <old-base-sha>` → force-push → retarget → merge child → then
+  delete the base branch.
+- **Isolation:** feature work in worktrees; never switch a checkout a human is
+  actively using; never branch from a local main that carries someone's unpushed
+  commits — branch from `origin/main`.
+- **Copy the working precedent.** Auth blocks, prune jobs, monitor modals, test
+  fixtures: this repo has a proven pattern for almost everything. Diff your new code
+  against the precedent (`byte-identical auth section` is a review check, not a
+  metaphor). Novelty in infrastructure code is a cost, not a virtue.
+
+## 5. Security posture
+
+- Auth boilerplate is copied verbatim from the newest shipped endpoint, then diffed
+  to prove it. HMAC verify with `timingSafeEqual`, expiry checked.
+- SQL: bound parameters only. User-influenced values (even a timezone offset) never
+  reach a query string by interpolation — clamp, then bind.
+- Redirect/URL inputs: same-origin proof via the URL constructor *plus* serialized
+  re-check (§3). Assume every query param is hostile.
+- Secrets never enter the repo, docs, or memory — AppKeys, sync tokens, production
+  SSH. Production (`osicloud.ch`) access requires explicit user consent in the
+  current conversation; a working key is not consent.
+- Prefer reading sysfs to spawning subprocesses in long-running flows; prefer
+  read-only DB access in observability paths.
+
+## 6. When you are stuck or debugging
+
+1. **Reproduce before theorizing.** Run the failing thing; capture exact output.
+2. **Read the actual code, not your memory of it.** Line numbers move; claims rot.
+3. **Bisect with history:** `git log -S "string"` finds when a behavior appeared;
+   `git show <ref>:<path>` compares generations without switching branches.
+4. **Test hypotheses empirically and cheaply:** a temp SQLite DB from the seed, a
+   ten-line Node script in the scratchpad, one `curl`. Minutes, not arguments.
+5. **Root cause, then fix.** A signal that pattern-matches a known failure may have
+   a different cause (the "duplicate column" errors were blamed on the boot DDL in
+   writing — the real cause was a stale test baseline; the misattribution itself had
+   to be fixed later).
+6. **Fix the class, not the instance,** and grep for siblings — the `-42 kPa`
+   fallback had a `?? 24` sibling one line up. File issues for what you don't fix.
+7. **If your fix fights the harness or the conventions, you misread the system.**
+   Stop and re-read AGENTS.md and the nearest working precedent.
+
+## 7. Orchestrating agents (and being one)
+
+- **Separate the three roles.** Author, adversarial reviewer, and post-execution
+  verifier must be different contexts. Authors are systematically blind to their own
+  assumptions; every serious bug this quarter that reached review was caught by a
+  non-author.
+- **Capability-match the stage.** Design, review, and verification need the
+  strongest available model; faithful execution of a zero-placeholder plan is
+  exactly what a sonnet-class agent does well. A weaker executor with a stronger
+  plan beats the reverse.
+- **The plan is the contract.** Executors get fresh context and only the plan — if
+  they need conversation history to succeed, the plan is incomplete. The
+  stop-on-divergence rule is what makes delegation safe.
+- **Verify agent reports.** Trust structure, not claims: clean tree, expected commit
+  list, gates re-run by the verifier. Agents (and engineers) sincerely report
+  successes that didn't happen — the report is a hypothesis, the repo is the truth.
+- **Expect interruption.** Quota walls and network flaps killed agents mid-write
+  this month. Design work to be resumable: plans on disk, commits early, state in
+  the branch — then inspect leftovers before resuming (the half-executed worktree
+  was completed inline by diffing it against its plan).
+
+## 8. Definition of done
+
+A change is done when: the issue's claim was re-verified against reality; the plan
+and its review live in the repo; tests exist that fail without the change; every
+gate is green *as re-run by a non-author*; both profiles/seeds are in parity where
+applicable; the PR body carries root cause, tradeoffs, and evidence; stale docs and
+memory touched by the change are corrected; and follow-ups you chose not to do are
+filed as issues, not left as silences.
+
+Anything less is work in progress wearing a green checkmark.

--- a/docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md
+++ b/docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md
@@ -1,0 +1,259 @@
+# Kaba100 Chameleon 1 I2C Outage Analysis
+
+Date: 2026-06-28  
+Device: Chameleon 1, `A84041A75D5E7CFB`  
+Gateway: Kaba100, `0016C001F11766E7`  
+Final tested array ID: `28DE7EC80B0000E2`
+
+## Executive Summary
+
+Chameleon 1 did not primarily suffer from a LoRaWAN, server-sync, calibration, or soil-probe outage. The dominant outage mode was a device-side I2C acquisition failure: uplinks kept arriving, but the Chameleon firmware reported `i2c_missing=1` and therefore the SWT values were unavailable.
+
+The most likely root cause is the original power/interface topology:
+
+- The Chameleon I2C board was powered from the LSN50 switched 5 V output.
+- SDA/SCL were connected directly to the LSN50 STM32 I2C pins.
+- The Chameleon board has pull-ups to VCC on SDA/SCL. Supplying VCC with 5 V therefore pulls the I2C bus toward 5 V.
+- When switched 5 V is off, SDA/SCL remain connected and can back-power the board into a partial brownout state.
+
+This matches the field measurements exactly: SDA/SCL rose to about 4.6 V during measurement when powered from switched 5 V, and when the 5 V rail was off the board sat at about 1.4-1.5 V on VCC and about 1.9-2.0 V on SDA/SCL. After moving the Chameleon board to LSN50 VDD, all rails stayed around 3.6 V and the I2C fault stopped in the refreshed observation window.
+
+Recommendation: keep the Chameleon board powered from the same 3.3-3.6 V rail as the LSN50 I2C bus, or add a proper bidirectional I2C level shifter plus power isolation if 5 V switching is required.
+
+## Data Sources
+
+Sources used:
+
+- Kaba100 local SQLite DB at `/data/db/farming.db`
+- Server-export analysis artifacts in `analysis/chameleon1_i2c_20260628/`
+- Firmware notes in `../chameleon-integration.md`
+- Hardware/protocol notes in `../hardware/chameleon-reference.md`
+- Custom LSN50 firmware source in `/home/phil/Repos/LoRa_STM32-claude`
+- Live multimeter observations made during the 2026-06-28 field test
+
+The current Kaba100 local DB snapshot for this device starts at `2026-06-24T21:49:57Z`. The earlier server export covers `2026-06-17T00:02:21Z` to `2026-06-28T18:19:57Z`.
+
+## Firmware and Data Path
+
+The Chameleon board is an ATtiny814 I2C slave at address `0x08`, sampled by the LSN50 STM32 over I2C at 400 kHz. The LSN50 firmware probes the address, triggers a measurement, polls status, then reads temperature, compensated resistances, raw resistances, and the DS18B20 array ID.
+
+Relevant firmware behavior:
+
+- `i2c_missing` is set when the I2C address probe fails or a later I2C read fails.
+- `timeout` is set when the board is reachable but does not become ready in time.
+- `comp_pending` is separate and means raw and compensated resistances matched before compensation settled.
+- The first MOD=3 ADC fields are legacy stock LSN50 fields and are not the Chameleon soil-water-tension data.
+
+Therefore rows can arrive on schedule while still being unusable for SWT if the I2C acquisition failed.
+
+## Data Completeness and Outage Pattern
+
+### Server Export, 2026-06-17 to 2026-06-28 18:19 UTC
+
+From `analysis/chameleon1_i2c_20260628/chameleon1_i2c_summary.txt`:
+
+| Metric | Value |
+|---|---:|
+| Total rows | 3379 |
+| Good rows | 1886 |
+| I2C-missing rows | 1493 |
+| I2C-missing share | 44.2% |
+| Other invalid rows | 0 |
+| Rows with SWT | 1886 |
+| Max cadence gap | 43.4 min |
+| Cadence gaps > 7.5 min | 3 |
+
+The key finding is that most bad periods were not missing uplinks. The node still transmitted, but the payload carried the fixed diagnostic signature `i2c_missing=1`, `timeout=0`, no temp fault, no ID fault, and no open-channel flags.
+
+Largest I2C-missing blocks in the server export:
+
+| Start UTC | End UTC | Duration | Rows |
+|---|---|---:|---:|
+| 2026-06-24 06:20 | 2026-06-26 06:44 | 48.41 h | 581 |
+| 2026-06-18 19:32 | 2026-06-20 14:27 | 42.91 h | 515 |
+| 2026-06-27 00:50 | 2026-06-27 07:40 | 6.83 h | 83 |
+| 2026-06-22 19:45 | 2026-06-23 01:35 | 5.83 h | 71 |
+| 2026-06-28 03:25 | 2026-06-28 08:09 | 4.75 h | 58 |
+
+The complete block list is in `analysis/chameleon1_i2c_20260628/chameleon1_i2c_blocks.csv`. The visual timeline is in `analysis/chameleon1_i2c_20260628/chameleon1_i2c_timeline.png`.
+
+### Refreshed Gateway Data, 2026-06-24 to 2026-06-28 21:59 UTC
+
+The local gateway DB had 1298 Chameleon rows for this refreshed window:
+
+| Metric | Value |
+|---|---:|
+| Total rows | 1298 |
+| I2C-missing rows | 726 |
+| I2C-missing share | 55.9% |
+| Timeout rows | 0 |
+| Data-invalid rows | 726 |
+| `comp_pending` rows | 6 |
+| Canonical `device_data` rows with SWT | 559 |
+| Canonical `device_data` rows without SWT | 739 |
+
+There were no cadence gaps over 20 minutes in this refreshed local window. This again supports a sensor-side acquisition fault rather than an uplink or sync outage.
+
+### After Moving the Board to VDD
+
+After connecting the Chameleon board to LSN50 VDD, the local DB showed:
+
+| Window | Rows | I2C missing | Data invalid |
+|---|---:|---:|---:|
+| 2026-06-28 21:29:20 UTC to 21:59:17 UTC | 31 | 0 | 0 |
+
+The latest checked canonical `device_data` row was `2026-06-28T21:59:17Z` with SWT values `7.42`, `6.79`, `3.10` and battery `3.6 V`.
+
+## Physical Test Timeline
+
+Observed during the 2026-06-28 live field test:
+
+1. Switched 5 V topology, original I2C board and array connected:
+   - Uplinks arrived, but rows repeatedly reported `I2C_MISSING`.
+   - VCC was 5 V during measurements, then floated around 1.4-1.5 V.
+   - SDA/SCL were around 1.9-2.0 V while idle/off.
+   - SDA/SCL rose to about 3.9-4.6 V during measurement.
+
+2. Chameleon array disconnected, I2C board still connected:
+   - Fault persisted, so the soil array itself was not the primary cause.
+
+3. Test array connected:
+   - The fault pattern was still controlled by the board/power/bus behavior, not by the specific soil probe.
+
+4. Second I2C board tested:
+   - Similar voltage behavior appeared.
+   - With only VCC connected and no SDA/SCL, the rail rose weakly during measurement and then decayed toward zero.
+   - With SDA/SCL connected, VCC again stayed around 1.4 V when off.
+   - This is strong evidence that the off-state voltage came from bus back-powering through SDA/SCL.
+
+5. Chameleon board moved to LSN50 VDD:
+   - VCC, SDA, and SCL all remained around 3.6 V.
+   - I2C acquisition recovered.
+   - Subsequent rows were clean on `i2c_missing`, `timeout`, and `data_invalid`.
+
+## Root Cause Analysis
+
+### Confirmed Symptom
+
+The outage is not primarily a missing-uplink outage. It is an I2C readout outage:
+
+- Chameleon rows exist in the database.
+- Frame counters advance during most fault windows.
+- Battery remains normal at about 3.6 V.
+- `timeout=0`, so the firmware is usually not reaching a measurement wait timeout.
+- `i2c_missing=1`, so the STM32 cannot reliably talk to the Chameleon slave at `0x08`.
+
+### Most Likely Root Cause
+
+The Chameleon board was powered from switched 5 V while its I2C bus was directly connected to a 3.3-3.6 V STM32 master.
+
+The board can be supplied at 5 V in the generic Arduino example, but that does not mean the LSN50 can safely use it at 5 V without level shifting. Because SDA/SCL pull-ups go to VCC, using 5 V VCC raises the I2C high level toward 5 V. This is valid for a 5 V Arduino-style master, but not for the LSN50 STM32 bus.
+
+When the switched 5 V output turns off, SDA/SCL are still attached. The measured idle voltages show the Chameleon board is then partially powered through the I2C lines. This leaves the ATtiny/I2C peripheral in an undefined state between true off and valid power. That explains why the fault is intermittent: sometimes the slave wakes cleanly enough to ACK, sometimes it stays brownout-latched or bus-stuck and the STM32 sees a NACK/read failure.
+
+### Why the Fault Came and Went
+
+The intermittent behavior is expected under this topology:
+
+- A real open wire would usually fail consistently.
+- Moisture or corrosion would not be expected to disappear immediately after moving only the supply rail.
+- The same pattern appeared with another I2C board.
+- The fault changed immediately when the power topology changed.
+- Frame-counter resets and recovery after power events fit a board-state reset problem.
+
+The board likely needed a clean reset or stable rail. Switched 5 V plus bus back-power prevented a clean off-state.
+
+## Hypotheses Considered
+
+| Hypothesis | Evidence | Conclusion |
+|---|---|---|
+| Server sync or cloud mirror issue | Local rows contained the same diagnostic flags; earlier local/server checks matched. | Not root cause. |
+| LoRaWAN/radio outage | Rows continued to arrive during fault windows. | Not root cause for the main issue. |
+| Calibration missing | Fault rows had `i2c_missing`; good rows produced raw/comp resistance and canonical SWT. | Not root cause. |
+| Soil probe disconnected/open | Open-channel flags were not the dominant bad-row signature. | Not root cause. |
+| One bad I2C board | Similar behavior with a second board. | Unlikely. |
+| Moisture on board | No visible moisture; behavior changed with power rail. | Possible aggravator, not primary cause. |
+| Firmware timeout too short | `timeout_rows=0` in refreshed data; fault is probe/read failure. | Not primary cause. |
+| Switched 5 V mixed with direct 3.3 V I2C | Predicts 5 V-ish SDA/SCL, off-state back-power, intermittent NACKs, recovery on VDD. All observed. | Most likely root cause. |
+
+## SWT Storage Note
+
+For operational analysis, use different tables for different questions:
+
+- `chameleon_readings`: protocol-level diagnosis, including `f_cnt`, raw payload, `status_flags`, `i2c_missing`, `timeout`, raw/comp resistances, and array ID.
+- `device_data`: canonical SWT values used by the application and cloud mirror.
+
+In the refreshed local DB, `chameleon_readings.swt_1..3` remained NULL even for clean calibrated rows, while `device_data.swt_1..3` contained the expected SWT values. This should be clarified or fixed separately, but it does not change the hardware root-cause conclusion because the raw/comp readings and `device_data` SWT recover after VDD wiring.
+
+## Recommended Corrective Actions
+
+1. Keep the current wiring for ongoing soak tests:
+   - Chameleon VCC to LSN50 VDD.
+   - Common GND.
+   - SDA/SCL directly connected only if both sides share the same 3.3-3.6 V logic rail.
+
+2. Do not connect the Chameleon board to switched 5 V with direct SDA/SCL to the LSN50.
+
+3. If 5 V supply is required:
+   - Add a proper bidirectional I2C level shifter.
+   - Keep pull-ups on the LSN50 side to 3.3-3.6 V.
+   - Prevent back-powering when the 5 V rail is off.
+   - Ensure the Chameleon side gets a real power-off reset or stays continuously powered.
+
+4. If low-power switching is required:
+   - Switch a compatible 3.3 V rail, not 5 V, or isolate SDA/SCL while the slave is unpowered.
+   - Add a discharge path or defined pull-down so VCC cannot float at 1.4-1.5 V.
+   - Verify with a multimeter that off-state VCC is truly near 0 V and SDA/SCL are not feeding the board.
+
+5. Add a hardware bring-up checklist:
+   - Idle VCC/SDA/SCL voltage.
+   - Measurement VCC/SDA/SCL voltage.
+   - `i2c_missing` count after 30-60 minutes.
+   - `timeout` count.
+   - `device_data.swt_*` presence.
+   - Array ID stability.
+
+6. Add firmware hardening later, after the hardware topology is fixed:
+   - Optional I2C bus recovery on NACK, such as deinit/reinit and SCL clock pulses.
+   - More granular status bits for probe failure versus later read failure.
+   - A boot-time or periodic diagnostic counter for Chameleon acquisition failures.
+
+## Follow-Up Checks
+
+Run a 24-48 hour soak on VDD wiring and check:
+
+- Zero or near-zero `i2c_missing` rows.
+- No large cadence gaps.
+- Stable array ID `28DE7EC80B0000E2`.
+- Stable SWT in `device_data`.
+- Battery trend, because VDD continuous power may increase current draw.
+
+Suggested gateway SQL:
+
+```sql
+SELECT
+  MIN(recorded_at) AS first_row,
+  MAX(recorded_at) AS latest_row,
+  COUNT(*) AS rows,
+  SUM(i2c_missing) AS i2c_missing_rows,
+  SUM(timeout) AS timeout_rows,
+  SUM(data_invalid) AS data_invalid_rows,
+  SUM(comp_pending) AS comp_pending_rows
+FROM chameleon_readings
+WHERE upper(deveui)=upper('A84041A75D5E7CFB')
+  AND recorded_at >= '2026-06-28T21:29:00Z';
+```
+
+```sql
+SELECT recorded_at, swt_1, swt_2, swt_3, bat_v
+FROM device_data
+WHERE upper(deveui)=upper('A84041A75D5E7CFB')
+ORDER BY recorded_at DESC
+LIMIT 20;
+```
+
+## Conclusion
+
+The root cause is best explained as an electrical integration fault: switched 5 V power was used with a direct 3.3-3.6 V I2C bus, causing both over-voltage bus highs during measurement and back-powered brownout states when switched 5 V was off. The board's 5 V compatibility applies to the board supply in a compatible bus environment; it does not make direct 5 V-pulled I2C safe for the LSN50 STM32.
+
+The VDD wiring change is the correct immediate mitigation and should be treated as the baseline for the next soak test.


### PR DESCRIPTION
Knowledge-preservation pass from the outgoing senior engineer.

**Adds [docs/engineering-playbook.md](../blob/docs/engineering-playbook/docs/engineering-playbook.md):** the working loop (verify reality → written plan → adversarial review → exact execution → independent verification → ship with evidence → record), thinking tools (find the invariant; blast radius before edit; boundaries are exact complements; validate with the consumer's parser; interleaving over happy path), prevention rules (schema/parity/flows.json/guard-test/stacked-PR/isolation), security posture, a debugging method, agent-orchestration guidance (role separation, capability matching, plan-as-contract, verify reports, resumability), and a definition of done. Every rule traces to a real 2026 incident or a review catch from the July issue sweeps.

**AGENTS.md:** links the playbook up top; refreshes the stale Issues section (#33 fixed by #91, #34 closed) and adds the 're-verify issues against main before planning' rule that kept paying off.

**CLAUDE.md:** playbook added as reading-order item 2.

Docs-only; no code paths touched. `git diff --check` clean.