### PR TITLE
feat: surface unhandled flow errors

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -19,10 +19,11 @@ jobs:
       - name: Install sqlite3 CLI
         run: sudo apt-get update && sudo apt-get install -y sqlite3
       - run: node --test lib/osi-migrate/__tests__/*.test.js
-      - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js
+      - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js scripts/verify-no-new-silent-catch.test.js
       - run: node scripts/test-history-helper.js
       - run: node scripts/verify-migrations.js
       - run: node scripts/verify-seed-replay.js
+      - run: node scripts/verify-no-new-silent-catch.js
       - run: node scripts/verify-runtime-schema-parity.js
       - run: node scripts/verify-devices-rebuild-fence.js
       - run: node --test scripts/rehearse-devices-rebuild.test.js

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install sqlite3 CLI
         run: sudo apt-get update && sudo apt-get install -y sqlite3
       - run: node --test lib/osi-migrate/__tests__/*.test.js
-      - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js scripts/verify-no-new-silent-catch.test.js
+      - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js scripts/verify-no-new-silent-catch.test.js scripts/test-error-recording-flow.js
       - run: node scripts/test-history-helper.js
       - run: node scripts/verify-migrations.js
       - run: node scripts/verify-seed-replay.js

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,7 @@ Full Raspberry Pi image workflow: [docs/build/rpi5-full-osi-image.md](docs/build
 
 ```bash
 node scripts/verify-sync-flow.js              # sync implementation
+node scripts/verify-no-new-silent-catch.js    # empty catch ratchet
 node scripts/verify-strega-gen1.js            # STREGA Gen1 decoder
 node scripts/verify-lorain-codec.js           # Aqua-Scope LoRain decoder
 node scripts/verify-communication-contract.js # contract preflight
@@ -230,6 +231,8 @@ cd web/react-gui && npm run build             # frontend build
 - Commit prefixes: `feat:` for new features, `fix:` for bug fixes, `chore:` / `docs:` / `release:` as appropriate.
 - BusyBox case conversion: use `tr 'abcdef' 'ABCDEF'`; `tr '[:lower:]' '[:upper:]'` is unreliable on the Pi image.
 - Treat `flows.json` as the main edge backend — most API and scheduler changes live there.
+- Empty `catch` blocks in `flows.json`: `scripts/verify-no-new-silent-catch.js` ratchets the maintained-profile baseline. When touching any function node, convert empty `catch(_){}` / `catch(e){}` blocks in that node to a visible warning such as `catch (e) { node.warn('<node/context>: ' + (e && e.message ? e.message : e)); }`; new function code must not swallow errors silently. Keep new function-node `libs: []`.
+- Error-counter heartbeat fields: maintained profiles now have catch nodes wired to `Record Error` (`global.error_counts`). Do not add heartbeat `errors_total` / `errors_last_at` fields until the flow has a `Gather Edge Health` node; that node is absent in the current maintained-profile baseline, so heartbeat surfacing is intentionally skipped.
 - `MqttPublisherService` on the cloud is deprecated (kept for potential future use); all cloud→edge commands are REST.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,7 +231,7 @@ cd web/react-gui && npm run build             # frontend build
 - Commit prefixes: `feat:` for new features, `fix:` for bug fixes, `chore:` / `docs:` / `release:` as appropriate.
 - BusyBox case conversion: use `tr 'abcdef' 'ABCDEF'`; `tr '[:lower:]' '[:upper:]'` is unreliable on the Pi image.
 - Treat `flows.json` as the main edge backend — most API and scheduler changes live there.
-- Empty `catch` blocks in `flows.json`: `scripts/verify-no-new-silent-catch.js` ratchets the maintained-profile baseline. When touching any function node, convert empty `catch(_){}` / `catch(e){}` blocks in that node to a visible warning such as `catch (e) { node.warn('<node/context>: ' + (e && e.message ? e.message : e)); }`; new function code must not swallow errors silently. Keep new function-node `libs: []`.
+- Empty `catch` blocks in `flows.json`: `scripts/verify-no-new-silent-catch.js` ratchets the maintained-profile baseline. When touching any function node, convert empty `catch(_){}` / `catch(e){}` / `catch {}` blocks in that node to a visible warning such as `catch (e) { node.warn('<node/context>: ' + (e && e.message ? e.message : e)); }`; new function code must not swallow errors silently. Keep new function-node `libs: []`.
 - Error-counter heartbeat fields: maintained profiles now have catch nodes wired to `Record Error` (`global.error_counts`). Do not add heartbeat `errors_total` / `errors_last_at` fields until the flow has a `Gather Edge Health` node; that node is absent in the current maintained-profile baseline, so heartbeat surfacing is intentionally skipped.
 - `MqttPublisherService` on the cloud is deprecated (kept for potential future use); all cloud→edge commands are REST.
 

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
@@ -10179,6 +10179,217 @@
     ]
   },
   {
+    "id": "record-error-link-out-auth",
+    "type": "link out",
+    "z": "auth-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1170,
+    "y": 540,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-device-api",
+    "type": "link out",
+    "z": "device-api-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1230,
+    "y": 2450,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-scheduler",
+    "type": "link out",
+    "z": "c2b43a6c6e7d2c11",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1070,
+    "y": 780,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-kiwi",
+    "type": "link out",
+    "z": "49e87447205bb849",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1620,
+    "y": 380,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-strega",
+    "type": "link out",
+    "z": "8a18de184886c8a8",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1420,
+    "y": 500,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-field-testing",
+    "type": "link out",
+    "z": "a3f03829ad106e10",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1070,
+    "y": 600,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-download",
+    "type": "link out",
+    "z": "7d4f3e45f4b0d111",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 420,
+    "y": 300,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-lsn50",
+    "type": "link out",
+    "z": "lsn50-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1580,
+    "y": 540,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-system-admin",
+    "type": "link out",
+    "z": "sys-admin-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 660,
+    "y": 480,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-account-link",
+    "type": "link out",
+    "z": "account-link-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 3180,
+    "y": 540,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-dendro-analytics",
+    "type": "link out",
+    "z": "dendro-analytics-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 900,
+    "y": 900,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-s2120",
+    "type": "link out",
+    "z": "s2120-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 660,
+    "y": 260,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-history-api",
+    "type": "link out",
+    "z": "history-api-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 900,
+    "y": 1060,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-lorain",
+    "type": "link out",
+    "z": "lorain-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 900,
+    "y": 240,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-in",
+    "type": "link in",
+    "z": "93b1537a596e0e6d",
+    "name": "Record Error (link)",
+    "links": [
+      "record-error-link-out-auth",
+      "record-error-link-out-device-api",
+      "record-error-link-out-scheduler",
+      "record-error-link-out-kiwi",
+      "record-error-link-out-strega",
+      "record-error-link-out-field-testing",
+      "record-error-link-out-download",
+      "record-error-link-out-lsn50",
+      "record-error-link-out-system-admin",
+      "record-error-link-out-account-link",
+      "record-error-link-out-dendro-analytics",
+      "record-error-link-out-s2120",
+      "record-error-link-out-history-api",
+      "record-error-link-out-lorain"
+    ],
+    "x": 1590,
+    "y": 1340,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
     "id": "record-error-catch-auth",
     "type": "catch",
     "z": "auth-tab",
@@ -10189,7 +10400,7 @@
     "y": 540,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-auth"
       ]
     ]
   },
@@ -10204,7 +10415,7 @@
     "y": 2450,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-device-api"
       ]
     ]
   },
@@ -10219,7 +10430,7 @@
     "y": 780,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-scheduler"
       ]
     ]
   },
@@ -10234,7 +10445,7 @@
     "y": 380,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-kiwi"
       ]
     ]
   },
@@ -10249,7 +10460,7 @@
     "y": 500,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-strega"
       ]
     ]
   },
@@ -10264,7 +10475,7 @@
     "y": 600,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-field-testing"
       ]
     ]
   },
@@ -10279,7 +10490,7 @@
     "y": 300,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-download"
       ]
     ]
   },
@@ -10309,7 +10520,7 @@
     "y": 540,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-lsn50"
       ]
     ]
   },
@@ -10324,7 +10535,7 @@
     "y": 480,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-system-admin"
       ]
     ]
   },
@@ -10339,7 +10550,7 @@
     "y": 540,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-account-link"
       ]
     ]
   },
@@ -10354,7 +10565,7 @@
     "y": 900,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-dendro-analytics"
       ]
     ]
   },
@@ -10369,7 +10580,7 @@
     "y": 260,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-s2120"
       ]
     ]
   },
@@ -10384,7 +10595,7 @@
     "y": 1060,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-history-api"
       ]
     ]
   },
@@ -10399,7 +10610,7 @@
     "y": 240,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-lorain"
       ]
     ]
   }

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
@@ -10160,5 +10160,247 @@
         "history-api-response"
       ]
     ]
+  },
+  {
+    "id": "record-error-fn",
+    "type": "function",
+    "z": "93b1537a596e0e6d",
+    "name": "Record Error",
+    "func": "const now = Date.now();\nconst err = msg.error || msg._error || {};\nconst source = err.source || msg._error?.source || {};\nconst rawMessage = err.message || msg.payload?.message || String(err || 'unknown error');\nconst message = String(rawMessage || 'unknown error').slice(0, 120);\nconst src = String(source.name || source.id || source.type || msg.topic || 'unknown');\n\nconst counts = global.get('error_counts') || {};\nconst previousTotal = Number(counts.total || 0);\ncounts.total = Number.isFinite(previousTotal) ? previousTotal + 1 : 1;\ncounts.last = { at: now, src, message };\nglobal.set('error_counts', counts);\n\nconst limitMs = 60000;\nconst warned = flow.get('record_error_warned') || {};\nfor (const key of Object.keys(warned)) {\n  if (now - Number(warned[key] || 0) > limitMs * 10) {\n    delete warned[key];\n  }\n}\n\nconst lastWarned = Number(warned[message] || 0);\nif (!lastWarned || now - lastWarned >= limitMs) {\n  warned[message] = now;\n  node.warn(src + ': ' + message);\n}\nflow.set('record_error_warned', warned);\n\nreturn null;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 1750,
+    "y": 1340,
+    "wires": [
+      []
+    ]
+  },
+  {
+    "id": "record-error-catch-auth",
+    "type": "catch",
+    "z": "auth-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1030,
+    "y": 540,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-device-api",
+    "type": "catch",
+    "z": "device-api-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1090,
+    "y": 2450,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-scheduler",
+    "type": "catch",
+    "z": "c2b43a6c6e7d2c11",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 930,
+    "y": 780,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-kiwi",
+    "type": "catch",
+    "z": "49e87447205bb849",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1480,
+    "y": 380,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-strega",
+    "type": "catch",
+    "z": "8a18de184886c8a8",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1280,
+    "y": 500,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-field-testing",
+    "type": "catch",
+    "z": "a3f03829ad106e10",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 930,
+    "y": 600,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-download",
+    "type": "catch",
+    "z": "7d4f3e45f4b0d111",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 280,
+    "y": 300,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-cloud-sync",
+    "type": "catch",
+    "z": "93b1537a596e0e6d",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1530,
+    "y": 1340,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-lsn50",
+    "type": "catch",
+    "z": "lsn50-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1440,
+    "y": 540,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-system-admin",
+    "type": "catch",
+    "z": "sys-admin-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 520,
+    "y": 480,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-account-link",
+    "type": "catch",
+    "z": "account-link-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 3040,
+    "y": 540,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-dendro-analytics",
+    "type": "catch",
+    "z": "dendro-analytics-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 760,
+    "y": 900,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-s2120",
+    "type": "catch",
+    "z": "s2120-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 520,
+    "y": 260,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-history-api",
+    "type": "catch",
+    "z": "history-api-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 760,
+    "y": 1060,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-lorain",
+    "type": "catch",
+    "z": "lorain-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 760,
+    "y": 240,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
   }
 ]

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
@@ -10179,6 +10179,217 @@
     ]
   },
   {
+    "id": "record-error-link-out-auth",
+    "type": "link out",
+    "z": "auth-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1170,
+    "y": 540,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-device-api",
+    "type": "link out",
+    "z": "device-api-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1230,
+    "y": 2450,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-scheduler",
+    "type": "link out",
+    "z": "c2b43a6c6e7d2c11",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1070,
+    "y": 780,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-kiwi",
+    "type": "link out",
+    "z": "49e87447205bb849",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1620,
+    "y": 380,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-strega",
+    "type": "link out",
+    "z": "8a18de184886c8a8",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1420,
+    "y": 500,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-field-testing",
+    "type": "link out",
+    "z": "a3f03829ad106e10",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1070,
+    "y": 600,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-download",
+    "type": "link out",
+    "z": "7d4f3e45f4b0d111",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 420,
+    "y": 300,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-lsn50",
+    "type": "link out",
+    "z": "lsn50-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 1580,
+    "y": 540,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-system-admin",
+    "type": "link out",
+    "z": "sys-admin-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 660,
+    "y": 480,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-account-link",
+    "type": "link out",
+    "z": "account-link-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 3180,
+    "y": 540,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-dendro-analytics",
+    "type": "link out",
+    "z": "dendro-analytics-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 900,
+    "y": 900,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-s2120",
+    "type": "link out",
+    "z": "s2120-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 660,
+    "y": 260,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-history-api",
+    "type": "link out",
+    "z": "history-api-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 900,
+    "y": 1060,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-out-lorain",
+    "type": "link out",
+    "z": "lorain-tab",
+    "name": "Record Error (link)",
+    "mode": "link",
+    "links": [
+      "record-error-link-in"
+    ],
+    "x": 900,
+    "y": 240,
+    "wires": []
+  },
+  {
+    "id": "record-error-link-in",
+    "type": "link in",
+    "z": "93b1537a596e0e6d",
+    "name": "Record Error (link)",
+    "links": [
+      "record-error-link-out-auth",
+      "record-error-link-out-device-api",
+      "record-error-link-out-scheduler",
+      "record-error-link-out-kiwi",
+      "record-error-link-out-strega",
+      "record-error-link-out-field-testing",
+      "record-error-link-out-download",
+      "record-error-link-out-lsn50",
+      "record-error-link-out-system-admin",
+      "record-error-link-out-account-link",
+      "record-error-link-out-dendro-analytics",
+      "record-error-link-out-s2120",
+      "record-error-link-out-history-api",
+      "record-error-link-out-lorain"
+    ],
+    "x": 1590,
+    "y": 1340,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
     "id": "record-error-catch-auth",
     "type": "catch",
     "z": "auth-tab",
@@ -10189,7 +10400,7 @@
     "y": 540,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-auth"
       ]
     ]
   },
@@ -10204,7 +10415,7 @@
     "y": 2450,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-device-api"
       ]
     ]
   },
@@ -10219,7 +10430,7 @@
     "y": 780,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-scheduler"
       ]
     ]
   },
@@ -10234,7 +10445,7 @@
     "y": 380,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-kiwi"
       ]
     ]
   },
@@ -10249,7 +10460,7 @@
     "y": 500,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-strega"
       ]
     ]
   },
@@ -10264,7 +10475,7 @@
     "y": 600,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-field-testing"
       ]
     ]
   },
@@ -10279,7 +10490,7 @@
     "y": 300,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-download"
       ]
     ]
   },
@@ -10309,7 +10520,7 @@
     "y": 540,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-lsn50"
       ]
     ]
   },
@@ -10324,7 +10535,7 @@
     "y": 480,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-system-admin"
       ]
     ]
   },
@@ -10339,7 +10550,7 @@
     "y": 540,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-account-link"
       ]
     ]
   },
@@ -10354,7 +10565,7 @@
     "y": 900,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-dendro-analytics"
       ]
     ]
   },
@@ -10369,7 +10580,7 @@
     "y": 260,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-s2120"
       ]
     ]
   },
@@ -10384,7 +10595,7 @@
     "y": 1060,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-history-api"
       ]
     ]
   },
@@ -10399,7 +10610,7 @@
     "y": 240,
     "wires": [
       [
-        "record-error-fn"
+        "record-error-link-out-lorain"
       ]
     ]
   }

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
@@ -10160,5 +10160,247 @@
         "history-api-response"
       ]
     ]
+  },
+  {
+    "id": "record-error-fn",
+    "type": "function",
+    "z": "93b1537a596e0e6d",
+    "name": "Record Error",
+    "func": "const now = Date.now();\nconst err = msg.error || msg._error || {};\nconst source = err.source || msg._error?.source || {};\nconst rawMessage = err.message || msg.payload?.message || String(err || 'unknown error');\nconst message = String(rawMessage || 'unknown error').slice(0, 120);\nconst src = String(source.name || source.id || source.type || msg.topic || 'unknown');\n\nconst counts = global.get('error_counts') || {};\nconst previousTotal = Number(counts.total || 0);\ncounts.total = Number.isFinite(previousTotal) ? previousTotal + 1 : 1;\ncounts.last = { at: now, src, message };\nglobal.set('error_counts', counts);\n\nconst limitMs = 60000;\nconst warned = flow.get('record_error_warned') || {};\nfor (const key of Object.keys(warned)) {\n  if (now - Number(warned[key] || 0) > limitMs * 10) {\n    delete warned[key];\n  }\n}\n\nconst lastWarned = Number(warned[message] || 0);\nif (!lastWarned || now - lastWarned >= limitMs) {\n  warned[message] = now;\n  node.warn(src + ': ' + message);\n}\nflow.set('record_error_warned', warned);\n\nreturn null;",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 1750,
+    "y": 1340,
+    "wires": [
+      []
+    ]
+  },
+  {
+    "id": "record-error-catch-auth",
+    "type": "catch",
+    "z": "auth-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1030,
+    "y": 540,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-device-api",
+    "type": "catch",
+    "z": "device-api-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1090,
+    "y": 2450,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-scheduler",
+    "type": "catch",
+    "z": "c2b43a6c6e7d2c11",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 930,
+    "y": 780,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-kiwi",
+    "type": "catch",
+    "z": "49e87447205bb849",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1480,
+    "y": 380,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-strega",
+    "type": "catch",
+    "z": "8a18de184886c8a8",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1280,
+    "y": 500,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-field-testing",
+    "type": "catch",
+    "z": "a3f03829ad106e10",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 930,
+    "y": 600,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-download",
+    "type": "catch",
+    "z": "7d4f3e45f4b0d111",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 280,
+    "y": 300,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-cloud-sync",
+    "type": "catch",
+    "z": "93b1537a596e0e6d",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1530,
+    "y": 1340,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-lsn50",
+    "type": "catch",
+    "z": "lsn50-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 1440,
+    "y": 540,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-system-admin",
+    "type": "catch",
+    "z": "sys-admin-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 520,
+    "y": 480,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-account-link",
+    "type": "catch",
+    "z": "account-link-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 3040,
+    "y": 540,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-dendro-analytics",
+    "type": "catch",
+    "z": "dendro-analytics-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 760,
+    "y": 900,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-s2120",
+    "type": "catch",
+    "z": "s2120-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 520,
+    "y": 260,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-history-api",
+    "type": "catch",
+    "z": "history-api-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 760,
+    "y": 1060,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
+  },
+  {
+    "id": "record-error-catch-lorain",
+    "type": "catch",
+    "z": "lorain-tab",
+    "name": "Catch unhandled errors",
+    "scope": null,
+    "uncaught": false,
+    "x": 760,
+    "y": 240,
+    "wires": [
+      [
+        "record-error-fn"
+      ]
+    ]
   }
 ]

--- a/scripts/fixtures/silent-catch-baseline.json
+++ b/scripts/fixtures/silent-catch-baseline.json
@@ -1,0 +1,15 @@
+{
+  "description": "Ratchet baseline for empty catch blocks in maintained Node-RED function nodes. Update counts downward in the same commit that removes silent catches.",
+  "generatedFrom": "origin/main 22cffe6d",
+  "pattern": "catch\\s*\\(\\s*\\w*\\s*\\)\\s*\\{\\s*\\}",
+  "profiles": {
+    "bcm2712": {
+      "path": "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json",
+      "silentCatchCount": 247
+    },
+    "bcm2709": {
+      "path": "conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json",
+      "silentCatchCount": 247
+    }
+  }
+}

--- a/scripts/fixtures/silent-catch-baseline.json
+++ b/scripts/fixtures/silent-catch-baseline.json
@@ -1,7 +1,7 @@
 {
   "description": "Ratchet baseline for empty catch blocks in maintained Node-RED function nodes. Update counts downward in the same commit that removes silent catches.",
-  "generatedFrom": "origin/main 22cffe6d",
-  "pattern": "catch\\s*(?:\\(\\s*\\w*\\s*\\))?\\s*\\{\\s*\\}",
+  "generatedFrom": "feat/surface-swallowed-errors 3bb12e08 (regenerated with broadened detector: comment-only/semicolon-only/destructured catch bodies, empty promise .catch(), and initialize/finalize fields; count unchanged at 247/247)",
+  "pattern": "catch\\s*(?:\\([^)]*\\))?\\s*\\{(?:\\s|;|//[^\\n]*|/\\*[\\s\\S]*?\\*/)*\\}  |  \\.catch\\s*\\(\\s*(?:(?:\\([^)]*\\)|[A-Za-z_$][\\w$]*)\\s*=>\\s*\\{(?:\\s|;|//[^\\n]*|/\\*[\\s\\S]*?\\*/)*\\}|function\\s*[A-Za-z_$][\\w$]*?\\s*\\([^)]*\\)\\s*\\{(?:\\s|;|//[^\\n]*|/\\*[\\s\\S]*?\\*/)*\\})\\s*\\)",
   "profiles": {
     "bcm2712": {
       "path": "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json",

--- a/scripts/fixtures/silent-catch-baseline.json
+++ b/scripts/fixtures/silent-catch-baseline.json
@@ -1,7 +1,7 @@
 {
   "description": "Ratchet baseline for empty catch blocks in maintained Node-RED function nodes. Update counts downward in the same commit that removes silent catches.",
   "generatedFrom": "origin/main 22cffe6d",
-  "pattern": "catch\\s*\\(\\s*\\w*\\s*\\)\\s*\\{\\s*\\}",
+  "pattern": "catch\\s*(?:\\(\\s*\\w*\\s*\\))?\\s*\\{\\s*\\}",
   "profiles": {
     "bcm2712": {
       "path": "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json",

--- a/scripts/test-error-recording-flow.js
+++ b/scripts/test-error-recording-flow.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const test = require('node:test');
+const vm = require('vm');
 
 const repoRoot = path.resolve(__dirname, '..');
 
@@ -10,7 +11,18 @@ const flowProfiles = [
   'conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json',
 ];
 
-const expectedCatchNodes = {
+const recordErrorTab = '93b1537a596e0e6d';
+const recordErrorLinkInId = 'record-error-link-in';
+
+// Catch nodes that are on the same tab as record-error-fn: wired directly.
+const directCatchNodes = {
+  'record-error-catch-cloud-sync': recordErrorTab,
+};
+
+// Catch nodes on a different tab than record-error-fn: must route through a
+// same-tab `link out` -> shared `link in` -> record-error-fn, never a direct
+// cross-tab wire (Node-RED's editor silently drops cross-tab drawn wires).
+const crossTabCatchNodes = {
   'record-error-catch-auth': 'auth-tab',
   'record-error-catch-device-api': 'device-api-tab',
   'record-error-catch-scheduler': 'c2b43a6c6e7d2c11',
@@ -18,7 +30,6 @@ const expectedCatchNodes = {
   'record-error-catch-strega': '8a18de184886c8a8',
   'record-error-catch-field-testing': 'a3f03829ad106e10',
   'record-error-catch-download': '7d4f3e45f4b0d111',
-  'record-error-catch-cloud-sync': '93b1537a596e0e6d',
   'record-error-catch-lsn50': 'lsn50-tab',
   'record-error-catch-system-admin': 'sys-admin-tab',
   'record-error-catch-account-link': 'account-link-tab',
@@ -27,6 +38,8 @@ const expectedCatchNodes = {
   'record-error-catch-history-api': 'history-api-tab',
   'record-error-catch-lorain': 'lorain-tab',
 };
+
+const expectedCatchNodes = { ...directCatchNodes, ...crossTabCatchNodes };
 
 function readFlow(relativePath) {
   return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'));
@@ -41,6 +54,7 @@ for (const relativePath of flowProfiles) {
     assert.strictEqual(recordErrorNodes.length, 1, 'expected exactly one Record Error function node');
     const recordError = recordErrorNodes[0];
     assert.strictEqual(recordError.id, 'record-error-fn');
+    assert.strictEqual(recordError.z, recordErrorTab);
     assert.deepStrictEqual(recordError.libs, []);
     assert.match(recordError.func, /global\.get\('error_counts'\)/);
     assert.match(recordError.func, /global\.set\('error_counts', counts\)/);
@@ -53,7 +67,131 @@ for (const relativePath of flowProfiles) {
       assert.strictEqual(catchNode.type, 'catch');
       assert.strictEqual(catchNode.z, tabId);
       assert.strictEqual(catchNode.scope, null);
+    }
+
+    // Direct-wire catch nodes (same tab as record-error-fn) wire straight to it.
+    for (const catchId of Object.keys(directCatchNodes)) {
+      const catchNode = byId.get(catchId);
       assert.deepStrictEqual(catchNode.wires, [['record-error-fn']]);
     }
+
+    // Cross-tab catch nodes must NOT wire directly to record-error-fn. Each
+    // wires to a same-tab `link out` node whose `links` includes the shared
+    // `link in` node, which in turn wires to record-error-fn.
+    const linkInNode = byId.get(recordErrorLinkInId);
+    assert(linkInNode, `${recordErrorLinkInId} missing`);
+    assert.strictEqual(linkInNode.type, 'link in');
+    assert.strictEqual(linkInNode.z, recordErrorTab);
+    assert.deepStrictEqual(linkInNode.wires, [['record-error-fn']]);
+
+    const linkOutIdsFeedingLinkIn = new Set(linkInNode.links);
+
+    for (const [catchId, tabId] of Object.entries(crossTabCatchNodes)) {
+      const catchNode = byId.get(catchId);
+      assert.strictEqual(catchNode.wires.length, 1, `${catchId} should have exactly one wire group`);
+      const targets = catchNode.wires[0];
+      assert.strictEqual(targets.length, 1, `${catchId} should wire to exactly one node`);
+      const [targetId] = targets;
+      assert.notStrictEqual(targetId, 'record-error-fn', `${catchId} must not wire directly to record-error-fn (cross-tab)`);
+
+      const linkOutNode = byId.get(targetId);
+      assert(linkOutNode, `${catchId} target ${targetId} missing`);
+      assert.strictEqual(linkOutNode.type, 'link out', `${catchId} must wire to a link out node`);
+      assert.strictEqual(linkOutNode.z, tabId, `${catchId}'s link out must be on the same tab (${tabId})`);
+      assert.strictEqual(linkOutNode.mode, 'link');
+      assert.deepStrictEqual(linkOutNode.wires, []);
+      assert(
+        linkOutNode.links.includes(recordErrorLinkInId),
+        `${catchId}'s link out must link to ${recordErrorLinkInId}`,
+      );
+      assert(
+        linkOutIdsFeedingLinkIn.has(linkOutNode.id),
+        `${recordErrorLinkInId}.links must include ${linkOutNode.id}`,
+      );
+    }
+
+    // Programmatic id -> tab (z) map: assert zero cross-tab drawn wires from
+    // ANY catch node in the flow (not just the ones this PR touches).
+    const idToTab = new Map(flow.map((node) => [node.id, node.z]));
+    const catchNodesInFlow = flow.filter((node) => node.type === 'catch');
+    for (const catchNode of catchNodesInFlow) {
+      const targets = (catchNode.wires || []).flat();
+      for (const targetId of targets) {
+        const targetTab = idToTab.get(targetId);
+        assert.strictEqual(
+          targetTab,
+          catchNode.z,
+          `catch node ${catchNode.id} (tab ${catchNode.z}) has a cross-tab drawn wire to ${targetId} (tab ${targetTab})`,
+        );
+      }
+    }
+  });
+}
+
+// --- Fix 3: actually execute record-error-fn's body, not just string-match it. ---
+
+/**
+ * Build a minimal Node-RED-like sandbox and run `func` (a Node-RED function
+ * node's source, which runs with implicit `msg`, `node`, `flow`, `global` in
+ * scope and no wrapping function/return statement of its own -- Node-RED
+ * wraps it in `new Function('msg','node',...,'flow','global', func)`).
+ */
+function runFunctionNodeBody(func, { msg, nodeWarnCalls, flowStore, globalStore }) {
+  const node = {
+    warn(...args) {
+      nodeWarnCalls.push(args.length === 1 ? args[0] : args);
+    },
+  };
+  const flowApi = {
+    get: (key) => flowStore.get(key),
+    set: (key, value) => flowStore.set(key, value),
+  };
+  const globalApi = {
+    get: (key) => globalStore.get(key),
+    set: (key, value) => globalStore.set(key, value),
+  };
+
+  const fn = new vm.Script(`(function(msg, node, flow, global) {\n${func}\n})`);
+  const context = vm.createContext({});
+  const compiled = fn.runInContext(context);
+  return compiled(msg, node, flowApi, globalApi);
+}
+
+for (const relativePath of flowProfiles) {
+  test(`${relativePath} record-error-fn actually records and rate-limits when executed`, () => {
+    const flow = readFlow(relativePath);
+    const recordError = flow.find((node) => node.id === 'record-error-fn');
+    assert(recordError, 'record-error-fn missing');
+
+    const flowStore = new Map();
+    const globalStore = new Map();
+    const nodeWarnCalls = [];
+
+    const fakeMsg = {
+      error: { message: 'boom: sensor timed out', source: { name: 'test-source' } },
+    };
+
+    // First error: should record and warn.
+    runFunctionNodeBody(recordError.func, { msg: fakeMsg, nodeWarnCalls, flowStore, globalStore });
+
+    const countsAfterFirst = globalStore.get('error_counts');
+    assert(countsAfterFirst, 'error_counts should be set in global after first error');
+    assert.strictEqual(countsAfterFirst.total, 1);
+    assert(countsAfterFirst.last, 'error_counts.last should be set');
+    assert.strictEqual(countsAfterFirst.last.src, 'test-source');
+    assert.match(countsAfterFirst.last.message, /boom: sensor timed out/);
+    assert.strictEqual(nodeWarnCalls.length, 1, 'first occurrence should warn once');
+
+    // Second identical error within the rate-limit window: should still
+    // increment the total, but must NOT warn again.
+    runFunctionNodeBody(recordError.func, { msg: fakeMsg, nodeWarnCalls, flowStore, globalStore });
+
+    const countsAfterSecond = globalStore.get('error_counts');
+    assert.strictEqual(countsAfterSecond.total, 2, 'total should keep incrementing even when rate-limited');
+    assert.strictEqual(
+      nodeWarnCalls.length,
+      1,
+      'identical error within the rate-limit window must not warn a second time',
+    );
   });
 }

--- a/scripts/test-error-recording-flow.js
+++ b/scripts/test-error-recording-flow.js
@@ -1,0 +1,59 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+const flowProfiles = [
+  'conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json',
+  'conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json',
+];
+
+const expectedCatchNodes = {
+  'record-error-catch-auth': 'auth-tab',
+  'record-error-catch-device-api': 'device-api-tab',
+  'record-error-catch-scheduler': 'c2b43a6c6e7d2c11',
+  'record-error-catch-kiwi': '49e87447205bb849',
+  'record-error-catch-strega': '8a18de184886c8a8',
+  'record-error-catch-field-testing': 'a3f03829ad106e10',
+  'record-error-catch-download': '7d4f3e45f4b0d111',
+  'record-error-catch-cloud-sync': '93b1537a596e0e6d',
+  'record-error-catch-lsn50': 'lsn50-tab',
+  'record-error-catch-system-admin': 'sys-admin-tab',
+  'record-error-catch-account-link': 'account-link-tab',
+  'record-error-catch-dendro-analytics': 'dendro-analytics-tab',
+  'record-error-catch-s2120': 's2120-tab',
+  'record-error-catch-history-api': 'history-api-tab',
+  'record-error-catch-lorain': 'lorain-tab',
+};
+
+function readFlow(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, relativePath), 'utf8'));
+}
+
+for (const relativePath of flowProfiles) {
+  test(`${relativePath} has shared error recording wired from DB/sync/decode catch nodes`, () => {
+    const flow = readFlow(relativePath);
+    const byId = new Map(flow.map((node) => [node.id, node]));
+    const recordErrorNodes = flow.filter((node) => node.type === 'function' && node.name === 'Record Error');
+
+    assert.strictEqual(recordErrorNodes.length, 1, 'expected exactly one Record Error function node');
+    const recordError = recordErrorNodes[0];
+    assert.strictEqual(recordError.id, 'record-error-fn');
+    assert.deepStrictEqual(recordError.libs, []);
+    assert.match(recordError.func, /global\.get\('error_counts'\)/);
+    assert.match(recordError.func, /global\.set\('error_counts', counts\)/);
+    assert.match(recordError.func, /flow\.get\('record_error_warned'\)/);
+    assert.match(recordError.func, /node\.warn/);
+
+    for (const [catchId, tabId] of Object.entries(expectedCatchNodes)) {
+      const catchNode = byId.get(catchId);
+      assert(catchNode, `${catchId} missing`);
+      assert.strictEqual(catchNode.type, 'catch');
+      assert.strictEqual(catchNode.z, tabId);
+      assert.strictEqual(catchNode.scope, null);
+      assert.deepStrictEqual(catchNode.wires, [['record-error-fn']]);
+    }
+  });
+}

--- a/scripts/verify-no-new-silent-catch.js
+++ b/scripts/verify-no-new-silent-catch.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const BASELINE_PATH = path.join(__dirname, 'fixtures', 'silent-catch-baseline.json');
-const EMPTY_CATCH_RE = /catch\s*\(\s*\w*\s*\)\s*\{\s*\}/g;
+const EMPTY_CATCH_RE = /catch\s*(?:\(\s*\w*\s*\))?\s*\{\s*\}/g;
 
 function countSilentCatchesInFlow(flow) {
   let functionNodeCount = 0;

--- a/scripts/verify-no-new-silent-catch.js
+++ b/scripts/verify-no-new-silent-catch.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const BASELINE_PATH = path.join(__dirname, 'fixtures', 'silent-catch-baseline.json');
+const EMPTY_CATCH_RE = /catch\s*\(\s*\w*\s*\)\s*\{\s*\}/g;
+
+function countSilentCatchesInFlow(flow) {
+  let functionNodeCount = 0;
+  let silentCatchCount = 0;
+
+  for (const node of flow) {
+    if (!node || node.type !== 'function' || typeof node.func !== 'string') {
+      continue;
+    }
+
+    functionNodeCount += 1;
+    const matches = node.func.match(EMPTY_CATCH_RE);
+    silentCatchCount += matches ? matches.length : 0;
+  }
+
+  return { functionNodeCount, silentCatchCount };
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function countProfile(profileConfig) {
+  const flowPath = path.join(REPO_ROOT, profileConfig.path);
+  const flow = readJson(flowPath);
+  return {
+    path: profileConfig.path,
+    ...countSilentCatchesInFlow(flow),
+  };
+}
+
+function evaluateProfileCounts(liveCounts, baseline) {
+  const failures = [];
+
+  for (const [profile, profileBaseline] of Object.entries(baseline.profiles || {})) {
+    const live = liveCounts[profile];
+    if (!live) {
+      failures.push(`${profile}: missing live count`);
+      continue;
+    }
+
+    const liveCount = live.silentCatchCount;
+    const baselineCount = profileBaseline.silentCatchCount;
+
+    if (liveCount > baselineCount) {
+      failures.push(`${profile}: live silent catch count ${liveCount} exceeds baseline ${baselineCount}`);
+    } else if (liveCount < baselineCount) {
+      failures.push(
+        `${profile}: live silent catch count ${liveCount} is below baseline ${baselineCount}; update the baseline downward in this commit`,
+      );
+    }
+  }
+
+  return failures;
+}
+
+function countAllProfiles(baseline) {
+  return Object.fromEntries(
+    Object.entries(baseline.profiles || {}).map(([profile, profileConfig]) => [
+      profile,
+      countProfile(profileConfig),
+    ]),
+  );
+}
+
+function main() {
+  const baseline = readJson(BASELINE_PATH);
+  const liveCounts = countAllProfiles(baseline);
+  const failures = evaluateProfileCounts(liveCounts, baseline);
+
+  if (failures.length > 0) {
+    console.error('verify-no-new-silent-catch: FAIL');
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('verify-no-new-silent-catch: OK');
+  for (const [profile, live] of Object.entries(liveCounts)) {
+    const baselineCount = baseline.profiles[profile].silentCatchCount;
+    console.log(
+      `- ${profile}: ${live.silentCatchCount} empty catches across ${live.functionNodeCount} function nodes (baseline ${baselineCount})`,
+    );
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  countSilentCatchesInFlow,
+  evaluateProfileCounts,
+};

--- a/scripts/verify-no-new-silent-catch.js
+++ b/scripts/verify-no-new-silent-catch.js
@@ -6,7 +6,50 @@ const path = require('path');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const BASELINE_PATH = path.join(__dirname, 'fixtures', 'silent-catch-baseline.json');
-const EMPTY_CATCH_RE = /catch\s*(?:\(\s*\w*\s*\))?\s*\{\s*\}/g;
+
+// A catch body is "silent" if it contains nothing but whitespace, bare
+// semicolons, and/or comments (line or block) -- i.e. nothing that could
+// possibly surface the error. This deliberately covers evasion forms like
+// `catch(e){ /* ignore */ }`, `catch(e){;}`, and `catch({message}){}` in
+// addition to the truly-empty `catch(){}` / `catch{}` / `catch(e){}`.
+const EMPTY_BODY_INNER = String.raw`(?:\s|;|//[^\n]*|/\*[\s\S]*?\*/)*`;
+
+// try/catch: `catch`, an optional binding of any (non-nested-brace) content
+// -- covers no binding, a simple identifier, and destructured bindings like
+// `{message}` or `[a, b]` -- followed by a body that is empty per the above.
+const EMPTY_TRY_CATCH_RE = new RegExp(
+  String.raw`catch\s*(?:\([^)]*\))?\s*\{${EMPTY_BODY_INNER}\}`,
+  'g',
+);
+
+// Promise-style `.catch(handler)` where handler is an arrow function or a
+// function expression with an empty-per-the-above body, e.g.
+// `.catch(() => {})`, `.catch((e) => {})`, `.catch(function(){})`,
+// `.catch(function (err) { })`.
+const EMPTY_PROMISE_CATCH_RE = new RegExp(
+  String.raw`\.catch\s*\(\s*(?:` +
+    // arrow function: (args) => { ...empty... }  or  arg => { ...empty... }
+    String.raw`(?:\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*\{${EMPTY_BODY_INNER}\}` +
+    String.raw`|` +
+    // function expression: function(args) { ...empty... }
+    String.raw`function\s*[A-Za-z_$][\w$]*?\s*\([^)]*\)\s*\{${EMPTY_BODY_INNER}\}` +
+    String.raw`)\s*\)`,
+  'g',
+);
+
+function countMatches(source, regex) {
+  const matches = source.match(regex);
+  return matches ? matches.length : 0;
+}
+
+function countSilentCatchesInSource(source) {
+  if (typeof source !== 'string' || source.length === 0) {
+    return 0;
+  }
+  return countMatches(source, EMPTY_TRY_CATCH_RE) + countMatches(source, EMPTY_PROMISE_CATCH_RE);
+}
+
+const SCANNED_FUNCTION_FIELDS = ['func', 'initialize', 'finalize'];
 
 function countSilentCatchesInFlow(flow) {
   let functionNodeCount = 0;
@@ -18,8 +61,9 @@ function countSilentCatchesInFlow(flow) {
     }
 
     functionNodeCount += 1;
-    const matches = node.func.match(EMPTY_CATCH_RE);
-    silentCatchCount += matches ? matches.length : 0;
+    for (const field of SCANNED_FUNCTION_FIELDS) {
+      silentCatchCount += countSilentCatchesInSource(node[field]);
+    }
   }
 
   return { functionNodeCount, silentCatchCount };

--- a/scripts/verify-no-new-silent-catch.test.js
+++ b/scripts/verify-no-new-silent-catch.test.js
@@ -20,6 +20,18 @@ test('counts empty catch blocks only in function node source', () => {
   });
 });
 
+test('counts optional catch binding empty blocks', () => {
+  const flow = [
+    { type: 'function', func: 'try { work(); } catch {}' },
+    { type: 'function', func: 'try { work(); } catch { node.warn("visible"); }' },
+  ];
+
+  assert.deepStrictEqual(countSilentCatchesInFlow(flow), {
+    functionNodeCount: 2,
+    silentCatchCount: 1,
+  });
+});
+
 test('fails on increased or stale-lower counts against the baseline', () => {
   const baseline = {
     profiles: {

--- a/scripts/verify-no-new-silent-catch.test.js
+++ b/scripts/verify-no-new-silent-catch.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert');
+const test = require('node:test');
+
+const {
+  countSilentCatchesInFlow,
+  evaluateProfileCounts,
+} = require('./verify-no-new-silent-catch.js');
+
+test('counts empty catch blocks only in function node source', () => {
+  const flow = [
+    { type: 'function', func: 'try { work(); } catch(_){}' },
+    { type: 'function', func: 'try { work(); } catch (e) { } catch(err){ node.warn(err.message); }' },
+    { type: 'debug', func: 'try { work(); } catch(e){}' },
+    { type: 'function', func: 'try { work(); } catch (error) { node.warn(error.message); }' },
+  ];
+
+  assert.deepStrictEqual(countSilentCatchesInFlow(flow), {
+    functionNodeCount: 3,
+    silentCatchCount: 2,
+  });
+});
+
+test('fails on increased or stale-lower counts against the baseline', () => {
+  const baseline = {
+    profiles: {
+      bcm2712: { silentCatchCount: 247 },
+      bcm2709: { silentCatchCount: 247 },
+    },
+  };
+
+  assert.deepStrictEqual(
+    evaluateProfileCounts(
+      {
+        bcm2712: { silentCatchCount: 248 },
+        bcm2709: { silentCatchCount: 247 },
+      },
+      baseline,
+    ),
+    [
+      'bcm2712: live silent catch count 248 exceeds baseline 247',
+    ],
+  );
+
+  assert.deepStrictEqual(
+    evaluateProfileCounts(
+      {
+        bcm2712: { silentCatchCount: 246 },
+        bcm2709: { silentCatchCount: 247 },
+      },
+      baseline,
+    ),
+    [
+      'bcm2712: live silent catch count 246 is below baseline 247; update the baseline downward in this commit',
+    ],
+  );
+});

--- a/scripts/verify-no-new-silent-catch.test.js
+++ b/scripts/verify-no-new-silent-catch.test.js
@@ -9,7 +9,7 @@ const {
 test('counts empty catch blocks only in function node source', () => {
   const flow = [
     { type: 'function', func: 'try { work(); } catch(_){}' },
-    { type: 'function', func: 'try { work(); } catch (e) { } catch(err){ node.warn(err.message); }' },
+    { type: 'function', func: 'try { workA(); } catch (e) { } try { workB(); } catch(err){ node.warn(err.message); }' },
     { type: 'debug', func: 'try { work(); } catch(e){}' },
     { type: 'function', func: 'try { work(); } catch (error) { node.warn(error.message); }' },
   ];
@@ -29,6 +29,69 @@ test('counts optional catch binding empty blocks', () => {
   assert.deepStrictEqual(countSilentCatchesInFlow(flow), {
     functionNodeCount: 2,
     silentCatchCount: 1,
+  });
+});
+
+test('counts comment-only catch bodies as silent', () => {
+  const flow = [
+    { type: 'function', func: 'try { work(); } catch (e) { /* ignore */ }' },
+    { type: 'function', func: 'try { work(); } catch (e) { // ignore\n }' },
+  ];
+
+  assert.deepStrictEqual(countSilentCatchesInFlow(flow), {
+    functionNodeCount: 2,
+    silentCatchCount: 2,
+  });
+});
+
+test('counts bare-semicolon catch bodies as silent', () => {
+  const flow = [{ type: 'function', func: 'try { work(); } catch (e) {;}' }];
+
+  assert.deepStrictEqual(countSilentCatchesInFlow(flow), {
+    functionNodeCount: 1,
+    silentCatchCount: 1,
+  });
+});
+
+test('counts destructured-binding empty catch bodies as silent', () => {
+  const flow = [
+    { type: 'function', func: 'try { work(); } catch ({message}) {}' },
+    { type: 'function', func: 'try { work(); } catch ([a, b]) {}' },
+  ];
+
+  assert.deepStrictEqual(countSilentCatchesInFlow(flow), {
+    functionNodeCount: 2,
+    silentCatchCount: 2,
+  });
+});
+
+test('counts empty promise-style .catch() handlers as silent', () => {
+  const flow = [
+    { type: 'function', func: 'doThing().catch(() => {});' },
+    { type: 'function', func: 'doThing().catch(function(){});' },
+    { type: 'function', func: 'doThing().catch(function (err) {\n});' },
+    { type: 'function', func: 'doThing().catch((err) => { node.warn(err); });' },
+  ];
+
+  assert.deepStrictEqual(countSilentCatchesInFlow(flow), {
+    functionNodeCount: 4,
+    silentCatchCount: 3,
+  });
+});
+
+test('scans initialize and finalize fields in addition to func', () => {
+  const flow = [
+    {
+      type: 'function',
+      func: 'node.send(msg);',
+      initialize: 'try { setup(); } catch (e) {}',
+      finalize: 'try { teardown(); } catch (e) { /* ignore */ }',
+    },
+  ];
+
+  assert.deepStrictEqual(countSilentCatchesInFlow(flow), {
+    functionNodeCount: 1,
+    silentCatchCount: 2,
   });
 });
 


### PR DESCRIPTION
## Summary
- add a maintained-profile silent-catch ratchet for `flows.json`, including optional `catch {}` syntax
- add built-in Node-RED catch nodes wired to one `Record Error` function node with `libs: []` in both maintained profiles
- document the convert-on-touch rule for empty catches and the intentional heartbeat-field skip

## Scope Notes
- Silent-catch baseline is `247` for `bcm2712` and `247` for `bcm2709`.
- Added 15 new catch nodes per maintained profile plus one shared `Record Error` node per profile. Existing HTTP catch nodes are preserved.
- `bcm2708` is untouched.
- Heartbeat fields are intentionally skipped because `Gather Edge Health` is absent on the current maintained-profile baseline.
- No mass rewrite of existing empty catches.

## Verification
- `node --test scripts/verify-no-new-silent-catch.test.js scripts/test-error-recording-flow.js`
- `node scripts/verify-no-new-silent-catch.js`
- `node scripts/verify-profile-parity.js`
- `node scripts/verify-sync-flow.js`
- `scripts/check-mqtt-topics.sh`
- `git diff --check origin/main..HEAD`

## Review Notes
- Reviewer loop found and fixed the optional `catch {}` bypass in the ratchet.
- Final review found no blocking issues. Residual risk: `Record Error` is on the cloud-sync tab, so a recorder exception could be caught by the same tab catch; current implementation is built-ins-only, does no I/O, rate-limits warnings, and returns `null`.
