### PR TITLE
feat: add fleet heartbeat edge health

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -21,6 +21,7 @@ jobs:
       - run: node --test lib/osi-migrate/__tests__/*.test.js
       - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js
       - run: node scripts/test-history-helper.js
+      - run: node --test scripts/test-health-helper.js
       - run: node scripts/verify-migrations.js
       - run: node scripts/verify-seed-replay.js
       - run: node scripts/verify-runtime-schema-parity.js

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -25,5 +25,6 @@ jobs:
       - run: node scripts/verify-seed-replay.js
       - run: node scripts/verify-runtime-schema-parity.js
       - run: node scripts/verify-devices-rebuild-fence.js
+      - run: node scripts/verify-heartbeat-health.js
       - run: node --test scripts/rehearse-devices-rebuild.test.js
       - run: node --test scripts/test-gateway-health-persistence.js

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/etc/uci-defaults/98_osi_node_red_seed
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/etc/uci-defaults/98_osi_node_red_seed
@@ -35,7 +35,7 @@ fi
 # Native sqlite must come from the OpenWrt package built for the target CPU.
 rm -rf "$DST/node_modules/sqlite3" "$DST/node_modules/node-red-node-sqlite"
 
-for module in osi-chameleon-helper osi-chirpstack-helper osi-cloud-http osi-db-helper osi-dendro-helper osi-history-helper; do
+for module in osi-chameleon-helper osi-chirpstack-helper osi-cloud-http osi-db-helper osi-dendro-helper osi-history-helper osi-health-helper; do
     if [ -d "$SRC/$module" ]; then
         rm -rf "$DST/$module" "$DST/node_modules/$module"
         cp -a "$SRC/$module" "$DST/$module"

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
@@ -3401,7 +3401,8 @@
     "y": 100,
     "wires": [
       [
-        "062a0f9bf66d9789"
+        "062a0f9bf66d9789",
+        "2a4f142e3e9b6d80"
       ]
     ]
   },
@@ -3410,7 +3411,7 @@
     "type": "function",
     "z": "93b1537a596e0e6d",
     "name": "Build Heartbeat",
-    "func": "function findFanControl(fs) {\n  try {\n    var dirs = fs.readdirSync('/sys/class/hwmon');\n    for (var i = 0; i < dirs.length; i++) {\n      try {\n        var n = fs.readFileSync('/sys/class/hwmon/' + dirs[i] + '/name', 'utf8').trim();\n        if (n === 'pwmfan') return { type: 'hwmon', path: '/sys/class/hwmon/' + dirs[i] };\n      } catch(e) {}\n    }\n  } catch(e) {}\n  try {\n    fs.accessSync('/sys/class/pwm/pwmchip2');\n    return { type: 'pwm', path: '/sys/class/pwm/pwmchip2' };\n  } catch(e) {}\n  return null;\n}\nvar eui = env.get('DEVICE_EUI') || 'UNKNOWN';\nvar deviceType = env.get('DEVICE_TYPE') || 'GATEWAY';\nvar fw = env.get('FIRMWARE_VERSION') || '0.6.5';\n\nvar os = global.get('os');\nvar fs = global.get('fs');\nvar cpuTemp = null, memPercent = null, load1 = null, load5 = null, load15 = null, fanValue = null;\nvar fanAvailable = false;\n\ntry { cpuTemp = Math.round(parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim()) / 100) / 10; } catch(e) {}\ntry {\n    var tm = os.totalmem(), fm = os.freemem();\n    memPercent = Math.round(((tm - fm) / tm) * 100);\n} catch(e) {}\ntry {\n    var la = os.loadavg();\n    load1 = Math.round(la[0] * 100) / 100;\n    load5 = Math.round(la[1] * 100) / 100;\n    load15 = Math.round(la[2] * 100) / 100;\n} catch(e) {}\ntry {\n    var fanCtrl = findFanControl(fs);\n    if (fanCtrl) {\n        if (fanCtrl.type === 'hwmon') {\n            var pwm1Val = parseInt(fs.readFileSync(fanCtrl.path + '/pwm1', 'utf8').trim()) || 0;\n            fanAvailable = true;\n            fanValue = pwm1Val;\n        } else {\n            var pwmChan = fanCtrl.path + '/pwm3';\n            var period = parseInt(fs.readFileSync(pwmChan + '/period', 'utf8').trim());\n            var duty   = parseInt(fs.readFileSync(pwmChan + '/duty_cycle', 'utf8').trim());\n            fanAvailable = true;\n            fanValue = Math.round((1 - duty / period) * 255);\n        }\n    }\n} catch(e) {}\n\nmsg.topic = 'devices/' + eui + '/heartbeat';\nmsg.payload = JSON.stringify({\n    deviceEui: eui,\n    deviceType: deviceType,\n    firmwareVersion: fw,\n    timestamp: new Date().toISOString(),\n    ip: null,\n    cpu_temp_c: cpuTemp,\n    mem_percent: memPercent,\n    load_1: load1,\n    load_5: load5,\n    load_15: load15,\n    fan_available: fanAvailable,\n    fan_value: fanValue\n});\nmsg.qos = 1;\nreturn msg;",
+    "func": "function findFanControl(fs) {\n  try {\n    var dirs = fs.readdirSync('/sys/class/hwmon');\n    for (var i = 0; i < dirs.length; i++) {\n      try {\n        var n = fs.readFileSync('/sys/class/hwmon/' + dirs[i] + '/name', 'utf8').trim();\n        if (n === 'pwmfan') return { type: 'hwmon', path: '/sys/class/hwmon/' + dirs[i] };\n      } catch(e) {}\n    }\n  } catch(e) {}\n  try {\n    fs.accessSync('/sys/class/pwm/pwmchip2');\n    return { type: 'pwm', path: '/sys/class/pwm/pwmchip2' };\n  } catch(e) {}\n  return null;\n}\nvar eui = env.get('DEVICE_EUI') || 'UNKNOWN';\nvar deviceType = env.get('DEVICE_TYPE') || 'GATEWAY';\nvar fw = env.get('FIRMWARE_VERSION') || '0.6.5';\n\nvar os = global.get('os');\nvar fs = global.get('fs');\nvar cpuTemp = null, memPercent = null, load1 = null, load5 = null, load15 = null, fanValue = null;\nvar fanAvailable = false;\n\ntry { cpuTemp = Math.round(parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim()) / 100) / 10; } catch(e) {}\ntry {\n    var tm = os.totalmem(), fm = os.freemem();\n    memPercent = Math.round(((tm - fm) / tm) * 100);\n} catch(e) {}\ntry {\n    var la = os.loadavg();\n    load1 = Math.round(la[0] * 100) / 100;\n    load5 = Math.round(la[1] * 100) / 100;\n    load15 = Math.round(la[2] * 100) / 100;\n} catch(e) {}\ntry {\n    var fanCtrl = findFanControl(fs);\n    if (fanCtrl) {\n        if (fanCtrl.type === 'hwmon') {\n            var pwm1Val = parseInt(fs.readFileSync(fanCtrl.path + '/pwm1', 'utf8').trim()) || 0;\n            fanAvailable = true;\n            fanValue = pwm1Val;\n        } else {\n            var pwmChan = fanCtrl.path + '/pwm3';\n            var period = parseInt(fs.readFileSync(pwmChan + '/period', 'utf8').trim());\n            var duty   = parseInt(fs.readFileSync(pwmChan + '/duty_cycle', 'utf8').trim());\n            fanAvailable = true;\n            fanValue = Math.round((1 - duty / period) * 255);\n        }\n    }\n} catch(e) {}\n\nfunction healthValue(source, key) {\n  if (!source) return null;\n  var value = source[key];\n  if (value === null) return null;\n  if (typeof value === 'string') return value;\n  if (typeof value === 'boolean') return value;\n  if (typeof value === 'number') return Number.isFinite(value) ? value : null;\n  return null;\n}\nconst _h = global.get('edge_health');\nconst STALE_MS = 180000;\nconst freshHealth = _h && typeof _h === 'object' && Number.isFinite(_h.at) && (Date.now() - _h.at) < STALE_MS;\nconst health = freshHealth ? {\n  schema_sig: healthValue(_h, 'schema_sig'),\n  sync_linked: healthValue(_h, 'sync_linked'),\n  sync_pending: healthValue(_h, 'sync_pending'),\n  sync_oldest_age_s: healthValue(_h, 'sync_oldest_age_s'),\n  sync_rejected: healthValue(_h, 'sync_rejected'),\n  sync_dirty_pending: healthValue(_h, 'sync_dirty_pending'),\n  disk_free_pct: healthValue(_h, 'disk_free_pct')\n} : {\n  schema_sig: null,\n  sync_linked: null,\n  sync_pending: null,\n  sync_oldest_age_s: null,\n  sync_rejected: null,\n  sync_dirty_pending: null,\n  disk_free_pct: null\n};\n\nmsg.topic = 'devices/' + eui + '/heartbeat';\nmsg.payload = JSON.stringify({\n    deviceEui: eui,\n    deviceType: deviceType,\n    firmwareVersion: fw,\n    timestamp: new Date().toISOString(),\n    ip: null,\n    cpu_temp_c: cpuTemp,\n    mem_percent: memPercent,\n    load_1: load1,\n    load_5: load5,\n    load_15: load15,\n    fan_available: fanAvailable,\n    fan_value: fanValue,\n    health: health\n});\nmsg.qos = 1;\nreturn msg;",
     "outputs": 1,
     "noerr": 0,
     "initialize": "",
@@ -3422,6 +3423,32 @@
       [
         "d769e9face3844d5"
       ]
+    ]
+  },
+  {
+    "id": "2a4f142e3e9b6d80",
+    "type": "function",
+    "z": "93b1537a596e0e6d",
+    "name": "Gather Edge Health",
+    "func": "const _db = new osiDb.Database('/data/db/farming.db');\ntry {\n  global.set('edge_health', Object.assign({at: Date.now()}, await osiHealth.gatherEdgeHealth(_db)));\n} finally {\n  _db.close(()=>{});\n}\nreturn null;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [
+      {
+        "var": "osiHealth",
+        "module": "osi-health-helper"
+      },
+      {
+        "var": "osiDb",
+        "module": "osi-db-helper"
+      }
+    ],
+    "x": 360,
+    "y": 140,
+    "wires": [
+      []
     ]
   },
   {

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/node_modules/osi-health-helper
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/node_modules/osi-health-helper
@@ -1,0 +1,1 @@
+../osi-health-helper

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/index.js
@@ -35,6 +35,14 @@ function toCount(row) {
   return Number(row && row.c != null ? row.c : 0);
 }
 
+function compareByCodepoint(left, right) {
+  const a = String(left);
+  const b = String(right);
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
 async function structuralSignature(db) {
   const tables = await queryAll(
     db,
@@ -56,7 +64,7 @@ async function structuralSignature(db) {
 
     const indexRows = (await queryAll(db, `PRAGMA index_list(${quoteIdentifier(tableName)})`))
       .slice()
-      .sort((left, right) => String(left.name).localeCompare(String(right.name)));
+      .sort((left, right) => compareByCodepoint(left.name, right.name));
     const indexes = [];
     for (const index of indexRows) {
       const indexName = index.name;
@@ -224,5 +232,6 @@ function gatherEdgeHealth(db, options = {}) {
 
 module.exports = {
   structuralSignature,
-  gatherEdgeHealth
+  gatherEdgeHealth,
+  compareByCodepoint
 };

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/index.js
@@ -190,7 +190,7 @@ async function gatherWork(db, diskPath, timeoutMs) {
     const rawOldest = row ? row.s : 0;
     health.sync_oldest_age_s = pending > 0 && (rawOldest === null || rawOldest === undefined)
       ? Number.MAX_SAFE_INTEGER
-      : Number(rawOldest || 0);
+      : Math.max(0, Number(rawOldest || 0));
   } catch (_) {}
 
   try {

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/index.js
@@ -2,7 +2,7 @@
 
 const crypto = require('node:crypto');
 const fs = require('node:fs');
-const { execFileSync } = require('node:child_process');
+const childProcess = require('node:child_process');
 
 function allNullHealth() {
   return {
@@ -97,7 +97,38 @@ function roundedFreePct(available, total) {
   return Math.max(0, Math.min(100, Math.round((free / blocks) * 100)));
 }
 
-function diskFreePct(diskPath) {
+function boundedTimeoutMs(timeoutMs) {
+  const value = Number(timeoutMs);
+  return Number.isFinite(value) && value > 0 ? Math.ceil(value) : 4000;
+}
+
+function dfDiskFreePct(diskPath, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(
+      'df',
+      ['-kP', diskPath],
+      { encoding: 'utf8', timeout: boundedTimeoutMs(timeoutMs), maxBuffer: 16 * 1024 },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        try {
+          const lines = String(stdout || '').trim().split(/\r?\n/).filter(Boolean);
+          if (lines.length < 2) throw new Error('df output missing data row');
+          const columns = lines[1].trim().split(/\s+/);
+          const total = Number(columns[1]);
+          const available = Number(columns[3]);
+          resolve(roundedFreePct(available, total));
+        } catch (parseError) {
+          reject(parseError);
+        }
+      }
+    );
+  });
+}
+
+async function diskFreePct(diskPath, timeoutMs) {
   try {
     if (typeof fs.statfsSync === 'function') {
       const stats = fs.statfsSync(diskPath);
@@ -105,16 +136,10 @@ function diskFreePct(diskPath) {
     }
   } catch (_) {}
 
-  const output = execFileSync('df', ['-kP', diskPath], { encoding: 'utf8' }).trim();
-  const lines = output.split(/\r?\n/).filter(Boolean);
-  if (lines.length < 2) throw new Error('df output missing data row');
-  const columns = lines[1].trim().split(/\s+/);
-  const total = Number(columns[1]);
-  const available = Number(columns[3]);
-  return roundedFreePct(available, total);
+  return await dfDiskFreePct(diskPath, timeoutMs);
 }
 
-async function gatherWork(db, diskPath) {
+async function gatherWork(db, diskPath, timeoutMs) {
   const health = allNullHealth();
 
   try {
@@ -161,7 +186,7 @@ async function gatherWork(db, diskPath) {
   } catch (_) {}
 
   try {
-    health.disk_free_pct = diskFreePct(diskPath);
+    health.disk_free_pct = await diskFreePct(diskPath, timeoutMs);
   } catch (_) {}
 
   return health;
@@ -183,7 +208,7 @@ function gatherEdgeHealth(db, options = {}) {
     const timer = setTimeout(() => finish(allNullHealth()), timeoutMs);
 
     Promise.resolve()
-      .then(() => gatherWork(db, diskPath))
+      .then(() => gatherWork(db, diskPath, timeoutMs))
       .then(
         (health) => {
           clearTimeout(timer);

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/index.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+function allNullHealth() {
+  return {
+    schema_sig: null,
+    sync_linked: null,
+    sync_pending: null,
+    sync_oldest_age_s: null,
+    sync_rejected: null,
+    sync_dirty_pending: null,
+    disk_free_pct: null
+  };
+}
+
+function quoteIdentifier(identifier) {
+  return '"' + String(identifier).replace(/"/g, '""') + '"';
+}
+
+async function queryAll(db, sql) {
+  if (!db || typeof db.all !== 'function') throw new Error('database facade missing all()');
+  return await db.all(sql);
+}
+
+async function queryGet(db, sql) {
+  if (db && typeof db.get === 'function') return await db.get(sql);
+  const rows = await queryAll(db, sql);
+  return rows && rows[0];
+}
+
+function toCount(row) {
+  return Number(row && row.c != null ? row.c : 0);
+}
+
+async function structuralSignature(db) {
+  const tables = await queryAll(
+    db,
+    "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+  );
+  const projectedTables = [];
+
+  for (const table of tables) {
+    const tableName = table.name;
+    const columns = (await queryAll(db, `PRAGMA table_info(${quoteIdentifier(tableName)})`))
+      .sort((left, right) => Number(left.cid) - Number(right.cid))
+      .map((column) => ({
+        name: column.name,
+        type: column.type,
+        notnull: Number(column.notnull),
+        dflt_value: column.dflt_value == null ? null : String(column.dflt_value),
+        pk: Number(column.pk)
+      }));
+
+    const indexRows = (await queryAll(db, `PRAGMA index_list(${quoteIdentifier(tableName)})`))
+      .slice()
+      .sort((left, right) => String(left.name).localeCompare(String(right.name)));
+    const indexes = [];
+    for (const index of indexRows) {
+      const indexName = index.name;
+      const indexColumns = (await queryAll(db, `PRAGMA index_info(${quoteIdentifier(indexName)})`))
+        .sort((left, right) => Number(left.seqno) - Number(right.seqno))
+        .map((column) => ({
+          seqno: Number(column.seqno),
+          name: column.name
+        }));
+      indexes.push({
+        name: indexName,
+        unique: Number(index.unique),
+        partial: Number(index.partial || 0),
+        columns: indexColumns
+      });
+    }
+
+    projectedTables.push({ name: tableName, columns, indexes });
+  }
+
+  const triggers = (await queryAll(
+    db,
+    "SELECT name FROM sqlite_master WHERE type='trigger' ORDER BY name"
+  )).map((trigger) => ({
+    name: trigger.name
+  }));
+
+  const input = JSON.stringify({ version: 1, tables: projectedTables, triggers });
+  return crypto.createHash('sha256').update(Buffer.from(input, 'utf8')).digest('hex').slice(0, 16);
+}
+
+function roundedFreePct(available, total) {
+  const free = Number(available);
+  const blocks = Number(total);
+  if (!Number.isFinite(free) || !Number.isFinite(blocks) || blocks <= 0) {
+    throw new Error('invalid disk free values');
+  }
+  return Math.max(0, Math.min(100, Math.round((free / blocks) * 100)));
+}
+
+function diskFreePct(diskPath) {
+  try {
+    if (typeof fs.statfsSync === 'function') {
+      const stats = fs.statfsSync(diskPath);
+      return roundedFreePct(stats.bavail, stats.blocks);
+    }
+  } catch (_) {}
+
+  const output = execFileSync('df', ['-kP', diskPath], { encoding: 'utf8' }).trim();
+  const lines = output.split(/\r?\n/).filter(Boolean);
+  if (lines.length < 2) throw new Error('df output missing data row');
+  const columns = lines[1].trim().split(/\s+/);
+  const total = Number(columns[1]);
+  const available = Number(columns[3]);
+  return roundedFreePct(available, total);
+}
+
+async function gatherWork(db, diskPath) {
+  const health = allNullHealth();
+
+  try {
+    health.schema_sig = await structuralSignature(db);
+  } catch (_) {}
+
+  try {
+    const row = await queryGet(db, "SELECT linked FROM sync_link_state WHERE peer_node='cloud'");
+    health.sync_linked = !!(row && row.linked);
+  } catch (_) {}
+
+  try {
+    health.sync_pending = toCount(await queryGet(
+      db,
+      'SELECT COUNT(*) c FROM sync_outbox WHERE delivered_at IS NULL AND rejected_at IS NULL'
+    ));
+  } catch (_) {}
+
+  try {
+    health.sync_rejected = toCount(await queryGet(
+      db,
+      'SELECT COUNT(*) c FROM sync_outbox WHERE rejected_at IS NOT NULL'
+    ));
+  } catch (_) {}
+
+  try {
+    health.sync_dirty_pending = toCount(await queryGet(
+      db,
+      "SELECT COUNT(*) c FROM sync_history_dirty_keys WHERE status='pending'"
+    ));
+  } catch (_) {}
+
+  try {
+    const row = await queryGet(
+      db,
+      "SELECT COUNT(*) c, CAST((julianday('now') - julianday(MIN(occurred_at))) * 86400 AS INTEGER) s " +
+        'FROM sync_outbox WHERE delivered_at IS NULL AND rejected_at IS NULL'
+    );
+    const pending = toCount(row);
+    const rawOldest = row ? row.s : 0;
+    health.sync_oldest_age_s = pending > 0 && (rawOldest === null || rawOldest === undefined)
+      ? Number.MAX_SAFE_INTEGER
+      : Number(rawOldest || 0);
+  } catch (_) {}
+
+  try {
+    health.disk_free_pct = diskFreePct(diskPath);
+  } catch (_) {}
+
+  return health;
+}
+
+function gatherEdgeHealth(db, options = {}) {
+  const timeoutMs = Number.isFinite(Number(options.timeoutMs)) && Number(options.timeoutMs) > 0
+    ? Number(options.timeoutMs)
+    : 4000;
+  const diskPath = options.diskPath || '/data';
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(allNullHealth()), timeoutMs);
+
+    Promise.resolve()
+      .then(() => gatherWork(db, diskPath))
+      .then(
+        (health) => {
+          clearTimeout(timer);
+          finish(health);
+        },
+        () => {
+          clearTimeout(timer);
+          finish(allNullHealth());
+        }
+      );
+  });
+}
+
+module.exports = {
+  structuralSignature,
+  gatherEdgeHealth
+};

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/package.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-health-helper/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "osi-health-helper",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/package-lock.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/package-lock.json
@@ -16,6 +16,7 @@
         "osi-db-helper": "file:osi-db-helper",
         "osi-dendro-helper": "file:osi-dendro-helper",
         "osi-history-helper": "file:osi-history-helper",
+        "osi-health-helper": "file:osi-health-helper",
         "sqlite3": "^5.1.7"
       }
     },
@@ -1438,6 +1439,10 @@
       "resolved": "osi-history-helper",
       "link": true
     },
+    "node_modules/osi-health-helper": {
+      "resolved": "osi-health-helper",
+      "link": true
+    },
     "node_modules/p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -2065,6 +2070,9 @@
       "version": "1.0.0"
     },
     "osi-history-helper": {
+      "version": "1.0.0"
+    },
+    "osi-health-helper": {
       "version": "1.0.0"
     }
   }

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/package.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/package.json
@@ -12,6 +12,7 @@
     "osi-dendro-helper": "file:osi-dendro-helper",
     "osi-db-helper": "file:osi-db-helper",
     "osi-history-helper": "file:osi-history-helper",
+    "osi-health-helper": "file:osi-health-helper",
     "sqlite3": "^5.1.7"
   }
 }

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/98_osi_node_red_seed
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/98_osi_node_red_seed
@@ -35,7 +35,7 @@ fi
 # Native sqlite must come from the OpenWrt package built for the target CPU.
 rm -rf "$DST/node_modules/sqlite3" "$DST/node_modules/node-red-node-sqlite"
 
-for module in osi-chameleon-helper osi-chirpstack-helper osi-cloud-http osi-db-helper osi-dendro-helper osi-history-helper; do
+for module in osi-chameleon-helper osi-chirpstack-helper osi-cloud-http osi-db-helper osi-dendro-helper osi-history-helper osi-health-helper; do
     if [ -d "$SRC/$module" ]; then
         rm -rf "$DST/$module" "$DST/node_modules/$module"
         cp -a "$SRC/$module" "$DST/$module"

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
@@ -3401,7 +3401,8 @@
     "y": 100,
     "wires": [
       [
-        "062a0f9bf66d9789"
+        "062a0f9bf66d9789",
+        "2a4f142e3e9b6d80"
       ]
     ]
   },
@@ -3410,7 +3411,7 @@
     "type": "function",
     "z": "93b1537a596e0e6d",
     "name": "Build Heartbeat",
-    "func": "function findFanControl(fs) {\n  try {\n    var dirs = fs.readdirSync('/sys/class/hwmon');\n    for (var i = 0; i < dirs.length; i++) {\n      try {\n        var n = fs.readFileSync('/sys/class/hwmon/' + dirs[i] + '/name', 'utf8').trim();\n        if (n === 'pwmfan') return { type: 'hwmon', path: '/sys/class/hwmon/' + dirs[i] };\n      } catch(e) {}\n    }\n  } catch(e) {}\n  try {\n    fs.accessSync('/sys/class/pwm/pwmchip2');\n    return { type: 'pwm', path: '/sys/class/pwm/pwmchip2' };\n  } catch(e) {}\n  return null;\n}\nvar eui = env.get('DEVICE_EUI') || 'UNKNOWN';\nvar deviceType = env.get('DEVICE_TYPE') || 'GATEWAY';\nvar fw = env.get('FIRMWARE_VERSION') || '0.6.5';\n\nvar os = global.get('os');\nvar fs = global.get('fs');\nvar cpuTemp = null, memPercent = null, load1 = null, load5 = null, load15 = null, fanValue = null;\nvar fanAvailable = false;\n\ntry { cpuTemp = Math.round(parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim()) / 100) / 10; } catch(e) {}\ntry {\n    var tm = os.totalmem(), fm = os.freemem();\n    memPercent = Math.round(((tm - fm) / tm) * 100);\n} catch(e) {}\ntry {\n    var la = os.loadavg();\n    load1 = Math.round(la[0] * 100) / 100;\n    load5 = Math.round(la[1] * 100) / 100;\n    load15 = Math.round(la[2] * 100) / 100;\n} catch(e) {}\ntry {\n    var fanCtrl = findFanControl(fs);\n    if (fanCtrl) {\n        if (fanCtrl.type === 'hwmon') {\n            var pwm1Val = parseInt(fs.readFileSync(fanCtrl.path + '/pwm1', 'utf8').trim()) || 0;\n            fanAvailable = true;\n            fanValue = pwm1Val;\n        } else {\n            var pwmChan = fanCtrl.path + '/pwm3';\n            var period = parseInt(fs.readFileSync(pwmChan + '/period', 'utf8').trim());\n            var duty   = parseInt(fs.readFileSync(pwmChan + '/duty_cycle', 'utf8').trim());\n            fanAvailable = true;\n            fanValue = Math.round((1 - duty / period) * 255);\n        }\n    }\n} catch(e) {}\n\nmsg.topic = 'devices/' + eui + '/heartbeat';\nmsg.payload = JSON.stringify({\n    deviceEui: eui,\n    deviceType: deviceType,\n    firmwareVersion: fw,\n    timestamp: new Date().toISOString(),\n    ip: null,\n    cpu_temp_c: cpuTemp,\n    mem_percent: memPercent,\n    load_1: load1,\n    load_5: load5,\n    load_15: load15,\n    fan_available: fanAvailable,\n    fan_value: fanValue\n});\nmsg.qos = 1;\nreturn msg;",
+    "func": "function findFanControl(fs) {\n  try {\n    var dirs = fs.readdirSync('/sys/class/hwmon');\n    for (var i = 0; i < dirs.length; i++) {\n      try {\n        var n = fs.readFileSync('/sys/class/hwmon/' + dirs[i] + '/name', 'utf8').trim();\n        if (n === 'pwmfan') return { type: 'hwmon', path: '/sys/class/hwmon/' + dirs[i] };\n      } catch(e) {}\n    }\n  } catch(e) {}\n  try {\n    fs.accessSync('/sys/class/pwm/pwmchip2');\n    return { type: 'pwm', path: '/sys/class/pwm/pwmchip2' };\n  } catch(e) {}\n  return null;\n}\nvar eui = env.get('DEVICE_EUI') || 'UNKNOWN';\nvar deviceType = env.get('DEVICE_TYPE') || 'GATEWAY';\nvar fw = env.get('FIRMWARE_VERSION') || '0.6.5';\n\nvar os = global.get('os');\nvar fs = global.get('fs');\nvar cpuTemp = null, memPercent = null, load1 = null, load5 = null, load15 = null, fanValue = null;\nvar fanAvailable = false;\n\ntry { cpuTemp = Math.round(parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim()) / 100) / 10; } catch(e) {}\ntry {\n    var tm = os.totalmem(), fm = os.freemem();\n    memPercent = Math.round(((tm - fm) / tm) * 100);\n} catch(e) {}\ntry {\n    var la = os.loadavg();\n    load1 = Math.round(la[0] * 100) / 100;\n    load5 = Math.round(la[1] * 100) / 100;\n    load15 = Math.round(la[2] * 100) / 100;\n} catch(e) {}\ntry {\n    var fanCtrl = findFanControl(fs);\n    if (fanCtrl) {\n        if (fanCtrl.type === 'hwmon') {\n            var pwm1Val = parseInt(fs.readFileSync(fanCtrl.path + '/pwm1', 'utf8').trim()) || 0;\n            fanAvailable = true;\n            fanValue = pwm1Val;\n        } else {\n            var pwmChan = fanCtrl.path + '/pwm3';\n            var period = parseInt(fs.readFileSync(pwmChan + '/period', 'utf8').trim());\n            var duty   = parseInt(fs.readFileSync(pwmChan + '/duty_cycle', 'utf8').trim());\n            fanAvailable = true;\n            fanValue = Math.round((1 - duty / period) * 255);\n        }\n    }\n} catch(e) {}\n\nfunction healthValue(source, key) {\n  if (!source) return null;\n  var value = source[key];\n  if (value === null) return null;\n  if (typeof value === 'string') return value;\n  if (typeof value === 'boolean') return value;\n  if (typeof value === 'number') return Number.isFinite(value) ? value : null;\n  return null;\n}\nconst _h = global.get('edge_health');\nconst STALE_MS = 180000;\nconst freshHealth = _h && typeof _h === 'object' && Number.isFinite(_h.at) && (Date.now() - _h.at) < STALE_MS;\nconst health = freshHealth ? {\n  schema_sig: healthValue(_h, 'schema_sig'),\n  sync_linked: healthValue(_h, 'sync_linked'),\n  sync_pending: healthValue(_h, 'sync_pending'),\n  sync_oldest_age_s: healthValue(_h, 'sync_oldest_age_s'),\n  sync_rejected: healthValue(_h, 'sync_rejected'),\n  sync_dirty_pending: healthValue(_h, 'sync_dirty_pending'),\n  disk_free_pct: healthValue(_h, 'disk_free_pct')\n} : {\n  schema_sig: null,\n  sync_linked: null,\n  sync_pending: null,\n  sync_oldest_age_s: null,\n  sync_rejected: null,\n  sync_dirty_pending: null,\n  disk_free_pct: null\n};\n\nmsg.topic = 'devices/' + eui + '/heartbeat';\nmsg.payload = JSON.stringify({\n    deviceEui: eui,\n    deviceType: deviceType,\n    firmwareVersion: fw,\n    timestamp: new Date().toISOString(),\n    ip: null,\n    cpu_temp_c: cpuTemp,\n    mem_percent: memPercent,\n    load_1: load1,\n    load_5: load5,\n    load_15: load15,\n    fan_available: fanAvailable,\n    fan_value: fanValue,\n    health: health\n});\nmsg.qos = 1;\nreturn msg;",
     "outputs": 1,
     "noerr": 0,
     "initialize": "",
@@ -3422,6 +3423,32 @@
       [
         "d769e9face3844d5"
       ]
+    ]
+  },
+  {
+    "id": "2a4f142e3e9b6d80",
+    "type": "function",
+    "z": "93b1537a596e0e6d",
+    "name": "Gather Edge Health",
+    "func": "const _db = new osiDb.Database('/data/db/farming.db');\ntry {\n  global.set('edge_health', Object.assign({at: Date.now()}, await osiHealth.gatherEdgeHealth(_db)));\n} finally {\n  _db.close(()=>{});\n}\nreturn null;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [
+      {
+        "var": "osiHealth",
+        "module": "osi-health-helper"
+      },
+      {
+        "var": "osiDb",
+        "module": "osi-db-helper"
+      }
+    ],
+    "x": 360,
+    "y": 140,
+    "wires": [
+      []
     ]
   },
   {

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/node_modules/osi-health-helper
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/node_modules/osi-health-helper
@@ -1,0 +1,1 @@
+../osi-health-helper

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js
@@ -35,6 +35,14 @@ function toCount(row) {
   return Number(row && row.c != null ? row.c : 0);
 }
 
+function compareByCodepoint(left, right) {
+  const a = String(left);
+  const b = String(right);
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
 async function structuralSignature(db) {
   const tables = await queryAll(
     db,
@@ -56,7 +64,7 @@ async function structuralSignature(db) {
 
     const indexRows = (await queryAll(db, `PRAGMA index_list(${quoteIdentifier(tableName)})`))
       .slice()
-      .sort((left, right) => String(left.name).localeCompare(String(right.name)));
+      .sort((left, right) => compareByCodepoint(left.name, right.name));
     const indexes = [];
     for (const index of indexRows) {
       const indexName = index.name;
@@ -224,5 +232,6 @@ function gatherEdgeHealth(db, options = {}) {
 
 module.exports = {
   structuralSignature,
-  gatherEdgeHealth
+  gatherEdgeHealth,
+  compareByCodepoint
 };

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js
@@ -190,7 +190,7 @@ async function gatherWork(db, diskPath, timeoutMs) {
     const rawOldest = row ? row.s : 0;
     health.sync_oldest_age_s = pending > 0 && (rawOldest === null || rawOldest === undefined)
       ? Number.MAX_SAFE_INTEGER
-      : Number(rawOldest || 0);
+      : Math.max(0, Number(rawOldest || 0));
   } catch (_) {}
 
   try {

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js
@@ -2,7 +2,7 @@
 
 const crypto = require('node:crypto');
 const fs = require('node:fs');
-const { execFileSync } = require('node:child_process');
+const childProcess = require('node:child_process');
 
 function allNullHealth() {
   return {
@@ -97,7 +97,38 @@ function roundedFreePct(available, total) {
   return Math.max(0, Math.min(100, Math.round((free / blocks) * 100)));
 }
 
-function diskFreePct(diskPath) {
+function boundedTimeoutMs(timeoutMs) {
+  const value = Number(timeoutMs);
+  return Number.isFinite(value) && value > 0 ? Math.ceil(value) : 4000;
+}
+
+function dfDiskFreePct(diskPath, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(
+      'df',
+      ['-kP', diskPath],
+      { encoding: 'utf8', timeout: boundedTimeoutMs(timeoutMs), maxBuffer: 16 * 1024 },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        try {
+          const lines = String(stdout || '').trim().split(/\r?\n/).filter(Boolean);
+          if (lines.length < 2) throw new Error('df output missing data row');
+          const columns = lines[1].trim().split(/\s+/);
+          const total = Number(columns[1]);
+          const available = Number(columns[3]);
+          resolve(roundedFreePct(available, total));
+        } catch (parseError) {
+          reject(parseError);
+        }
+      }
+    );
+  });
+}
+
+async function diskFreePct(diskPath, timeoutMs) {
   try {
     if (typeof fs.statfsSync === 'function') {
       const stats = fs.statfsSync(diskPath);
@@ -105,16 +136,10 @@ function diskFreePct(diskPath) {
     }
   } catch (_) {}
 
-  const output = execFileSync('df', ['-kP', diskPath], { encoding: 'utf8' }).trim();
-  const lines = output.split(/\r?\n/).filter(Boolean);
-  if (lines.length < 2) throw new Error('df output missing data row');
-  const columns = lines[1].trim().split(/\s+/);
-  const total = Number(columns[1]);
-  const available = Number(columns[3]);
-  return roundedFreePct(available, total);
+  return await dfDiskFreePct(diskPath, timeoutMs);
 }
 
-async function gatherWork(db, diskPath) {
+async function gatherWork(db, diskPath, timeoutMs) {
   const health = allNullHealth();
 
   try {
@@ -161,7 +186,7 @@ async function gatherWork(db, diskPath) {
   } catch (_) {}
 
   try {
-    health.disk_free_pct = diskFreePct(diskPath);
+    health.disk_free_pct = await diskFreePct(diskPath, timeoutMs);
   } catch (_) {}
 
   return health;
@@ -183,7 +208,7 @@ function gatherEdgeHealth(db, options = {}) {
     const timer = setTimeout(() => finish(allNullHealth()), timeoutMs);
 
     Promise.resolve()
-      .then(() => gatherWork(db, diskPath))
+      .then(() => gatherWork(db, diskPath, timeoutMs))
       .then(
         (health) => {
           clearTimeout(timer);

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js
@@ -1,0 +1,203 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const { execFileSync } = require('node:child_process');
+
+function allNullHealth() {
+  return {
+    schema_sig: null,
+    sync_linked: null,
+    sync_pending: null,
+    sync_oldest_age_s: null,
+    sync_rejected: null,
+    sync_dirty_pending: null,
+    disk_free_pct: null
+  };
+}
+
+function quoteIdentifier(identifier) {
+  return '"' + String(identifier).replace(/"/g, '""') + '"';
+}
+
+async function queryAll(db, sql) {
+  if (!db || typeof db.all !== 'function') throw new Error('database facade missing all()');
+  return await db.all(sql);
+}
+
+async function queryGet(db, sql) {
+  if (db && typeof db.get === 'function') return await db.get(sql);
+  const rows = await queryAll(db, sql);
+  return rows && rows[0];
+}
+
+function toCount(row) {
+  return Number(row && row.c != null ? row.c : 0);
+}
+
+async function structuralSignature(db) {
+  const tables = await queryAll(
+    db,
+    "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+  );
+  const projectedTables = [];
+
+  for (const table of tables) {
+    const tableName = table.name;
+    const columns = (await queryAll(db, `PRAGMA table_info(${quoteIdentifier(tableName)})`))
+      .sort((left, right) => Number(left.cid) - Number(right.cid))
+      .map((column) => ({
+        name: column.name,
+        type: column.type,
+        notnull: Number(column.notnull),
+        dflt_value: column.dflt_value == null ? null : String(column.dflt_value),
+        pk: Number(column.pk)
+      }));
+
+    const indexRows = (await queryAll(db, `PRAGMA index_list(${quoteIdentifier(tableName)})`))
+      .slice()
+      .sort((left, right) => String(left.name).localeCompare(String(right.name)));
+    const indexes = [];
+    for (const index of indexRows) {
+      const indexName = index.name;
+      const indexColumns = (await queryAll(db, `PRAGMA index_info(${quoteIdentifier(indexName)})`))
+        .sort((left, right) => Number(left.seqno) - Number(right.seqno))
+        .map((column) => ({
+          seqno: Number(column.seqno),
+          name: column.name
+        }));
+      indexes.push({
+        name: indexName,
+        unique: Number(index.unique),
+        partial: Number(index.partial || 0),
+        columns: indexColumns
+      });
+    }
+
+    projectedTables.push({ name: tableName, columns, indexes });
+  }
+
+  const triggers = (await queryAll(
+    db,
+    "SELECT name FROM sqlite_master WHERE type='trigger' ORDER BY name"
+  )).map((trigger) => ({
+    name: trigger.name
+  }));
+
+  const input = JSON.stringify({ version: 1, tables: projectedTables, triggers });
+  return crypto.createHash('sha256').update(Buffer.from(input, 'utf8')).digest('hex').slice(0, 16);
+}
+
+function roundedFreePct(available, total) {
+  const free = Number(available);
+  const blocks = Number(total);
+  if (!Number.isFinite(free) || !Number.isFinite(blocks) || blocks <= 0) {
+    throw new Error('invalid disk free values');
+  }
+  return Math.max(0, Math.min(100, Math.round((free / blocks) * 100)));
+}
+
+function diskFreePct(diskPath) {
+  try {
+    if (typeof fs.statfsSync === 'function') {
+      const stats = fs.statfsSync(diskPath);
+      return roundedFreePct(stats.bavail, stats.blocks);
+    }
+  } catch (_) {}
+
+  const output = execFileSync('df', ['-kP', diskPath], { encoding: 'utf8' }).trim();
+  const lines = output.split(/\r?\n/).filter(Boolean);
+  if (lines.length < 2) throw new Error('df output missing data row');
+  const columns = lines[1].trim().split(/\s+/);
+  const total = Number(columns[1]);
+  const available = Number(columns[3]);
+  return roundedFreePct(available, total);
+}
+
+async function gatherWork(db, diskPath) {
+  const health = allNullHealth();
+
+  try {
+    health.schema_sig = await structuralSignature(db);
+  } catch (_) {}
+
+  try {
+    const row = await queryGet(db, "SELECT linked FROM sync_link_state WHERE peer_node='cloud'");
+    health.sync_linked = !!(row && row.linked);
+  } catch (_) {}
+
+  try {
+    health.sync_pending = toCount(await queryGet(
+      db,
+      'SELECT COUNT(*) c FROM sync_outbox WHERE delivered_at IS NULL AND rejected_at IS NULL'
+    ));
+  } catch (_) {}
+
+  try {
+    health.sync_rejected = toCount(await queryGet(
+      db,
+      'SELECT COUNT(*) c FROM sync_outbox WHERE rejected_at IS NOT NULL'
+    ));
+  } catch (_) {}
+
+  try {
+    health.sync_dirty_pending = toCount(await queryGet(
+      db,
+      "SELECT COUNT(*) c FROM sync_history_dirty_keys WHERE status='pending'"
+    ));
+  } catch (_) {}
+
+  try {
+    const row = await queryGet(
+      db,
+      "SELECT COUNT(*) c, CAST((julianday('now') - julianday(MIN(occurred_at))) * 86400 AS INTEGER) s " +
+        'FROM sync_outbox WHERE delivered_at IS NULL AND rejected_at IS NULL'
+    );
+    const pending = toCount(row);
+    const rawOldest = row ? row.s : 0;
+    health.sync_oldest_age_s = pending > 0 && (rawOldest === null || rawOldest === undefined)
+      ? Number.MAX_SAFE_INTEGER
+      : Number(rawOldest || 0);
+  } catch (_) {}
+
+  try {
+    health.disk_free_pct = diskFreePct(diskPath);
+  } catch (_) {}
+
+  return health;
+}
+
+function gatherEdgeHealth(db, options = {}) {
+  const timeoutMs = Number.isFinite(Number(options.timeoutMs)) && Number(options.timeoutMs) > 0
+    ? Number(options.timeoutMs)
+    : 4000;
+  const diskPath = options.diskPath || '/data';
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const timer = setTimeout(() => finish(allNullHealth()), timeoutMs);
+
+    Promise.resolve()
+      .then(() => gatherWork(db, diskPath))
+      .then(
+        (health) => {
+          clearTimeout(timer);
+          finish(health);
+        },
+        () => {
+          clearTimeout(timer);
+          finish(allNullHealth());
+        }
+      );
+  });
+}
+
+module.exports = {
+  structuralSignature,
+  gatherEdgeHealth
+};

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/package.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "osi-health-helper",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js"
+}

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/package-lock.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/package-lock.json
@@ -16,6 +16,7 @@
         "osi-db-helper": "file:osi-db-helper",
         "osi-dendro-helper": "file:osi-dendro-helper",
         "osi-history-helper": "file:osi-history-helper",
+        "osi-health-helper": "file:osi-health-helper",
         "sqlite3": "^5.1.7"
       }
     },
@@ -1438,6 +1439,10 @@
       "resolved": "osi-history-helper",
       "link": true
     },
+    "node_modules/osi-health-helper": {
+      "resolved": "osi-health-helper",
+      "link": true
+    },
     "node_modules/p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -2065,6 +2070,9 @@
       "version": "1.0.0"
     },
     "osi-history-helper": {
+      "version": "1.0.0"
+    },
+    "osi-health-helper": {
       "version": "1.0.0"
     }
   }

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/package.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/package.json
@@ -12,6 +12,7 @@
     "osi-dendro-helper": "file:osi-dendro-helper",
     "osi-db-helper": "file:osi-db-helper",
     "osi-history-helper": "file:osi-history-helper",
+    "osi-health-helper": "file:osi-health-helper",
     "sqlite3": "^5.1.7"
   }
 }

--- a/deploy.sh
+++ b/deploy.sh
@@ -562,6 +562,14 @@ fetch_required "osi-db-helper index.js" \
     "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-db-helper/index.js" \
     "/srv/node-red/osi-db-helper/index.js"
 
+fetch_required "osi-health-helper package.json" \
+    "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/package.json" \
+    "/srv/node-red/osi-health-helper/package.json"
+
+fetch_required "osi-health-helper index.js" \
+    "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper/index.js" \
+    "/srv/node-red/osi-health-helper/index.js"
+
 fetch_required "osi-dendro-helper package.json" \
     "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-dendro-helper/package.json" \
     "/srv/node-red/osi-dendro-helper/package.json"

--- a/scripts/test-health-helper.js
+++ b/scripts/test-health-helper.js
@@ -18,7 +18,8 @@ function requireHealthHelperFresh() {
 
 const {
   gatherEdgeHealth,
-  structuralSignature
+  structuralSignature,
+  compareByCodepoint
 } = requireHealthHelperFresh();
 
 const PUBLIC_HEALTH_KEYS = [
@@ -190,6 +191,39 @@ test('Uganda-shape schema resolves with null sync fields but keeps schema and di
   }
 });
 
+test('sync_outbox missing rejected_at column degrades sync_pending to null', async () => {
+  const db = makeFacadeShim();
+  try {
+    await db.exec(`
+      CREATE TABLE devices (
+        deveui TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        type_id TEXT NOT NULL,
+        updated_at TEXT
+      );
+      CREATE TABLE sync_link_state (
+        peer_node TEXT PRIMARY KEY,
+        linked INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE sync_outbox (
+        event_uuid TEXT PRIMARY KEY,
+        occurred_at TEXT NOT NULL,
+        delivered_at TEXT
+      );
+      INSERT INTO devices(deveui, name, type_id, updated_at)
+      VALUES ('0016C001F1000001', 'gateway', 'KIWI_SENSOR', '2026-07-05T00:00:00Z');
+      INSERT INTO sync_link_state(peer_node, linked) VALUES ('cloud', 1);
+    `);
+
+    const health = await gatherEdgeHealth(db, { timeoutMs: 1000, diskPath: os.tmpdir() });
+
+    assertPublicHealthShape(health);
+    assert.strictEqual(health.sync_pending, null);
+  } finally {
+    db.close();
+  }
+});
+
 test('sync backlog counters count pending, rejected, and dirty pending rows independently', async () => {
   const db = makeFacadeShim();
   try {
@@ -307,6 +341,14 @@ test('structural schema signature changes when trigger name changes', async () =
     first.close();
     renamed.close();
   }
+});
+
+test('index-name sort is codepoint-ordered, not locale-ordered', () => {
+  // 'B' (0x42) precedes 'a' (0x61) by codepoint; every common locale sorts
+  // them the other way (case-insensitive: a before B). This pins the sort to
+  // codepoint order so the structural signature is identical across ICU builds.
+  assert.deepStrictEqual(['a', 'B'].slice().sort(compareByCodepoint), ['B', 'a']);
+  assert.deepStrictEqual(['idx_b', 'idx_A', 'idx_a'].slice().sort(compareByCodepoint), ['idx_A', 'idx_a', 'idx_b']);
 });
 
 test('hung database returns all-null health within timeout', async () => {

--- a/scripts/test-health-helper.js
+++ b/scripts/test-health-helper.js
@@ -1,0 +1,316 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const { DatabaseSync } = require('node:sqlite');
+
+const {
+  gatherEdgeHealth,
+  structuralSignature
+} = require('../conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper');
+
+const PUBLIC_HEALTH_KEYS = [
+  'schema_sig',
+  'sync_linked',
+  'sync_pending',
+  'sync_oldest_age_s',
+  'sync_rejected',
+  'sync_dirty_pending',
+  'disk_free_pct'
+];
+
+const ALL_NULL_HEALTH = Object.fromEntries(PUBLIC_HEALTH_KEYS.map((key) => [key, null]));
+
+function assertPublicHealthShape(health) {
+  assert.deepStrictEqual(Object.keys(health).sort(), PUBLIC_HEALTH_KEYS.slice().sort());
+}
+
+function assertDiskFreePct(value) {
+  assert(Number.isInteger(value));
+  assert(value >= 0);
+  assert(value <= 100);
+}
+
+function makeFacadeShim() {
+  const db = new DatabaseSync(':memory:');
+  const call = (kind) => (sql, cb) => {
+    try {
+      let result;
+      if (kind === 'run' || kind === 'exec') {
+        db.exec(sql);
+        result = undefined;
+      } else if (kind === 'get') {
+        result = db.prepare(sql).get();
+      } else {
+        result = db.prepare(sql).all();
+      }
+      if (typeof cb === 'function') {
+        process.nextTick(() => cb(null, result));
+        return undefined;
+      }
+      return Promise.resolve(result);
+    } catch (error) {
+      if (typeof cb === 'function') {
+        process.nextTick(() => cb(error));
+        return undefined;
+      }
+      return Promise.reject(error);
+    }
+  };
+  const scope = { run: call('run'), all: call('all'), get: call('get'), exec: call('exec') };
+  return Object.assign({}, scope, {
+    async transaction(executor) {
+      db.exec('BEGIN IMMEDIATE');
+      try {
+        const result = await executor(scope);
+        db.exec('COMMIT');
+        return result;
+      } catch (error) {
+        try {
+          db.exec('ROLLBACK');
+        } catch (_) {}
+        throw error;
+      }
+    },
+    close() {
+      try {
+        db.close();
+      } catch (_) {}
+    }
+  });
+}
+
+function modernSchema(db) {
+  return db.exec(`
+    CREATE TABLE devices (
+      deveui TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      type_id TEXT NOT NULL,
+      updated_at TEXT
+    );
+    CREATE INDEX idx_devices_type_id ON devices(type_id);
+    CREATE TABLE sync_link_state (
+      peer_node TEXT PRIMARY KEY,
+      linked INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE sync_outbox (
+      event_uuid TEXT PRIMARY KEY,
+      occurred_at TEXT NOT NULL,
+      delivered_at TEXT,
+      rejected_at TEXT
+    );
+    CREATE INDEX idx_sync_outbox_pending
+      ON sync_outbox(occurred_at)
+      WHERE delivered_at IS NULL AND rejected_at IS NULL;
+    CREATE TABLE sync_history_dirty_keys (
+      peer_node TEXT,
+      table_name TEXT,
+      row_key TEXT,
+      changed_at TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'pending',
+      PRIMARY KEY(peer_node, table_name, row_key)
+    );
+    CREATE TRIGGER trg_devices_updated_at
+    AFTER UPDATE ON devices
+    BEGIN
+      UPDATE devices SET updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+      WHERE deveui = NEW.deveui;
+    END;
+    INSERT INTO devices(deveui, name, type_id, updated_at)
+    VALUES ('0016C001F1000001', 'gateway', 'KIWI_SENSOR', '2026-07-05T00:00:00Z');
+    INSERT INTO sync_link_state(peer_node, linked) VALUES ('cloud', 1);
+  `);
+}
+
+function assertSyncFieldsNull(health) {
+  assert.strictEqual(health.sync_linked, null);
+  assert.strictEqual(health.sync_pending, null);
+  assert.strictEqual(health.sync_oldest_age_s, null);
+  assert.strictEqual(health.sync_rejected, null);
+  assert.strictEqual(health.sync_dirty_pending, null);
+}
+
+test('modern schema reports schema, sync, and disk health', async () => {
+  const db = makeFacadeShim();
+  try {
+    await modernSchema(db);
+    await db.exec(`
+      INSERT INTO sync_outbox(event_uuid, occurred_at, delivered_at, rejected_at)
+      VALUES ('delivered', '2026-07-05T00:00:00Z', '2026-07-05T00:00:01Z', NULL);
+    `);
+
+    const health = await gatherEdgeHealth(db, { timeoutMs: 1000, diskPath: os.tmpdir() });
+
+    assertPublicHealthShape(health);
+    assert.match(health.schema_sig, /^[0-9a-f]{16}$/);
+    assert.strictEqual(health.sync_linked, true);
+    assert.strictEqual(health.sync_pending, 0);
+    assert.strictEqual(health.sync_oldest_age_s, 0);
+    assert.strictEqual(health.sync_rejected, 0);
+    assert.strictEqual(health.sync_dirty_pending, 0);
+    assertDiskFreePct(health.disk_free_pct);
+  } finally {
+    db.close();
+  }
+});
+
+test('Uganda-shape schema resolves with null sync fields but keeps schema and disk metrics', async () => {
+  const db = makeFacadeShim();
+  try {
+    await db.exec(`
+      CREATE TABLE devices (
+        deveui TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        type_id TEXT NOT NULL
+      );
+      INSERT INTO devices(deveui, name, type_id)
+      VALUES ('0016C001F1000001', 'legacy', 'KIWI_SENSOR');
+    `);
+
+    const health = await gatherEdgeHealth(db, { timeoutMs: 1000, diskPath: os.tmpdir() });
+
+    assertPublicHealthShape(health);
+    assert.match(health.schema_sig, /^[0-9a-f]{16}$/);
+    assertDiskFreePct(health.disk_free_pct);
+    assertSyncFieldsNull(health);
+  } finally {
+    db.close();
+  }
+});
+
+test('sync backlog counters count pending, rejected, and dirty pending rows independently', async () => {
+  const db = makeFacadeShim();
+  try {
+    await modernSchema(db);
+    await db.exec(`
+      INSERT INTO sync_outbox(event_uuid, occurred_at, delivered_at, rejected_at)
+      VALUES
+        ('delivered', '2026-07-05T00:00:00Z', '2026-07-05T00:00:01Z', NULL),
+        ('pending-1', '2026-07-05T00:01:00Z', NULL, NULL),
+        ('pending-2', '2026-07-05T00:02:00Z', NULL, NULL),
+        ('rejected', '2026-07-05T00:03:00Z', NULL, '2026-07-05T00:03:01Z');
+      INSERT INTO sync_history_dirty_keys(peer_node, table_name, row_key, changed_at, status)
+      VALUES
+        ('cloud', 'device_data', 'pending-key', '2026-07-05T00:04:00Z', 'pending'),
+        ('cloud', 'device_data', 'done-key', '2026-07-05T00:05:00Z', 'done');
+    `);
+
+    const health = await gatherEdgeHealth(db, { timeoutMs: 1000, diskPath: os.tmpdir() });
+
+    assertPublicHealthShape(health);
+    assert.strictEqual(health.sync_pending, 2);
+    assert.strictEqual(health.sync_rejected, 1);
+    assert.strictEqual(health.sync_dirty_pending, 1);
+    assert(Number.isInteger(health.sync_oldest_age_s));
+  } finally {
+    db.close();
+  }
+});
+
+test('structural schema signature is stable and changes after an added column', async () => {
+  const db = makeFacadeShim();
+  try {
+    await modernSchema(db);
+
+    const first = await structuralSignature(db);
+    const second = await structuralSignature(db);
+    await db.exec('ALTER TABLE devices ADD COLUMN firmware_version TEXT;');
+    const afterAddColumn = await structuralSignature(db);
+
+    assert.match(first, /^[0-9a-f]{16}$/);
+    assert.strictEqual(second, first);
+    assert.notStrictEqual(afterAddColumn, first);
+  } finally {
+    db.close();
+  }
+});
+
+test('structural schema signature ignores trigger SQL formatting when trigger names match', async () => {
+  const compact = makeFacadeShim();
+  const formatted = makeFacadeShim();
+  try {
+    await compact.exec(`
+      CREATE TABLE devices (
+        deveui TEXT PRIMARY KEY,
+        updated_at TEXT
+      );
+      CREATE TABLE trigger_audit (
+        device_deveui TEXT NOT NULL
+      );
+      CREATE TRIGGER trg_devices_audit AFTER UPDATE ON devices BEGIN INSERT INTO trigger_audit(device_deveui) VALUES (NEW.deveui); END;
+    `);
+    await formatted.exec(`
+      CREATE TABLE devices (
+        deveui TEXT PRIMARY KEY,
+        updated_at TEXT
+      );
+      CREATE TABLE trigger_audit (
+        device_deveui TEXT NOT NULL
+      );
+      CREATE TRIGGER trg_devices_audit
+      AFTER UPDATE ON devices
+      BEGIN
+        INSERT INTO trigger_audit(device_deveui)
+        VALUES (NEW.deveui);
+      END;
+    `);
+
+    const compactSignature = await structuralSignature(compact);
+    const formattedSignature = await structuralSignature(formatted);
+
+    assert.strictEqual(formattedSignature, compactSignature);
+  } finally {
+    compact.close();
+    formatted.close();
+  }
+});
+
+test('structural schema signature changes when trigger name changes', async () => {
+  const first = makeFacadeShim();
+  const renamed = makeFacadeShim();
+  try {
+    const schema = (triggerName) => `
+      CREATE TABLE devices (
+        deveui TEXT PRIMARY KEY,
+        updated_at TEXT
+      );
+      CREATE TABLE trigger_audit (
+        device_deveui TEXT NOT NULL
+      );
+      CREATE TRIGGER ${triggerName}
+      AFTER UPDATE ON devices
+      BEGIN
+        INSERT INTO trigger_audit(device_deveui)
+        VALUES (NEW.deveui);
+      END;
+    `;
+    await first.exec(schema('trg_devices_audit'));
+    await renamed.exec(schema('trg_devices_audit_renamed'));
+
+    const firstSignature = await structuralSignature(first);
+    const renamedSignature = await structuralSignature(renamed);
+
+    assert.notStrictEqual(renamedSignature, firstSignature);
+  } finally {
+    first.close();
+    renamed.close();
+  }
+});
+
+test('hung database returns all-null health within timeout', async () => {
+  const pending = new Promise(() => {});
+  const hungDb = {
+    all() { return pending; },
+    get() { return pending; },
+    run() { return pending; },
+    exec() { return pending; }
+  };
+
+  const start = Date.now();
+  const health = await gatherEdgeHealth(hungDb, { timeoutMs: 50, diskPath: os.tmpdir() });
+  const elapsedMs = Date.now() - start;
+
+  assert.deepStrictEqual(health, ALL_NULL_HEALTH);
+  assert(elapsedMs < 500);
+});

--- a/scripts/test-health-helper.js
+++ b/scripts/test-health-helper.js
@@ -2,13 +2,24 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
 const os = require('node:os');
+const childProcess = require('node:child_process');
 const { DatabaseSync } = require('node:sqlite');
+
+const HEALTH_HELPER_MODULE =
+  '../conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper';
+const HEALTH_HELPER_FILE = require.resolve(HEALTH_HELPER_MODULE);
+
+function requireHealthHelperFresh() {
+  delete require.cache[HEALTH_HELPER_FILE];
+  return require(HEALTH_HELPER_MODULE);
+}
 
 const {
   gatherEdgeHealth,
   structuralSignature
-} = require('../conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-health-helper');
+} = requireHealthHelperFresh();
 
 const PUBLIC_HEALTH_KEYS = [
   'schema_sig',
@@ -313,4 +324,58 @@ test('hung database returns all-null health within timeout', async () => {
 
   assert.deepStrictEqual(health, ALL_NULL_HEALTH);
   assert(elapsedMs < 500);
+});
+
+test('disk df fallback is async, bounded, and cannot outlive gather timeout', async (t) => {
+  const diskPath = os.tmpdir();
+  const originalStatfsSync = fs.statfsSync;
+  const originalExecFile = childProcess.execFile;
+  const originalExecFileSync = childProcess.execFileSync;
+  let execFileCall = null;
+
+  fs.statfsSync = () => {
+    throw new Error('statfs unavailable');
+  };
+  childProcess.execFile = (...args) => {
+    execFileCall = args;
+    return { kill() {} };
+  };
+  childProcess.execFileSync = () => {
+    throw new Error('execFileSync fallback must not be used');
+  };
+
+  t.after(() => {
+    fs.statfsSync = originalStatfsSync;
+    childProcess.execFile = originalExecFile;
+    childProcess.execFileSync = originalExecFileSync;
+    delete require.cache[HEALTH_HELPER_FILE];
+  });
+
+  const db = makeFacadeShim();
+  try {
+    await modernSchema(db);
+    const { gatherEdgeHealth: gatherWithPatchedDependencies } = requireHealthHelperFresh();
+
+    const start = Date.now();
+    const health = await gatherWithPatchedDependencies(db, { timeoutMs: 50, diskPath });
+    const elapsedMs = Date.now() - start;
+
+    assert.deepStrictEqual(health, ALL_NULL_HEALTH);
+    assert(elapsedMs < 500);
+    assert(execFileCall, 'df fallback should use async execFile');
+    assert.strictEqual(execFileCall[0], 'df');
+    assert.deepStrictEqual(execFileCall[1], ['-kP', diskPath]);
+    assert.strictEqual(typeof execFileCall[2].timeout, 'number');
+    assert(execFileCall[2].timeout > 0);
+    assert.strictEqual(typeof execFileCall[2].maxBuffer, 'number');
+    assert(execFileCall[2].maxBuffer > 0);
+  } finally {
+    db.close();
+  }
+});
+
+test('disk df fallback source does not use synchronous child process collection', () => {
+  const source = fs.readFileSync(HEALTH_HELPER_FILE, 'utf8');
+
+  assert.doesNotMatch(source, /\bexecFileSync\b/);
 });

--- a/scripts/verify-heartbeat-health.js
+++ b/scripts/verify-heartbeat-health.js
@@ -28,16 +28,32 @@ const REQUIRED_GATHER_LIBS = [
 const PROFILES = [
   {
     name: 'bcm2712',
+    nodeRedRoot: path.join(
+      REPO_ROOT,
+      'conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red'
+    ),
     flowsPath: path.join(
       REPO_ROOT,
       'conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json'
     ),
+    seedPath: path.join(
+      REPO_ROOT,
+      'conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/98_osi_node_red_seed'
+    ),
   },
   {
     name: 'bcm2709',
+    nodeRedRoot: path.join(
+      REPO_ROOT,
+      'conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red'
+    ),
     flowsPath: path.join(
       REPO_ROOT,
       'conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json'
+    ),
+    seedPath: path.join(
+      REPO_ROOT,
+      'conf/full_raspberrypi_bcm27xx_bcm2709/files/etc/uci-defaults/98_osi_node_red_seed'
     ),
   },
 ];
@@ -81,6 +97,33 @@ function parseFlow(profile) {
     fail(profile.name, `failed to parse ${profile.flowsPath}: ${err.message}`);
     return null;
   }
+}
+
+function parseJsonFile(profile, label, filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (err) {
+    fail(profile, `failed to parse ${label} at ${filePath}: ${err.message}`);
+    return null;
+  }
+}
+
+function parseSeedHelperModules(profile, seedPath) {
+  let source;
+  try {
+    source = fs.readFileSync(seedPath, 'utf8');
+  } catch (err) {
+    fail(profile, `failed to read first-boot seed script at ${seedPath}: ${err.message}`);
+    return new Set();
+  }
+
+  const modules = new Set();
+  for (const match of source.matchAll(/for\s+module\s+in\s+([^;\n]+);\s+do/g)) {
+    for (const moduleName of match[1].trim().split(/\s+/)) {
+      if (moduleName) modules.add(moduleName);
+    }
+  }
+  return modules;
 }
 
 function sortedKeys(obj) {
@@ -368,6 +411,83 @@ function assertGatherNode(profile, gatherNode) {
   compileAsyncBody(profile, 'Gather Edge Health', gatherNode.func);
 }
 
+function assertExactObject(profile, label, actual, expected) {
+  assert(
+    profile,
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${label} expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+  );
+}
+
+function assertPackagedGatherLibs(profile, gatherNode) {
+  if (!gatherNode || !Array.isArray(gatherNode.libs)) return;
+
+  const moduleNames = [...new Set(
+    gatherNode.libs
+      .map((lib) => lib && lib.module)
+      .filter((moduleName) => typeof moduleName === 'string' && moduleName.length > 0)
+  )];
+  const packageJson = parseJsonFile(profile.name, 'node-red/package.json', path.join(profile.nodeRedRoot, 'package.json'));
+  const packageLock = parseJsonFile(profile.name, 'node-red/package-lock.json', path.join(profile.nodeRedRoot, 'package-lock.json'));
+  const seedModules = parseSeedHelperModules(profile.name, profile.seedPath);
+
+  for (const moduleName of moduleNames) {
+    assert(
+      profile.name,
+      packageJson && packageJson.dependencies && packageJson.dependencies[moduleName] === `file:${moduleName}`,
+      `node-red/package.json missing ${moduleName}: file:${moduleName}`
+    );
+
+    const lockRootDependencies = packageLock && packageLock.packages && packageLock.packages[''] && packageLock.packages[''].dependencies;
+    assert(
+      profile.name,
+      lockRootDependencies && lockRootDependencies[moduleName] === `file:${moduleName}`,
+      `node-red/package-lock.json root dependencies missing ${moduleName}: file:${moduleName}`
+    );
+
+    const lockPackages = packageLock && packageLock.packages;
+    assertExactObject(
+      profile.name,
+      `node-red/package-lock.json node_modules/${moduleName}`,
+      lockPackages && lockPackages[`node_modules/${moduleName}`],
+      { resolved: moduleName, link: true }
+    );
+    assertExactObject(
+      profile.name,
+      `node-red/package-lock.json ${moduleName}`,
+      lockPackages && lockPackages[moduleName],
+      { version: '1.0.0' }
+    );
+
+    const nodeModulePath = path.join(profile.nodeRedRoot, 'node_modules', moduleName);
+    let stat = null;
+    try {
+      stat = fs.lstatSync(nodeModulePath);
+    } catch (err) {
+      fail(profile.name, `node-red/node_modules/${moduleName} missing: ${err.message}`);
+    }
+    assert(
+      profile.name,
+      stat && stat.isSymbolicLink(),
+      `node-red/node_modules/${moduleName} must be a symlink`
+    );
+    if (stat && stat.isSymbolicLink()) {
+      const target = fs.readlinkSync(nodeModulePath);
+      assert(
+        profile.name,
+        target === `../${moduleName}`,
+        `node-red/node_modules/${moduleName} symlink target expected ../${moduleName}, got ${target}`
+      );
+    }
+
+    assert(
+      profile.name,
+      seedModules.has(moduleName),
+      `first-boot seed helper loop missing ${moduleName}`
+    );
+  }
+}
+
 function assertInjectWiring(profile, injectNode) {
   assert(profile, injectNode, `heartbeat inject node ${INJECT_ID} is missing`);
   if (!injectNode) return;
@@ -388,6 +508,7 @@ for (const { profile, parsed } of parsedProfiles) {
   if (!parsed) continue;
   assertBuildNode(profile.name, parsed.byId[BUILD_ID]);
   assertGatherNode(profile.name, parsed.byId[GATHER_ID]);
+  assertPackagedGatherLibs(profile, parsed.byId[GATHER_ID]);
   assertInjectWiring(profile.name, parsed.byId[INJECT_ID]);
 }
 

--- a/scripts/verify-heartbeat-health.js
+++ b/scripts/verify-heartbeat-health.js
@@ -1,0 +1,422 @@
+#!/usr/bin/env node
+// Guards the heartbeat flow split: Build Heartbeat must stay synchronous and
+// dependency-free, while Gather Edge Health owns helper-backed DB access.
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const BUILD_ID = '062a0f9bf66d9789';
+const GATHER_ID = '2a4f142e3e9b6d80';
+const INJECT_ID = '310dfe7cfe34a448';
+
+const REQUIRED_HEALTH_KEYS = [
+  'schema_sig',
+  'sync_linked',
+  'sync_pending',
+  'sync_oldest_age_s',
+  'sync_rejected',
+  'sync_dirty_pending',
+  'disk_free_pct',
+];
+
+const REQUIRED_GATHER_LIBS = [
+  { var: 'osiHealth', module: 'osi-health-helper' },
+  { var: 'osiDb', module: 'osi-db-helper' },
+];
+
+const PROFILES = [
+  {
+    name: 'bcm2712',
+    flowsPath: path.join(
+      REPO_ROOT,
+      'conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json'
+    ),
+  },
+  {
+    name: 'bcm2709',
+    flowsPath: path.join(
+      REPO_ROOT,
+      'conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json'
+    ),
+  },
+];
+
+const failures = [];
+
+function fail(profile, msg) {
+  failures.push(`${profile}: ${msg}`);
+}
+
+function assert(profile, condition, msg) {
+  if (!condition) fail(profile, msg);
+}
+
+function compilePlain(profile, label, func) {
+  try {
+    new Function(func);
+  } catch (err) {
+    fail(profile, `${label} does not compile as a plain function: ${err.message}`);
+  }
+}
+
+function compileAsyncBody(profile, label, func) {
+  try {
+    new Function(`return (async function(){\n${func}\n});`);
+  } catch (err) {
+    fail(profile, `${label} does not compile as an async function body: ${err.message}`);
+  }
+}
+
+function parseFlow(profile) {
+  try {
+    const raw = fs.readFileSync(profile.flowsPath, 'utf8');
+    const flows = JSON.parse(raw);
+    return {
+      raw,
+      flows,
+      byId: Object.fromEntries(flows.filter((node) => node.id).map((node) => [node.id, node])),
+    };
+  } catch (err) {
+    fail(profile.name, `failed to parse ${profile.flowsPath}: ${err.message}`);
+    return null;
+  }
+}
+
+function sortedKeys(obj) {
+  return Object.keys(obj).sort();
+}
+
+function sameStringArray(actual, expected) {
+  return JSON.stringify([...actual].sort()) === JSON.stringify([...expected].sort());
+}
+
+function assertHealthKeys(profile, label, health) {
+  assert(profile, health && typeof health === 'object', `Build Heartbeat ${label} payload.health is missing`);
+  if (!health || typeof health !== 'object') return false;
+  assert(
+    profile,
+    sameStringArray(sortedKeys(health), REQUIRED_HEALTH_KEYS),
+    `Build Heartbeat ${label} payload.health keys differ: ${JSON.stringify(sortedKeys(health))}`
+  );
+  return true;
+}
+
+function assertHealthMatches(profile, label, health, expected) {
+  if (!assertHealthKeys(profile, label, health)) return;
+  for (const key of REQUIRED_HEALTH_KEYS) {
+    assert(
+      profile,
+      health[key] === expected[key],
+      `Build Heartbeat ${label} health ${key} expected ${JSON.stringify(expected[key])}, got ${JSON.stringify(health[key])}`
+    );
+  }
+}
+
+function assertAllNullHealth(profile, label, health) {
+  if (!assertHealthKeys(profile, label, health)) return;
+  for (const key of REQUIRED_HEALTH_KEYS) {
+    assert(profile, health[key] === null, `Build Heartbeat ${label} health ${key} is not null`);
+  }
+}
+
+function fakeEnv() {
+  const values = {
+    DEVICE_EUI: 'ABCDEF1234567890',
+    DEVICE_TYPE: 'GATEWAY',
+    FIRMWARE_VERSION: 'test-fw',
+  };
+  return {
+    get(name) {
+      return values[name];
+    },
+  };
+}
+
+function fakeFs() {
+  return {
+    readFileSync() {
+      throw new Error('not available in verifier');
+    },
+    readdirSync() {
+      throw new Error('not available in verifier');
+    },
+    accessSync() {
+      throw new Error('not available in verifier');
+    },
+  };
+}
+
+function fakeOs() {
+  return {
+    totalmem() {
+      return 100;
+    },
+    freemem() {
+      return 25;
+    },
+    loadavg() {
+      return [0.12, 0.34, 0.56];
+    },
+  };
+}
+
+function runBuildHeartbeat(profile, buildNode, edgeHealth) {
+  const global = {
+    get(name) {
+      if (name === 'edge_health') return edgeHealth;
+      if (name === 'fs') return fakeFs();
+      if (name === 'os') return fakeOs();
+      return undefined;
+    },
+  };
+  const msg = {};
+  const fn = new Function('env', 'global', 'msg', buildNode.func);
+  const result = fn(fakeEnv(), global, msg);
+  const outbound = result || msg;
+  return {
+    msg: outbound,
+    payload: JSON.parse(outbound.payload),
+  };
+}
+
+function assertHasOwn(profile, label, obj, key) {
+  assert(
+    profile,
+    Object.prototype.hasOwnProperty.call(obj, key),
+    `Build Heartbeat ${label} payload missing ${key}`
+  );
+}
+
+function assertNormalHeartbeatMessage(profile, label, result) {
+  const outbound = result && result.msg;
+  const payload = result && result.payload;
+  assert(profile, outbound && outbound.topic === 'devices/ABCDEF1234567890/heartbeat', `Build Heartbeat ${label} msg.topic changed`);
+  assert(profile, outbound && outbound.qos === 1, `Build Heartbeat ${label} msg.qos changed`);
+  assert(profile, payload && typeof payload === 'object', `Build Heartbeat ${label} payload is not an object`);
+  if (!payload || typeof payload !== 'object') return;
+
+  const requiredPayloadKeys = [
+    'deviceEui',
+    'deviceType',
+    'firmwareVersion',
+    'timestamp',
+    'ip',
+    'cpu_temp_c',
+    'mem_percent',
+    'load_1',
+    'load_5',
+    'load_15',
+    'fan_available',
+    'fan_value',
+    'health',
+  ];
+  for (const key of requiredPayloadKeys) {
+    assertHasOwn(profile, label, payload, key);
+  }
+  assert(profile, payload.deviceEui === 'ABCDEF1234567890', `Build Heartbeat ${label} deviceEui changed`);
+  assert(profile, payload.deviceType === 'GATEWAY', `Build Heartbeat ${label} deviceType changed`);
+  assert(profile, payload.firmwareVersion === 'test-fw', `Build Heartbeat ${label} firmwareVersion changed`);
+  assert(profile, typeof payload.timestamp === 'string' && !Number.isNaN(Date.parse(payload.timestamp)), `Build Heartbeat ${label} timestamp is invalid`);
+  assert(profile, payload.ip === null, `Build Heartbeat ${label} ip should remain null in verifier`);
+  assert(profile, payload.mem_percent === 75, `Build Heartbeat ${label} mem_percent changed`);
+  assert(profile, payload.load_1 === 0.12, `Build Heartbeat ${label} load_1 changed`);
+  assert(profile, payload.load_5 === 0.34, `Build Heartbeat ${label} load_5 changed`);
+  assert(profile, payload.load_15 === 0.56, `Build Heartbeat ${label} load_15 changed`);
+  assert(profile, Object.prototype.hasOwnProperty.call(payload, 'cpu_temp_c'), `Build Heartbeat ${label} cpu_temp_c missing`);
+  assert(profile, Object.prototype.hasOwnProperty.call(payload, 'fan_available'), `Build Heartbeat ${label} fan_available missing`);
+  assert(profile, Object.prototype.hasOwnProperty.call(payload, 'fan_value'), `Build Heartbeat ${label} fan_value missing`);
+}
+
+function assertHealthPayload(profile, buildNode) {
+  const freshHealth = {
+    at: Date.now(),
+    schema_sig: 'sig',
+    sync_linked: true,
+    sync_pending: 3,
+    sync_oldest_age_s: 42,
+    sync_rejected: 1,
+    sync_dirty_pending: 2,
+    disk_free_pct: 87,
+    ignored_extra_key: 'must not leak',
+  };
+
+  try {
+    const freshResult = runBuildHeartbeat(profile, buildNode, freshHealth);
+    assertNormalHeartbeatMessage(profile, 'fresh', freshResult);
+    assertHealthMatches(profile, 'fresh', freshResult.payload && freshResult.payload.health, freshHealth);
+
+    const emptyFreshResult = runBuildHeartbeat(profile, buildNode, { at: Date.now() });
+    assertAllNullHealth(profile, 'fresh empty', emptyFreshResult.payload && emptyFreshResult.payload.health);
+
+    const partialResult = runBuildHeartbeat(profile, buildNode, {
+      at: Date.now(),
+      sync_linked: false,
+      sync_pending: 0,
+      disk_free_pct: 0,
+    });
+    assertHealthMatches(profile, 'fresh partial', partialResult.payload && partialResult.payload.health, {
+      schema_sig: null,
+      sync_linked: false,
+      sync_pending: 0,
+      sync_oldest_age_s: null,
+      sync_rejected: null,
+      sync_dirty_pending: null,
+      disk_free_pct: 0,
+    });
+
+    const stringResult = runBuildHeartbeat(profile, buildNode, 'malformed-health');
+    assertAllNullHealth(profile, 'primitive string', stringResult.payload && stringResult.payload.health);
+
+    const numberResult = runBuildHeartbeat(profile, buildNode, 12345);
+    assertAllNullHealth(profile, 'primitive number', numberResult.payload && numberResult.payload.health);
+
+    const invalidAtResult = runBuildHeartbeat(profile, buildNode, {
+      ...freshHealth,
+      at: 'not-a-timestamp',
+    });
+    assertAllNullHealth(profile, 'invalid at', invalidAtResult.payload && invalidAtResult.payload.health);
+
+    const staleResult = runBuildHeartbeat(profile, buildNode, {
+      ...freshHealth,
+      at: Date.now() - 181000,
+    });
+    assertAllNullHealth(profile, 'stale', staleResult.payload && staleResult.payload.health);
+
+    const invalidValuesResult = runBuildHeartbeat(profile, buildNode, {
+      at: Date.now(),
+      schema_sig: function invalidHealthFunction() {},
+      sync_linked: Symbol('invalid-health-symbol'),
+      sync_pending: BigInt(1),
+      sync_oldest_age_s: { invalid: true },
+      sync_rejected: ['invalid'],
+      sync_dirty_pending: NaN,
+      disk_free_pct: Infinity,
+    });
+    assertAllNullHealth(profile, 'fresh invalid values', invalidValuesResult.payload && invalidValuesResult.payload.health);
+
+    const negativeInfinityResult = runBuildHeartbeat(profile, buildNode, {
+      ...freshHealth,
+      disk_free_pct: -Infinity,
+    });
+    assert(
+      profile,
+      negativeInfinityResult.payload && negativeInfinityResult.payload.health && negativeInfinityResult.payload.health.disk_free_pct === null,
+      'Build Heartbeat fresh negative infinity health disk_free_pct is not null'
+    );
+  } catch (err) {
+    fail(profile, `Build Heartbeat payload execution failed: ${err.message}`);
+  }
+}
+
+function assertBuildNode(profile, buildNode) {
+  assert(profile, buildNode, `Build Heartbeat node ${BUILD_ID} is missing`);
+  if (!buildNode) return;
+
+  assert(profile, buildNode.type === 'function', 'Build Heartbeat is not a function node');
+  assert(profile, buildNode.name === 'Build Heartbeat', 'Build Heartbeat name changed');
+  assert(
+    profile,
+    JSON.stringify(buildNode.libs) === JSON.stringify([]),
+    `Build Heartbeat.libs must be []; got ${JSON.stringify(buildNode.libs)}`
+  );
+  assert(profile, typeof buildNode.func === 'string', 'Build Heartbeat.func is missing');
+  if (typeof buildNode.func !== 'string') return;
+
+  assert(
+    profile,
+    (buildNode.func.match(/global\.get\(['"]edge_health['"]\)/g) || []).length === 1,
+    "Build Heartbeat must read health once via global.get('edge_health')"
+  );
+  assert(profile, !buildNode.func.includes('require'), 'Build Heartbeat must not contain require');
+  assert(profile, !buildNode.func.includes('await'), 'Build Heartbeat must not contain await');
+  assert(profile, /\bmsg\.topic\s*=/.test(buildNode.func), 'Build Heartbeat must assign msg.topic');
+  assert(profile, /\bmsg\.payload\s*=/.test(buildNode.func), 'Build Heartbeat must assign msg.payload');
+  compilePlain(profile, 'Build Heartbeat', buildNode.func);
+  assertHealthPayload(profile, buildNode);
+}
+
+function hasRequiredGatherLibs(libs) {
+  if (!Array.isArray(libs)) return false;
+  return REQUIRED_GATHER_LIBS.every((required) => (
+    libs.some((lib) => lib && lib.var === required.var && lib.module === required.module)
+  ));
+}
+
+function assertGatherNode(profile, gatherNode) {
+  assert(profile, gatherNode, `Gather Edge Health node ${GATHER_ID} is missing`);
+  if (!gatherNode) return;
+
+  assert(profile, gatherNode.type === 'function', 'Gather Edge Health is not a function node');
+  assert(profile, gatherNode.name === 'Gather Edge Health', 'Gather Edge Health name changed');
+  assert(
+    profile,
+    hasRequiredGatherLibs(gatherNode.libs),
+    `Gather Edge Health.libs missing required helper libs; got ${JSON.stringify(gatherNode.libs)}`
+  );
+  assert(profile, typeof gatherNode.func === 'string', 'Gather Edge Health.func is missing');
+  if (typeof gatherNode.func !== 'string') return;
+
+  assert(profile, gatherNode.func.includes("global.set('edge_health'"), "Gather Edge Health must set global edge_health");
+  assert(
+    profile,
+    gatherNode.func.includes("new osiDb.Database('/data/db/farming.db')"),
+    'Gather Edge Health must open /data/db/farming.db via osiDb.Database'
+  );
+  assert(profile, gatherNode.func.includes('.close('), 'Gather Edge Health must close the DB handle');
+  assert(profile, /\bfinally\s*{[\s\S]*_db\.close\s*\(\s*\(\s*\)\s*=>\s*{}\s*\)/.test(gatherNode.func), 'Gather Edge Health must close _db in a finally block');
+  compileAsyncBody(profile, 'Gather Edge Health', gatherNode.func);
+}
+
+function assertInjectWiring(profile, injectNode) {
+  assert(profile, injectNode, `heartbeat inject node ${INJECT_ID} is missing`);
+  if (!injectNode) return;
+
+  assert(profile, injectNode.type === 'inject', 'heartbeat tick is not an inject node');
+  assert(profile, injectNode.name === 'Every 60s', 'heartbeat inject name changed');
+  assert(profile, injectNode.repeat === '60', `heartbeat inject repeat must be "60"; got ${JSON.stringify(injectNode.repeat)}`);
+  const firstOutput = Array.isArray(injectNode.wires) && Array.isArray(injectNode.wires[0])
+    ? injectNode.wires[0]
+    : [];
+  assert(profile, firstOutput.includes(BUILD_ID), `heartbeat inject does not wire to Build Heartbeat ${BUILD_ID}`);
+  assert(profile, firstOutput.includes(GATHER_ID), `heartbeat inject does not wire to Gather Edge Health ${GATHER_ID}`);
+}
+
+const parsedProfiles = PROFILES.map((profile) => ({ profile, parsed: parseFlow(profile) }));
+
+for (const { profile, parsed } of parsedProfiles) {
+  if (!parsed) continue;
+  assertBuildNode(profile.name, parsed.byId[BUILD_ID]);
+  assertGatherNode(profile.name, parsed.byId[GATHER_ID]);
+  assertInjectWiring(profile.name, parsed.byId[INJECT_ID]);
+}
+
+const [canonical, mirror] = parsedProfiles;
+if (canonical && canonical.parsed && mirror && mirror.parsed) {
+  assert('profiles', canonical.parsed.raw === mirror.parsed.raw, 'flows.json differs byte-for-byte between bcm2712 and bcm2709');
+  const canonicalBuild = canonical.parsed.byId[BUILD_ID];
+  const mirrorBuild = mirror.parsed.byId[BUILD_ID];
+  const canonicalGather = canonical.parsed.byId[GATHER_ID];
+  const mirrorGather = mirror.parsed.byId[GATHER_ID];
+  if (canonicalBuild && mirrorBuild) {
+    assert('profiles', canonicalBuild.func === mirrorBuild.func, 'Build Heartbeat function bodies differ between bcm2712 and bcm2709');
+  }
+  if (canonicalGather && mirrorGather) {
+    assert('profiles', canonicalGather.func === mirrorGather.func, 'Gather Edge Health function bodies differ between bcm2712 and bcm2709');
+    assert(
+      'profiles',
+      JSON.stringify(canonicalGather.libs) === JSON.stringify(mirrorGather.libs),
+      'Gather Edge Health libs differ between bcm2712 and bcm2709'
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`FAIL: ${failures.length} heartbeat health flow guard failure(s):`);
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('OK: heartbeat health flow guard passed for bcm2712 and bcm2709');


### PR DESCRIPTION
## Summary

Adds edge fleet-observability health to the existing MQTT heartbeat without putting the heartbeat publisher at risk:

- adds `osi-health-helper` with structural schema signatures, sync counters, dirty-key counts, and disk-free collection
- wires a separate `Gather Edge Health` function node into the existing 60s heartbeat inject
- keeps `Build Heartbeat` libs-free and synchronous, reading only `global.get('edge_health')`
- installs the helper across runtime package files, node_modules symlink, first-boot seed loop, deploy fetches, and CI

## Node IDs

- Existing heartbeat inject: `310dfe7cfe34a448`
- Existing `Build Heartbeat`: `062a0f9bf66d9789`
- New `Gather Edge Health`: `2a4f142e3e9b6d80`

## Profile Parity

`bcm2712` and `bcm2709` are byte-identical for the edited runtime payloads. `verify-profile-parity.js` passed after the helper, symlink, package, seed, and flow changes.

## Related Work

- Companion server PR: Open-Smart-Irrigation/osi-server#48
- Follow-up history-sync issue filed: #99

## Verification

- `node --test scripts/test-health-helper.js` -> 9/9 pass
- `node scripts/verify-heartbeat-health.js` -> OK for `bcm2712` and `bcm2709`
- `node scripts/test-flows-wiring.js` -> PASS
- `node scripts/verify-profile-parity.js` -> All parity checks passed
- `node scripts/verify-sync-flow.js` -> Sync flow verification passed and chained parity passed
- `git diff --check origin/main..HEAD` -> no output

## Rollout Note

No deployment is included. Rollout remains operator-driven: deploy a demo gateway first, verify heartbeat `health`, then harvest schema signatures for the server allowlist before broader rollout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Gather Edge Health” to Node-RED and included edge-health details in heartbeat payloads.
  * Introduced an `osi-health-helper` module to compute schema signatures and collect DB sync and disk availability metrics.
  * Updated deployment/first-boot seeding to ship the new helper.
* **Bug Fixes**
  * Heartbeat health now reliably returns `null` health fields when data is stale, malformed, or unavailable.
* **Tests**
  * Expanded helper and heartbeat health verification with schema-variant, fallback, and timeout coverage.
* **Chores**
  * Enhanced migrations workflow with additional health checks during migration runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->