### PR TITLE
[probe] cross-repo checkout of private osi-server (do not merge)

### DIFF
--- a/.github/workflows/_crossrepo-probe.yml
+++ b/.github/workflows/_crossrepo-probe.yml
@@ -1,0 +1,29 @@
+name: crossrepo-probe
+on:
+  pull_request:
+    branches: [ main ]
+permissions:
+  contents: read
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Try cross-repo checkout of private osi-server (default GITHUB_TOKEN, no explicit token)
+        id: crossrepo
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: Open-Smart-Irrigation/osi-server
+          path: osi-server
+          persist-credentials: false
+      - name: Report result
+        run: |
+          if [ -f osi-server/backend/src/main/java/org/osi/server/sync/EdgeSyncService.java ]; then
+            echo "CROSSREPO_CHECKOUT=SUCCESS (default token can clone private osi-server)"
+          else
+            echo "CROSSREPO_CHECKOUT=FAILED (default token cannot clone private osi-server — needs a secret)"
+            exit 1
+          fi


### PR DESCRIPTION
Throwaway probe to empirically test whether a workflow's default GITHUB_TOKEN can `actions/checkout` the private osi-server repo (the sync-contract parity check depends on this). Will be closed once the run reports. `continue-on-error` on the checkout so the step conclusion is captured either way.