### PR TITLE
docs(skills): agent onboarding skill library v1

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
+++ b/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
@@ -452,7 +452,7 @@ sed -n '1,40p' docs/architecture/dendrometer-analytics-v6.md
 grep -n "et0\|Et0" ../osi-server/backend/src/main/java/org/osi/server/analytics/WeatherMath.java  # sister-repo checkout required, path relative to this repo root
 
 # Rain aggregation (S2120 cumulative-delta status machine; LoRain interval decoder)
-grep -n "rainDeltaStatus" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+grep -n "rainDeltaStatus\|rain_delta_status" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
 sed -n '1,130p' conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/aquascope_lorain_decoder.js
 
 # Battery footer fallback behavior (confirm issue #51 / bat_v fallback still present)

--- a/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
+++ b/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
@@ -59,7 +59,7 @@ sensor capability, not a shipped field.
 `deviceCardBattery.ts`, `buildDeviceFooterMeta`) prefers a real `bat_pct` and
 **falls back to a voltage-derived percent from `bat_v`** using a fixed LSN50
 discharge curve (`getBatteryPercentFromVoltage`, 2.1 V = 0%, 3.6 V = 100%,
-clamped) when `bat_pct` is absent. `DraginoTempCard.tsx` passes both
+clamped) when `bat_pct` is absent or not a valid finite 0-100 value. `DraginoTempCard.tsx` passes both
 `batteryPercent={bat_pct}` and `batteryVoltage={bat_v}`, so `DRAGINO_LSN50`
 devices that only report `bat_v` still show a footer percentage. This closed
 GitHub issue #51 (`osi-os`); it supersedes any older note claiming the LSN50

--- a/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
+++ b/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
@@ -1,0 +1,473 @@
+---
+name: osi-agronomy-sensors-reference
+description: Use when interpreting soil water tension (SWT) kPa or pF values, Chameleon sensor calibration/wiring, dendrometer TWD/MDS output, rain gauge aggregation (LoRain/S2120), ET0/evapotranspiration questions, deciding which device_data column a sensor writes to, STREGA valve command semantics, or any device-payload/decoder question. Covers KIWI_SENSOR, TEKTELIC_CLOVER, DRAGINO_LSN50, SENSECAP_S2120, AQUASCOPE_LORAIN, STREGA_VALVE.
+---
+
+# OSI Agronomy & Sensors Reference
+
+## Overview
+
+This skill is the domain model for how OSI OS represents soil, plant-water, and
+weather measurements in the database, the scheduler, and the dashboard. It
+answers "what does this number mean and where does it live", not general
+agronomy theory. Every claim below was checked against the code or docs named
+next to it, as of 2026-07-06 (worktree `feat/agent-skill-library`,
+`osi-os` HEAD `22cffe6d`).
+
+## When to use / When NOT to use
+
+Use this skill when you need to:
+- Interpret a stored SWT/kPa/pF value, or decide whether a number is "wet" or "dry".
+- Understand Chameleon resistance-to-kPa calibration or the array_id lookup flow.
+- Explain dendrometer MDS/TWD/TWD_rel output or find which side (edge vs cloud) computes it.
+- Explain rain aggregation semantics for LoRain or S2120, or a "missing vs zero" rain question.
+- Determine which `device_data` column a given sensor/device type populates.
+- Explain STREGA valve command semantics (`OPEN_FOR_DURATION`, cancel).
+- Explain LoRaWAN join/uplink vocabulary (OTAA, FPort, DevEUI...) as used by this system.
+
+Do NOT use this skill for (route instead):
+- Debugging a symptom like `i2c_missing=1`, a data gap, or a stuck sync — **osi-debugging-playbook**.
+- Deploying to or repairing a live Pi, backups, restart procedures — **osi-live-ops-runbook**.
+- Mechanically editing `flows.json` (node shapes, wiring function nodes) — **osi-flows-json-editing**.
+- Adding/altering a table, column, or migration — **osi-schema-change-control**.
+- `CHIRPSTACK_PROFILE_*` env vars, device-profile provisioning, feature flags — **osi-config-and-flags**.
+
+## Device catalog and units quick-reference
+
+| Device | ChirpStack app | Custom OSI decoder? | Primary `device_data` fields | Units |
+|---|---|---|---|---|
+| `KIWI_SENSOR` | Sensors | No (TEKTELIC/vendor payload, no file under `codecs/`) | `swt_1`, `swt_2` (via legacy `swt_wm1/2` aliasing), `light_lux`, `ambient_temperature`, `relative_humidity` | kPa, lux, °C, %RH |
+| `TEKTELIC_CLOVER` | Sensors | No | same shape as KIWI; VWC is **typed but not populated** (see VWC note below) | °C, %RH; VWC not stored |
+| `DRAGINO_LSN50` | Sensors | Yes — `dragino_lsn50_decoder.js` | `ext_temperature_c` (DS18B20), `adc_ch0v/adc_ch1v`, `bat_v`, plus MOD-specific: `dendro_position_mm`/`dendro_*` (dendrometer), `rain_*` (rain gauge), `flow_*` (flow meter), and Chameleon `swt_1/2/3` when a VIA Chameleon module is attached over I2C | °C, V, mm, µm, L |
+| `SENSECAP_S2120` | Sensors | Yes — `sensecap_s2120_decoder.js` | `ambient_temperature`, `relative_humidity`, `light_lux`, `barometric_pressure_hpa`, wind speed/direction/gust, `uv_index`, `rain_gauge_cumulative_mm` → `rain_mm_delta`/`rain_mm_today`, `bat_pct` | °C, %RH, hPa, m/s, deg, mm |
+| `AQUASCOPE_LORAIN` | Sensors | Yes — `aquascope_lorain_decoder.js` | `rain_mm_delta` (from raw 0.5 mm steps), `ambient_temperature`, `bat_v` | mm, °C, V |
+| `STREGA_VALVE` | Actuators | Yes — `strega_gen1_decoder.js` | `devices.current_state` (not a `device_data` column), `bat_pct`/`bat_v` | — |
+
+File locations for all OSI-authored decoders:
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/{aquascope_lorain_decoder.js, dragino_lsn50_decoder.js, sensecap_s2120_decoder.js, strega_gen1_decoder.js}`.
+KIWI/CLOVER have no file here — their payload arrives already decoded (vendor/ChirpStack-side codec), which is why the table above says "No".
+
+**VWC note (not implemented on the edge):** `web/react-gui/src/types/farming.ts` types a
+`VWC` trigger metric as "planned; typed now", and `docs/channel-manifest.md`
+records the canonical `vwc` manifest entry with `edgeField: null` — there is no
+local osi-os telemetry column for VWC today. Do not assume `TEKTELIC_CLOVER`
+populates a VWC column; treat AGENTS.md's "VWC" catalog label as the intended
+sensor capability, not a shipped field.
+
+**Battery quirks (verified in code, not just docs):** the shared footer
+(`web/react-gui/src/components/farming/shared/DeviceCardFooter.tsx` →
+`deviceCardBattery.ts`, `buildDeviceFooterMeta`) prefers a real `bat_pct` and
+**falls back to a voltage-derived percent from `bat_v`** using a fixed LSN50
+discharge curve (`getBatteryPercentFromVoltage`, 2.1 V = 0%, 3.6 V = 100%,
+clamped) when `bat_pct` is absent. `DraginoTempCard.tsx` passes both
+`batteryPercent={bat_pct}` and `batteryVoltage={bat_v}`, so `DRAGINO_LSN50`
+devices that only report `bat_v` still show a footer percentage. This closed
+GitHub issue #51 (`osi-os`); it supersedes any older note claiming the LSN50
+battery footer is hidden — that was true before the voltage-fallback shipped
+(commit `01dc45fa`, "derive lsn50 battery footer percent") and is stale now.
+
+## Soil water tension (SWT)
+
+**Definition (as used here):** SWT is the suction (matric potential) the soil
+exerts on water — the force a root must overcome to extract it. Higher tension
+means drier soil; lower tension means wetter soil. It is not the same
+quantity as VWC (volumetric water content); this repo does not convert
+between them.
+
+**Storage and sign convention (verified, load-bearing):**
+- Canonical channels are `device_data.swt_1`, `swt_2`, `swt_3` in **kPa**, and
+  they are stored and compared as **positive numbers where higher = drier**.
+  Verified in three independent places:
+  1. The Chameleon resistance→kPa conversion clamps to `[MIN_KPA=0, MAX_KPA=300]`
+     — `conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-chameleon-helper/index.js`,
+     function `resistanceOhmsToKpa`.
+  2. The irrigation scheduler's decision rule is `const irrigate = (meanKpa >= threshold);`
+     — `flows.json` node id `5f0d2b7e9b9b1b3a` ("Decide + build actuator cmd +
+     build DB logs"). Rising kPa past the threshold triggers irrigation, i.e.
+     higher kPa = drier = irrigate.
+  3. The GUI's SWT summary bucketing treats low kPa as "Wet" and high kPa as
+     "Dry": `mean < 20` → Wet, `mean < 60` → Moderate, else Dry
+     (`web/react-gui/src/utils/swt.ts`, `summarizeSwtValues`).
+- Legacy `device_data.swt_wm1` / `swt_wm2` are **read-only aliases** for old
+  rows (pre-canonicalization); new writes go to `swt_1`/`swt_2`/`swt_3`. Reads
+  should coalesce canonical-then-legacy — `flows.json`'s latest-data query uses
+  `COALESCE(dd.swt_1, dd.swt_wm1) AS swt_1`.
+- `irrigation_schedules.threshold_kpa` is validated `0 < x ≤ 300` for
+  non-DENDRO trigger metrics (`flows.json`, "Verify Zone Ownership" node); for
+  `trigger_metric = 'DENDRO'` the same column instead holds an **encoded
+  1-4 stress level** (1=mild … 4=severe), not a kPa value — do not treat
+  `threshold_kpa` as kPa when the metric is DENDRO.
+- **Known schema gap (informational, not this skill's fix):** the shipped
+  `irrigation_schedules` CHECK constraint (`database/seed-blank.sql`) still
+  only allows `trigger_metric IN ('SWT_WM1','SWT_WM2','SWT_AVG')`, while the
+  API/GUI have accepted `SWT_1`/`SWT_2`/`SWT_3`/`DENDRO` since 2026-06-24/25.
+  This is a live P0 tracked as osi-os issue #92 — a schema/migration concern,
+  see **osi-schema-change-control**, not an agronomy modeling question.
+
+**Depth columns:** `devices.chameleon_swt1_depth_cm`, `chameleon_swt2_depth_cm`,
+`chameleon_swt3_depth_cm` record the physical burial depth of each Chameleon
+sensor channel (`database/seed-blank.sql`). Per-device calibration
+coefficient columns (`chameleon_swt[123]_[abc]`) were **removed** in the
+2026-05-19 migration in favor of the global `chameleon_calibrations` table
+(see below) — depth stayed device-local because it's installation geometry,
+not a sensor calibration constant.
+
+### pF (soil water tension, logarithmic)
+
+pF is the base-10 logarithm of tension expressed in hPa (1 kPa = 10 hPa); it
+compresses the wide dynamic range of soil suction into a small number
+range (roughly 0-4.5) more familiar to some agronomists.
+
+**pF is never stored.** It is derived at read time everywhere it is shown —
+GUI display, CSV export, and (per the sync contract) any cloud consumer.
+There is no `swt_*_pf` column and no schema change was needed to add it
+(osi-os PR #98, "swt-pf-display-csv", merged as `22cffe6d`).
+
+**Exact formula, verified in `web/react-gui/src/utils/swt.ts`:**
+```ts
+// pF = log10(tension in hPa); 1 kPa = 10 hPa. Non-positive tension has no pF.
+export function kpaToPf(kpa: unknown): number | null {
+  const value = toFiniteSwtValue(kpa);
+  if (value === null || value <= 0) return null;
+  return Math.log10(value * 10);
+}
+```
+So **`pF = log10(kPa * 10)`**, and the inverse `pfToKpa` is
+`kPa = 10^pF / 10`. Non-positive, non-finite, or missing kPa produces `null`
+pF — there is no clamping and no substitute value (consistent with the
+missing-data rule below). This exact formula, and its rounding, is pinned as
+a cross-runtime contract in `docs/contracts/sync-schema/canonicalization.md`
+("SWT pF Derivation") with golden vectors edge JS / GUI TS / server Java must
+all match, e.g. 30 kPa → `2.4771212547196626` (2.48 at 2 dp, 2.4771 at 4 dp),
+0 or negative kPa → `null`. Display rounds pF to 2 decimals
+(`formatSwtValue`); CSV export rounds to 4 decimals.
+
+**CSV pairing:** each SWT kPa row exported gets a paired `_pf` row — verified
+in `conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-history-helper/index.js`:
+`channel_key: \`${channel.id}_pf\`` and `series_label: \`${kpaRow.series_label} (pF)\`` — with `unit: 'pF'`.
+
+**What did NOT ship:** an earlier spec draft considered adding
+`threshold_unit` + `threshold_pf` authoring columns to `irrigation_schedules`
+so operators could author thresholds in pF. That was descoped — PR #98 is
+"zero-schema": pF is display/export only, and the scheduler **always**
+compares in kPa regardless of the operator's display preference (comparing
+in pF would silently change trigger behavior, since a mean of pF values is a
+geometric-mean-like quantity in kPa space — Jensen's inequality). If you see
+a document proposing `threshold_pf`, treat it as an unimplemented proposal,
+not current behavior.
+
+## Chameleon sensor stack
+
+**What it is:** the VIA Chameleon module is a 3-channel resistance-based soil
+water sensor array, read over I2C by a Dragino LSN50 running OSI custom
+firmware (`feature/chameleon-i2c-reader`, standalone repo, not part of
+osi-os). The LSN50 uplink (FPort 2, LSN50 MOD=2 "3ADC+IIC" frame) carries a
+Chameleon extension: per-channel temperature-compensated and raw resistances,
+a status byte, soil temperature, and (V1 payload) an 8-byte array ID. Two
+payload versions exist and are both decoded —
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/dragino_lsn50_decoder.js`,
+functions `decodeChameleonV1`/`decodeChameleonV2` (dispatched by
+`isChameleonV1Frame`/`isChameleonV2Frame` on byte 8 of the payload).
+
+**Status flags exposed by the decoder** (verified field names):
+V1: `Chameleon_I2C_Missing`, `Chameleon_Timeout`, `Chameleon_Temp_Fault`,
+`Chameleon_ID_Fault`, `Chameleon_CH1_Open`/`CH2_Open`/`CH3_Open`. V2 collapses
+the first two into `Chameleon_Data_Invalid`, plus `Chameleon_Temp_Fault`,
+`Chameleon_ID_Fault`, and the same per-channel `_Open` flags (derived from an
+open-circuit resistance sentinel of 10,000,000 Ω rather than a status bit).
+`i2c_missing`/`timeout`/`data_invalid` downstream in `chameleon_readings` and
+the calibration helper trace back to these flags.
+
+**Calibration model — global table, verified formula:**
+`chameleon_calibrations` is keyed by `array_id` (uppercase 16-char hex,
+normalized by `normalizeArrayId`), with per-sensor coefficients `a`, `b`, `c`
+for each of the 3 channels. The conversion, verified in
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-chameleon-helper/index.js`,
+function `resistanceOhmsToKpa`:
+
+```
+resistance_kΩ = resistance_Ω / 1000
+kPa = a * ln(resistance_kΩ) + b * resistance_kΩ + c
+```
+
+...clamped to `[0, 300]` kPa and rounded to 2 decimals; resistances `<= 0` or
+`>= 10,000,000 Ω` (open circuit) are rejected as `null` before the formula
+runs. `calibration_status` is `'calibrated'` (a matching `chameleon_calibrations`
+row exists), `'pending'` (Chameleon enabled, no calibration row yet), or
+implicitly `'unknown'` when the array ID itself can't be read.
+`chameleon_calibration_misses` is a 24-hour negative cache keyed by
+`array_id` so the sync worker doesn't hammer the cloud for IDs it just
+learned are missing. The Node-RED sync worker polls
+`/api/v1/sync/chameleon/calibrations/lookup` every 30 s (same cadence as
+pending-commands) for any outstanding misses, persists new rows locally, and
+backfills previously-pending `device_data.swt_*` values.
+
+**Raw vs canonical:** `chameleon_readings` is the raw/diagnostic mirror (raw +
+compensated resistances, status flags, array ID, calibration_status) —
+useful for protocol debugging. `device_data.swt_1/swt_2/swt_3` are the
+canonical application values that scheduler, GUI, and cloud sync all read.
+If you repair history from `chameleon_readings` + `chameleon_calibrations`,
+you must also update `device_data` and enqueue `DEVICE_DATA_APPENDED` sync
+events, because the live sync trigger fires on `INSERT`, not historical
+`UPDATE` (AGENTS.md, "Chameleon calibration global table").
+
+**Wiring rule (one line; full analysis lives elsewhere):** power the VIA
+Chameleon I2C reader from the LSN50's own `VDD` rail (3.3-3.6 V) when SDA/SCL
+are wired directly to the LSN50 STM32 I2C pins. Do not power it from switched
+5 V without a proper bidirectional I2C level shifter plus power isolation —
+the reader's pull-ups follow VCC and a switched-off 5 V rail can back-power
+the board through SDA/SCL. Full field diagnosis:
+`docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md`; for
+troubleshooting a live `i2c_missing` symptom, use **osi-debugging-playbook**
+instead of re-deriving this here.
+
+## Dendrometry
+
+**What it measures:** an LSN50 with a point dendrometer measures micrometer-scale
+stem/trunk radius change. Edge storage: `device_data.dendro_position_mm`
+(mm) is the live/latest value; `dendrometer_readings` is the append-only
+history table with `position_um` (µm, `NOT NULL`), `position_raw_um`,
+`adc_v`/`adc_ch0v`/`adc_ch1v`, `dendro_ratio`, `dendro_mode_used`, `is_valid`,
+`invalid_reason`, `is_outlier`, `dendro_saturated`/`dendro_saturation_side`,
+and `recorded_at` — verified against `database/seed-blank.sql` (`CREATE TABLE
+dendrometer_readings`).
+
+**MDS (maximum daily shrinkage), as implemented (edge, v5):** the day's
+maximum stem position minus its minimum (`d_max_um - d_min_um`), stored as
+`dendrometer_daily.mds_um`. Computed in `flows.json` node id
+`dendro-compute-fn` ("Daily Dendrometer Analytics"), which the node's own
+header comment labels "Dendrometer Analytics v5 (envelope-based TWD, absolute
+thresholds)". This v5 edge computation also derives `d_max_um`, `d_min_um`,
+`tgr_um` (trunk growth rate), `twd_um`, `dr_um` (daily recovery), and a
+`stress_level` classified against **absolute-µm** per-crop thresholds
+(`CALIBRATIONS` map keyed by crop, e.g. `apple`, `grapevine`, `olive`,
+`default`) — not the self-calibrating model described next.
+
+**TWD (tree water deficit)** — two distinct implementations, different
+ownership, do not conflate them:
+- **Edge (v5, shipped, this repo):** `twd_um`, an absolute stepwise "envelope"
+  deficit in micrometers, computed daily by `dendro-compute-fn` in
+  `flows.json` and stored in `dendrometer_daily`. This is what powers the
+  on-device DENDRO scheduler trigger and the edge dashboard today.
+- **Cloud (v6, shipped, osi-server-only):** `TWD_rel = TWD_day / A_ref`, a
+  dimensionless ratio against a self-calibrated well-watered baseline
+  amplitude (`A_ref`, ~14 good days to establish). This is **cloud-only** —
+  it runs server-side (`DendroScheduler`/`DendroController` in osi-server) and
+  is persisted in the cloud's recommendation payload, but it is **not
+  surfaced in the edge dashboard and does not drive the edge DENDRO
+  scheduler**; the edge keeps running its own v5 absolute-µm classifier.
+  Reference: `docs/architecture/dendrometer-analytics-v6.md` (status:
+  "Implemented (osi-server). ... the edge UI is not yet a consumer" — see its
+  own "Boundaries" section). Until a tree has an edge-computed v5 baseline,
+  edge classification behavior is unchanged from v5 regardless of what the
+  cloud does.
+
+**Agroscope dendrometer controller — draft only:**
+`docs/architecture/agroscope-dendrometer-controller.md` begins "**Status:**
+Draft design, not shipped behavior." It describes a future opt-in
+`controller_mode='dendrometer'` architecture that would compare against
+Agroscope's `Tree_HSMM`/`Tree_irrigator` reference logic. Treat it purely as
+a design reference, not current runtime behavior, and do not cite it as if
+MDS/TWD already work this way.
+
+## ET0 (reference evapotranspiration)
+
+**Concept, not implemented on the edge as of 2026-07-06.** ET0 exists only in
+`osi-server` (cloud), in `backend/src/main/java/org/osi/server/analytics/{WeatherMath.java,Et0Resolver.java}`,
+merged via osi-server PR #46 ("per-zone weather source (cloud Phases 1-2)").
+It is resolved per irrigation zone through a tiered `Et0Resolver`:
+1. **Native ET0** from a weather source that already supplies one
+   (Open-Meteo's own FAO-56 value) — used as-is.
+2. **FAO-56 Penman-Monteith**, computed locally (`WeatherMath.fao56Et0`) when
+   the source instead supplies humidity + wind + solar radiation.
+3. **Hargreaves-Samani** (`WeatherMath.hargreavesEt0`, needs only Tmin/Tmax +
+   latitude + day-of-year) as the final fallback.
+
+There is no ET0 field in the edge `device_data`/`zone_daily_environment`
+schema and no edge computation of it — this is a cloud/`osi-server`-owned
+capability. If asked "does the edge compute ET0", the answer is no.
+
+## Rain semantics
+
+**Cardinal rule (engineering playbook, Prime Directive 3 — applies to ALL
+sensors, not just rain):** a day with zero *samples* is "no data", never
+"0.0 mm dry". Ingest writes real zeros when it is actually dry; never
+substitute a plausible default for an absent measurement. This repo once
+shipped a `-42 kPa` fallback and a `rootVwcPct ?? 24` fallback — both looked
+like real agronomy and misled operators before being caught. `null` must
+propagate end to end and render as an explicit "unavailable" state, not a
+guessed number (`docs/engineering-playbook.md`, "1. Prime directives", item 3).
+
+**AQUASCOPE_LORAIN (Aqua-Scope LoRain / RANLWE01):** reports **interval**
+rainfall, not cumulative. The vendor payload command `0x06 0x81` carries raw
+0.5 mm tip-bucket steps; the decoder
+(`aquascope_lorain_decoder.js`) keeps the vendor value as `rainlevel` /
+`rain_tips_delta` and exposes a normalized `rain_mm_delta = rainlevel * 0.5`
+in millimeters directly — there is no delta computation against a previous
+reading because each uplink already reports the interval, not a running
+total. Because each report is already a delta, duplicate or out-of-order
+uplinks must not be aggregated twice (AGENTS.md). Public onboarding uses
+FPort `10`; the legacy firmware decoder path uses FPort `2` — the decoder
+accepts both. JoinEUI/AppEUI `4943485448592021` is public (already in
+AGENTS.md); AppKey is fetched from Aqua-Scope with DevEUI + email and must
+never be stored in this repo. Assigned LoRain gauges update
+`zone_daily_environment` with `rain_source='aquascope_lorain'`.
+
+**SENSECAP_S2120:** reports a **cumulative** rain gauge counter
+(measurementId `4113`, "Rain Gauge", and `4213`/"Rain Accumulation" on an
+alternate frame), unlike LoRain's interval reporting. The edge computes the
+delta itself in `flows.json` node `s2120-process-fn` ("Process S2120") by
+comparing the new cumulative value against the most recent prior
+`device_data.rain_gauge_cumulative_mm` for that DevEUI, with explicit status
+handling exposed as `rain_delta_status`: `first_sample` (no prior row),
+`counter_reset` (new cumulative value is lower than the previous one),
+`duplicate_timestamp`/`out_of_order` (a same-or-later prior row already
+exists at/after this timestamp), `invalid_interval`, or `ok`. Only `ok`
+samples produce a non-null `rain_mm_delta`/`rain_mm_per_hour`/`rain_mm_per_10min`
+and only those flow into `zone_daily_environment` aggregation
+(`s2120-rain-agg-fn`, "Aggregate Zone Rain"), which upserts
+`rain_source='sensecap_s2120'` and accumulates `rainfall_mm` per zone/day
+(multi-zone via the `weather_station_zones` junction table, since one S2120
+can serve multiple zones).
+
+## LoRaWAN / ChirpStack model (as used here)
+
+- **OTAA (Over-The-Air Activation):** the device negotiates session keys with
+  the network at join time instead of shipping hardcoded session keys. All
+  OSI device types join via OTAA.
+- **DevEUI:** a device's globally unique 64-bit identifier (16 hex chars);
+  primary key for `devices.deveui`.
+- **JoinEUI / AppEUI:** identifies the join server a device should join
+  through (older spec name is AppEUI, 1.1 renamed it JoinEUI). Aqua-Scope
+  LoRain's is `4943485448592021` (public, already in AGENTS.md).
+- **AppKey:** the root key used to derive OTAA session keys. Device-specific,
+  never stored in this repo.
+- **FPort:** the LoRaWAN application port number in an uplink/downlink,
+  used here to distinguish payload formats/versions within a device family
+  (LoRain FPort `10` vs legacy `2`; LSN50 FPort `2` sensor data vs FPort `5`
+  config/status).
+- **Uplink / downlink:** device→network and network→device LoRaWAN frames.
+- **Class A:** the lowest-power LoRaWAN device class — the device only opens
+  receive windows right after it transmits (no scheduled downlink reception
+  otherwise). All OSI device types listed here are Class A.
+
+**Device-type discrimination is never hardcoded** to a ChirpStack application
+UUID (those are generated per-installation at bootstrap). It's done via
+`CHIRPSTACK_PROFILE_*` env vars with a `deviceProfileName` fallback — the
+exact env semantics belong to **osi-config-and-flags**, not here. All MQTT
+uplink subscriptions use the wildcard topic `application/+/device/+/event/up`
+(`scripts/check-mqtt-topics.sh` enforces this). ChirpStack apps are split
+`Sensors` (all sensor device types) vs `Actuators` (`STREGA_VALVE`) — AGENTS.md
+device catalog.
+
+## STREGA valve semantics
+
+**`OPEN_FOR_DURATION` is the only normal-operation command.** The valve
+firmware closes itself when the commanded duration elapses; there is no
+paired "open" + "close" command pair in normal use, and a bare `CLOSE`
+command must never be sent during normal operation or testing/debugging —
+the valve is designed to self-close, and sending an unexpected CLOSE is not
+a supported operational pattern. If you need to end an irrigation early,
+that's a cancel, not a close (next paragraph).
+
+**Operator cancel:** `POST /api/v1/valves/:deveui/cancel`
+(`flows.json`, url `/api/v1/valves/:deveui/cancel`) flushes the pending
+ChirpStack device downlink queue and marks the most recent active
+`valve_actuation_expectations` row `CANCELLED`.
+
+**Expectation lifecycle:** `valve_actuation_expectations` (verified schema,
+`database/seed-blank.sql`) records `commanded_at`, `commanded_duration_seconds`,
+`expected_close_at`, `observed_open_at`/`observed_close_at`,
+`reconciliation_state` (default `'PENDING_OBSERVATION'`, active states are
+`PENDING_OBSERVATION` and `OBSERVED_RUNNING`), `cancel_reason`, and an
+optional `estimated_gross_liters` with its `volume_source`. The
+reconciliation monitor reads live STREGA state from `devices.current_state`
+and last-uplink time from `device_data.recorded_at` (AGENTS.md).
+
+**Estimated vs measured volume — kept separate:** `zone_irrigation_calibration`
+stores a per-zone `measured_flow_rate_lpm` (from a real flow-meter
+measurement) used only to *estimate* `valve_actuation_expectations.estimated_gross_liters`
+for a given commanded duration. `zone_daily_environment.flow_liters` is
+reserved for actually-measured flow-meter data — the two must never be
+merged into one column, so a farm without a flow meter never gets a
+volume number that looks measured but isn't.
+
+## Common mistakes
+
+- Assuming SWT is negative or that lower kPa means drier — it is the
+  opposite here: positive kPa, higher = drier, verified by the scheduler's
+  own `meanKpa >= threshold` comparison.
+- Treating `swt_wm1`/`swt_wm2` as writable in new code — they are read-only
+  legacy aliases; write to `swt_1`/`swt_2`/`swt_3`.
+- Assuming pF is stored anywhere, or that the scheduler compares in pF — it
+  doesn't; pF is derive-at-read display/export only, and the scheduler
+  always compares kPa.
+- Assuming `TWD_rel` is available on the edge dashboard — it's cloud-only
+  (v6, osi-server); the edge still runs its own absolute-µm v5 TWD/MDS.
+  Don't conflate the two TWD implementations.
+- Treating the Agroscope dendrometer controller doc as shipped behavior —
+  it explicitly says "Draft design, not shipped behavior."
+- Assuming `TEKTELIC_CLOVER` reports VWC today — it's typed for a future
+  channel but has no populated edge field (`edgeField: null` in the channel
+  manifest).
+- Assuming ET0 is computed on the edge — it is cloud-only
+  (`osi-server` `Et0Resolver`/`WeatherMath`).
+- Treating a day with zero rain samples as "0.0 mm" — that conflates
+  "no data" with "confirmed dry"; only ingest that actually observed zero
+  should write zero.
+- Confusing LoRain's interval rain (`rain_mm_delta` computed directly from
+  a raw step count, no history lookup needed) with S2120's cumulative-counter
+  delta (computed against the previous stored `rain_gauge_cumulative_mm` row,
+  with explicit `first_sample`/`counter_reset`/`duplicate_timestamp` guards).
+- Sending a bare `CLOSE` to a STREGA valve for any reason, including test
+  cleanup — always use a short `OPEN_FOR_DURATION` or the cancel endpoint.
+- Assuming the DRAGINO_LSN50 battery footer is always hidden because the
+  device only reports `bat_v` — the voltage-derived fallback (issue #51)
+  means it now shows a computed percentage; this contradicts older notes
+  that predate that fix.
+
+## Provenance and maintenance
+
+Re-verify these if this skill's answers seem stale:
+
+```bash
+# SWT sign convention: scheduler comparison direction
+grep -n "const irrigate" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+
+# Chameleon resistance->kPa formula and clamp bounds
+sed -n '1,50p' conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-chameleon-helper/index.js
+
+# pF formula + golden vectors (must match GUI TS, edge JS, and server Java)
+sed -n '1,60p' web/react-gui/src/utils/swt.ts
+sed -n '85,110p' docs/contracts/sync-schema/canonicalization.md
+
+# irrigation_schedules trigger_metric CHECK (confirm P0 issue #92 status)
+grep -n "trigger_metric" database/seed-blank.sql
+
+# Dendrometer edge (v5) vs cloud (v6) ownership
+grep -n "Dendrometer Analytics v5" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+sed -n '1,40p' docs/architecture/dendrometer-analytics-v6.md
+
+# ET0 cloud-only implementation
+grep -n "et0\|Et0" ../osi-server/backend/src/main/java/org/osi/server/analytics/WeatherMath.java  # sister-repo checkout required, path relative to this repo root
+
+# Rain aggregation (S2120 cumulative-delta status machine; LoRain interval decoder)
+grep -n "rainDeltaStatus" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+sed -n '1,130p' conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/aquascope_lorain_decoder.js
+
+# Battery footer fallback behavior (confirm issue #51 / bat_v fallback still present)
+sed -n '1,55p' web/react-gui/src/components/farming/shared/deviceCardBattery.ts
+
+# VWC not-implemented status
+grep -n "VWC" web/react-gui/src/types/farming.ts docs/channel-manifest.md
+
+# STREGA cancel endpoint + expectation table
+grep -n "valves/:deveui/cancel" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+grep -n "CREATE TABLE valve_actuation_expectations" -A 20 database/seed-blank.sql
+```
+
+Cross-reference AGENTS.md's "Device catalog", "Chameleon calibration global
+table", "Aqua-Scope LoRain", and "STREGA timed irrigation" sections — this
+skill expands on those, it does not override them. If this skill and
+AGENTS.md ever disagree, AGENTS.md wins; file an issue to reconcile rather
+than silently trusting either.

--- a/.claude/skills/osi-config-and-flags/SKILL.md
+++ b/.claude/skills/osi-config-and-flags/SKILL.md
@@ -242,7 +242,7 @@ Verified full set of env vars it writes (`writeEnvFile` / `envVars` object in
 | `CHIRPSTACK_PROFILE_CLOVER` | **Alias** — intentionally set to the same UUID as `CHIRPSTACK_PROFILE_RAK10701` (compatibility alias for the RAK10701 field tester profile, not a separate profile) | `chirpstack_profile_clover` |
 | `CHIRPSTACK_PROFILE_RAK10701` | RAK Field Tester profile UUID | `chirpstack_profile_rak10701` |
 | `CHIRPSTACK_PROFILE_S2120` | SenseCAP S2120 profile UUID | `chirpstack_profile_s2120` |
-| `CHIRPSTACK_PROFILE_LORAIN` | Aqua-Scope LoRain profile UUID | **none** — no UCI mapping exists; env-file only (see section 1 note) |
+| `CHIRPSTACK_PROFILE_LORAIN` | Aqua-Scope LoRain profile UUID | `chirpstack_profile_lorain` — mapped to UCI by `chirpstack-bootstrap.js`, but **not exported by `node-red.init`** (runtime sees it via the env-file path only; see section 1 note) |
 
 All `CHIRPSTACK_APP_*`/`CHIRPSTACK_PROFILE_*` values are validated as
 ChirpStack UUIDs (`assertValidUciValue`, regex

--- a/.claude/skills/osi-config-and-flags/SKILL.md
+++ b/.claude/skills/osi-config-and-flags/SKILL.md
@@ -1,0 +1,586 @@
+---
+name: osi-config-and-flags
+description: Use when looking up or changing OSI OS gateway configuration or feature-flag surface - UCI osi-server.cloud.* settings, DEVICE_EUI / gateway identity resolution and precedence, CHIRPSTACK_PROFILE_*/CHIRPSTACK_APP_* env vars, OSI_HEALTH_*_RETENTION_DAYS overrides, Node-RED settings.js load-bearing options, deploy.sh tunables, /api/system/features flags, or adding a brand-new config knob. Not for symptom triage, live-Pi repair execution, flows.json editing mechanics, or schema migrations.
+---
+
+# OSI Config and Flags
+
+## Overview
+
+An OSI OS gateway (Raspberry Pi 5, OpenWrt 24.10 + ChirpStack + Node-RED +
+SQLite + React) has configuration spread across five layers: UCI — OpenWrt's
+Unified Configuration Interface, the `/etc/config/*` files plus `uci` CLI that
+form the durable per-installation config store — under `osi-server.cloud.*`, a
+legacy per-key env-file fallback
+(`/srv/node-red/.chirpstack.env`), Node-RED process environment (set by the
+init script), Node-RED's own `settings.js`, and hardcoded constants inside
+`flows.json`. This skill is the map of that surface: what exists, where it is
+defined, who reads/writes it, and how to inspect or safely extend it.
+
+All facts below were verified against the repository on 2026-07-06 unless
+marked otherwise. Re-verification commands are in the last section.
+
+## When to use
+
+- You need to know what a UCI key under `osi-server.cloud` does, its default,
+  or who reads it.
+- Someone asks "why does the gateway think its EUI is X" or "why did the
+  gateway's identity change after a repair."
+- You are adding a new `CHIRPSTACK_PROFILE_*` / `CHIRPSTACK_APP_*` variable for
+  a new device type, or need to know why profile UUIDs differ per Pi.
+- You need to know whether gateway-health retention days can be overridden.
+- You are touching `settings.js`, `deploy.sh`, or `/api/system/features` and
+  need to know what is load-bearing versus decorative.
+- You are adding a brand-new config flag and need the full checklist.
+
+## When NOT to use
+
+- Diagnosing a symptom ("gateway won't connect," "MQTT down") — use
+  `osi-debugging-playbook` for triage, then come back here once you know which
+  knob is implicated.
+- Executing a live-Pi repair (identity repair, `.chirpstack.env` cleanup,
+  restoring service) — the step-by-step runbook lives in
+  `osi-live-ops-runbook`. This skill tells you what the trap is; that skill
+  tells you how to fix it live.
+- Editing `flows.json` node-by-node (adding nodes, wiring, function bodies) —
+  use `osi-flows-json-editing` for mechanics. This skill only documents the
+  env/UCI-facing surface flows.json reads.
+- Schema/migration work (`database/migrations`, `farming.db` DDL) — use
+  `osi-schema-change-control`.
+- Sensor/domain semantics (what SWT, dendro ratio, or LoRain rainfall mean) —
+  use `osi-agronomy-sensors-reference`.
+
+## Master table: config surfaces
+
+| Surface | Defined | Consumed | Live inspect |
+|---|---|---|---|
+| UCI `osi-server.cloud.*` | `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/96_osi_server_config` | `node-red.init` (procd env), `chirpstack-bootstrap.js`, flows.json (account-link nodes) | `uci show osi-server` |
+| Gateway identity (`DEVICE_EUI*`) | `usr/libexec/osi-gateway-identity.sh` (resolution logic) + UCI persistence | `node-red.init` → Node-RED process env → flows.json | `/usr/libexec/osi-gateway-identity.sh resolve` |
+| `.chirpstack.env` (legacy fallback) | Written by `chirpstack-bootstrap.js` | Read per-key by `node-red.init` (`load_chirpstack_env_value`) and `settings.js` compat loader | `cat /srv/node-red/.chirpstack.env` (never commit/paste secrets) |
+| `CHIRPSTACK_PROFILE_*` / `CHIRPSTACK_APP_*` | `chirpstack-bootstrap.js` (creates ChirpStack objects, writes UCI + env file) | `node-red.init` exports as process env; flows.json reads via `env.get(...)` | `scripts/diagnose-pi-communication.sh` |
+| `OSI_HEALTH_RAW_RETENTION_DAYS` / `OSI_HEALTH_HOURLY_RETENTION_DAYS` | Inline default in the flows.json rollup function (`14`, `365`) | Same function, via Node-RED `env.get(...)` | no live override mechanism is wired — see below |
+| Node-RED `settings.js` | `feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js` | Node-RED runtime on boot | `cat /srv/node-red/settings.js` |
+| `deploy.sh` | Repo root | Run manually on-Pi — see `osi-live-ops-runbook` deploy runbook (download-then-run, not `curl \| sh`) | n/a (script itself) |
+| `/api/system/features` | flows.json, node `history-api-router-fn` | `web/react-gui/src/history/useFeatureFlags.ts` | `curl http://127.0.0.1:1880/api/system/features` |
+
+---
+
+## 1. UCI `osi-server.cloud.*`
+
+Defined in full in
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/96_osi_server_config`
+(verified byte-identical to the bcm2709 profile's copy of the same file,
+2026-07-06). This uci-defaults script runs once on first boot and seeds every
+key with a default, then commits.
+
+| Key | Purpose | Default | Read/write by |
+|---|---|---|---|
+| `enabled` | Master on/off switch for cloud integration (not read by any grepped consumer as of 2026-07-06 — treat as reserved/unused; do not assume it gates anything) | `0` | uci-defaults only |
+| `device_eui` | Persisted canonical gateway EUI | resolved at boot by the identity helper, else empty | Written by `osi-gateway-identity.sh` (`gateway_identity_persist`); read by `node-red.init`, `chirpstack-bootstrap.js` |
+| `device_eui_source` | Where the EUI came from (`concentratord-runtime`, `concentratord-uci-<chipset>`, `concentratord-toml-<chipset>`, `linked`, `persisted`, `mac:<iface>`) | resolved at boot | Same as above |
+| `device_eui_confidence` | `authoritative` \| `persisted` \| `provisional` | resolved at boot | Same as above; gates whether account-linking is allowed (provisional blocks linking — see section 2) |
+| `device_eui_last_verified_at` | ISO-8601 UTC timestamp of last resolution | resolved at boot | Same as above |
+| `link_gateway_device_eui` | Server-linked override EUI written during account-link flow | empty | Written by flows.json account-link finalize node; read by `gateway_identity_read_linked` (highest-priority persisted source, see section 2) |
+| `device_type` | Reported device type string | `GATEWAY` | `node-red.init` exports as `DEVICE_TYPE` |
+| `firmware_version` | Reported firmware version string | `0.6.5` (2026-07-06; bump on release) | `node-red.init` exports as `FIRMWARE_VERSION` |
+| `server_host` | Cloud host set during account-link (used to persist/restore MQTT/server host across link/unlink), separate from the hardcoded telemetry broker URL (section 9) | empty | flows.json account-link nodes write it; `node-red.init` exports as `OSI_SERVER_HOST` |
+| `mqtt_password` | **Secret.** Cloud MQTT password used to build `/srv/node-red/flows_cred.json` | empty | Written by flows.json account-link finalize node; read by `node-red.init`. **Never print, log, or commit this value.** |
+| `allow_private_target` | Dev/test escape hatch allowing `http://` or private/loopback hosts for account-link `serverUrl` | `0` | flows.json `allowPrivateTargets()` reads via UCI directly (`uci -q get osi-server.cloud.allow_private_target`), also via `ALLOW_PRIVATE_SERVER_URLS`/`ALLOW_INSECURE_SERVER_URL` env fallback |
+| `openagri_weather_url` | OpenAgri weather integration endpoint | empty | `node-red.init` exports as `OPENAGRI_WEATHER_URL` |
+| `openagri_weather_username` | OpenAgri basic-auth username | empty | exports as `OPENAGRI_WEATHER_USERNAME` |
+| `openagri_weather_password` | **Secret.** OpenAgri basic-auth password | empty | exports as `OPENAGRI_WEATHER_PASSWORD` |
+| `openagri_weather_bearer_token` | **Secret.** OpenAgri bearer token (alternative to basic auth) | empty | exports as `OPENAGRI_WEATHER_BEARER_TOKEN` |
+| `openagri_weather_radius_km` | Weather station search radius | `10` | exports as `OPENAGRI_WEATHER_RADIUS_KM` |
+| `openagri_weather_current_cache_minutes` | Current-conditions cache TTL | `30` | exports as `OPENAGRI_WEATHER_CURRENT_CACHE_MINUTES` |
+| `openagri_weather_forecast_cache_minutes` | Forecast cache TTL | `120` | exports as `OPENAGRI_WEATHER_FORECAST_CACHE_MINUTES` |
+| `chirpstack_app_sensors`, `chirpstack_app_actuators`, `chirpstack_app_field_tester` | Per-installation ChirpStack application UUIDs | unset until bootstrap runs | Written by `chirpstack-bootstrap.js`; see section 3 |
+| `chirpstack_profile_kiwi`, `chirpstack_profile_strega`, `chirpstack_profile_lsn50`, `chirpstack_profile_clover`, `chirpstack_profile_rak10701`, `chirpstack_profile_s2120` | Per-installation ChirpStack device-profile UUIDs | unset until bootstrap runs | Written by `chirpstack-bootstrap.js`; see section 3 |
+
+Note: `chirpstack-bootstrap.js` writes `CHIRPSTACK_PROFILE_LORAIN` to both the
+env file and UCI — `chirpstack_profile_lorain` **is** mapped in
+`toUciCloudKey()` (`scripts/chirpstack-bootstrap.js:299`, mirrored at
+`conf/.../usr/share/node-red/chirpstack-bootstrap.js`). The real asymmetry is
+in `node-red.init`: its `resolve_chirpstack_value` list and `procd_set_param
+env` block omit `CHIRPSTACK_PROFILE_LORAIN`, so at Node-RED runtime the LoRain
+profile ID arrives only via `settings.js`'s `.chirpstack.env` compat loader,
+not via the UCI→procd path the other profiles use (as of 2026-07-06).
+
+**Live inspection:** `uci show osi-server` on the Pi. This prints
+`mqtt_password`, `openagri_weather_password`, and
+`openagri_weather_bearer_token` in **plaintext** — treat that output as
+sensitive and never paste it into a chat, issue, or log you don't control.
+
+**Re-verify this table:**
+```
+grep -n "uci -q batch\|^set " conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/96_osi_server_config
+```
+
+---
+
+## 2. DEVICE_EUI resolution — the identity precedence chain
+
+Gateway identity resolution is centralized in
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/libexec/osi-gateway-identity.sh`
+(same file, byte-identical, under the bcm2709 profile). It defines shell
+functions sourced by three call sites: `96_osi_server_config` (uci-defaults,
+first boot), `node-red.init` (every Node-RED start), and
+`chirpstack-bootstrap.js` (via `osi-gateway-identity.sh resolve`, shelled out).
+
+`gateway_identity_resolve()` tries sources in this exact order, first match
+wins:
+
+1. **`concentratord-runtime`** — `sh /usr/bin/gateway-id.sh` (live
+   concentratord query). Always `authoritative` confidence — this source is
+   explicitly exempt from the MAC-coincidence demotion described below.
+2. **`concentratord-uci-<chipset>`** — UCI `chirpstack-concentratord.@<chipset>[0].gateway_id`
+   for whichever chipset (`sx1301`/`sx1302`) is active per
+   `chirpstack-concentratord.@global[0].chipset`.
+3. **`concentratord-toml-<chipset>`** — same, read from the concentratord TOML
+   config file instead of UCI.
+4. **`linked`** — UCI `osi-server.cloud.link_gateway_device_eui` (set when an
+   account-link flow completes). Confidence is always `persisted`.
+5. **`persisted`** — UCI `osi-server.cloud.device_eui`, but only if its stored
+   confidence is empty, `authoritative`, or `persisted` (a stored
+   `provisional` value is deliberately skipped here and re-resolved).
+6. **`mac:<iface>`** — derived from `eth0`/`br-lan`/`wlan0` MAC address
+   (EUI-48 → EUI-64 via `FFFE` insertion). Always `provisional` confidence —
+   this is a last-resort guess, not a real gateway ID.
+
+The MAC-coincidence demotion applies only to steps 2–3: if a UCI/TOML-sourced
+EUI coincidentally equals what the local MAC-derived fallback would produce
+(meaning it can't be proven to be a real LoRa concentrator ID), that source is
+demoted to `provisional` and skipped, falling through to the next source. Step
+1 is unconditionally `authoritative`; steps 4–5 carry fixed `persisted`
+confidence and never apply the MAC check.
+
+`node-red.init` calls the sequence `resolve → repair_concentratord_config →
+resolve → persist` on every Node-RED start: the first resolve finds the
+current best answer, `gateway_identity_repair_concentratord_config` writes
+that EUI back into the active chipset's UCI `gateway_id` (and clears the
+inactive chipset's sibling section) if confidence is not provisional, the
+second resolve re-reads post-repair state, and `persist` commits the final
+answer to `osi-server.cloud.device_eui*`.
+
+**THE TRAP.** `/srv/node-red/.chirpstack.env` is a legacy compatibility file.
+`settings.js` explicitly protects identity keys from it:
+
+```js
+const protectedKeys = new Set([
+    'DEVICE_EUI', 'DEVICE_EUI_SOURCE', 'DEVICE_EUI_CONFIDENCE',
+    'DEVICE_EUI_LAST_VERIFIED_AT', 'LINK_GATEWAY_DEVICE_EUI'
+]);
+```
+(`feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js`) — so
+`settings.js`'s own env-file loader will never let a stale `.chirpstack.env`
+override an already-set `DEVICE_EUI`. **However**, `node-red.init` sets
+`DEVICE_EUI` via `procd_set_param env` directly from the UCI/helper
+resolution — it does not consult `.chirpstack.env` for identity at all. The
+real risk is elsewhere: other tooling or an operator manually sourcing
+`.chirpstack.env`, or `chirpstack-bootstrap.js` re-run with a stale
+`ENV_FILE`, can reintroduce a stale `DEVICE_EUI` value into that file, and any
+future code path that trusts `.chirpstack.env` wholesale (rather than the
+per-key protected-list loader) would pick it up. `chirpstack-bootstrap.js`
+itself is explicitly guarded against writing a stale identity:
+`scripts/verify-sync-flow.js` asserts the bootstrap script does **not**
+contain `envVars.DEVICE_EUI = gatewayEui` (it only ever writes
+`CHIRPSTACK_*` keys to the env file, never identity keys). Treat any
+`.chirpstack.env` that still contains `DEVICE_EUI*` lines as a stale
+artifact to remove during an identity repair.
+
+Canonical EUI is always **UPPERCASE** 16 hex chars (`normalize_gateway_eui` /
+`normalizeGatewayEui` uppercase and reject the all-`01` invalid pattern). The
+full identity-repair procedure (removing the stale file, restarting services,
+confirming `uci show osi-server` matches concentratord) lives in
+`osi-live-ops-runbook` — this section only documents the mechanism and the
+trap.
+
+**Consequence:** changing `DEVICE_EUI` invalidates the linked-login offline
+verifier, which is `bcrypt(password::DEVICE_EUI)` — any EUI change forces a
+verifier regeneration. The repair sequence for this is also in
+`osi-live-ops-runbook`.
+
+**Account-link gate:** flows.json's account-link node explicitly refuses to
+link while `gatewayDeviceEuiConfidence === 'provisional'` (HTTP 503, "Gateway
+identity is not ready yet"), so a MAC-fallback-only gateway cannot complete
+cloud linking until concentratord reports a real ID.
+
+**Re-verify:**
+```
+grep -n "gateway_identity_resolve\|gateway_identity_read_linked\|gateway_identity_read_persisted" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/libexec/osi-gateway-identity.sh
+grep -n "protectedKeys" feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js
+grep -n "envVars.DEVICE_EUI" scripts/verify-sync-flow.js
+```
+
+---
+
+## 3. `CHIRPSTACK_PROFILE_*` / `CHIRPSTACK_APP_*`
+
+`chirpstack-bootstrap.js` (repo copies: `scripts/chirpstack-bootstrap.js` and
+mirrored under both hardware profiles'
+`files/usr/share/node-red/chirpstack-bootstrap.js`) runs once per gateway (via
+`osi-bootstrap` init script, `START=99`, after ChirpStack's gRPC API answers)
+and creates-or-reuses:
+
+- 3 ChirpStack applications: **OSI Sensors**, **OSI Actuators**, **OSI Field Tester**
+- 6 device profiles: **KIWI Sensor**, **STREGA Valve**, **Dragino LSN50**,
+  **RAK Field Tester**, **SenseCAP S2120**, **Aqua-Scope LoRain**
+- 1 API key (`osi-nodered`)
+
+Verified full set of env vars it writes (`writeEnvFile` / `envVars` object in
+`chirpstack-bootstrap.js`):
+
+| Env var | Maps to | UCI key (via `toUciCloudKey`) |
+|---|---|---|
+| `CHIRPSTACK_API_URL` | ChirpStack gRPC endpoint | none (env-file only) |
+| `CHIRPSTACK_API_KEY` | **Secret.** osi-nodered API key | none (env-file only) |
+| `CHIRPSTACK_APP_SENSORS` | OSI Sensors app UUID | `chirpstack_app_sensors` |
+| `CHIRPSTACK_APP_ACTUATORS` | OSI Actuators app UUID | `chirpstack_app_actuators` |
+| `CHIRPSTACK_APP_FIELD_TESTER` | OSI Field Tester app UUID | `chirpstack_app_field_tester` |
+| `CHIRPSTACK_PROFILE_KIWI` | KIWI Sensor profile UUID | `chirpstack_profile_kiwi` |
+| `CHIRPSTACK_PROFILE_STREGA` | STREGA Valve profile UUID | `chirpstack_profile_strega` |
+| `CHIRPSTACK_PROFILE_LSN50` | Dragino LSN50 profile UUID | `chirpstack_profile_lsn50` |
+| `CHIRPSTACK_PROFILE_CLOVER` | **Alias** — intentionally set to the same UUID as `CHIRPSTACK_PROFILE_RAK10701` (compatibility alias for the RAK10701 field tester profile, not a separate profile) | `chirpstack_profile_clover` |
+| `CHIRPSTACK_PROFILE_RAK10701` | RAK Field Tester profile UUID | `chirpstack_profile_rak10701` |
+| `CHIRPSTACK_PROFILE_S2120` | SenseCAP S2120 profile UUID | `chirpstack_profile_s2120` |
+| `CHIRPSTACK_PROFILE_LORAIN` | Aqua-Scope LoRain profile UUID | **none** — no UCI mapping exists; env-file only (see section 1 note) |
+
+All `CHIRPSTACK_APP_*`/`CHIRPSTACK_PROFILE_*` values are validated as
+ChirpStack UUIDs (`assertValidUciValue`, regex
+`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`) before being
+written to UCI, and a readback check (`uci -q get` immediately after `uci
+set`) confirms the commit landed.
+
+**Why UUIDs are per-installation:** each gateway's `chirpstack-bootstrap.js`
+run creates its own tenant/apps/profiles against its own local ChirpStack
+instance — there is no shared/global UUID. Hardcoding a UUID observed on one
+gateway into flows.json or a script will silently break every other gateway
+(confirmed pattern the codebase actively guards against — see
+`extract_from_legacy_flow`'s comment in `scripts/prepare-pi-communication-config.sh`
+about not trusting a bare `FIXED_APP_ID` fallback).
+
+**Who consumes them:** `node-red.init` resolves each one **except
+`CHIRPSTACK_PROFILE_LORAIN`** with `resolve_chirpstack_value` (UCI first, then
+per-key `.chirpstack.env` fallback via `load_chirpstack_env_value`, logging the
+source via `logger -t node-red.init`) and exports the result as a Node-RED
+process env var; LORAIN reaches the runtime only through `settings.js`'s
+`.chirpstack.env` compat loader (see section 1 note, as of 2026-07-06).
+flows.json function nodes then read them with `env.get('CHIRPSTACK_PROFILE_S2120')`
+etc. to discriminate device type on uplink. The actual MQTT topic
+subscription rule and the `deviceProfileName`-fallback discrimination pattern
+inside flows.json are mechanics of `osi-flows-json-editing` — not duplicated
+here.
+
+**Deploy-time post-check:** `deploy.sh` does **not** assert
+`CHIRPSTACK_PROFILE_RAK10701` or `CHIRPSTACK_PROFILE_S2120` anywhere (verified
+by reading the full 687-line file: it fetches, seeds the DB conditionally, and
+repairs schema — it has no ChirpStack-profile assertions at all). The actual
+check for "is RAK10701/S2120 provisioned" is `scripts/diagnose-pi-communication.sh`
+(prints `uci.chirpstack_profile_rak10701` / `env.CHIRPSTACK_PROFILE_S2120`) and
+`scripts/prepare-pi-communication-config.sh` (repairs missing UCI values from
+the env-file/legacy-flow fallback, `--dry-run` by default). Both are operator
+tools run manually on the Pi, not something `deploy.sh` gates automatically —
+if you were told a "deploy post-check" enforces this, that check is a manual
+operator step (`osi-live-ops-runbook`), not code in `deploy.sh`.
+
+The preflight `deploy.sh` *does* run
+(`run_communication_preflight` → `scripts/verify-communication-contract.js`)
+only checks that `node-red.init` **exports** `CHIRPSTACK_PROFILE_RAK10701` as
+a shell variable — it does not check the UUID is valid or present on the
+target Pi.
+
+**Re-verify:**
+```
+grep -n "CFG = {" -A 25 scripts/chirpstack-bootstrap.js
+grep -n "toUciCloudKey\|mapping = {" -A 15 scripts/chirpstack-bootstrap.js
+grep -n "CHIRPSTACK_PROFILE_RAK10701\|CHIRPSTACK_PROFILE_S2120" deploy.sh   # expect: no matches
+grep -n "chirpstack_profile" scripts/diagnose-pi-communication.sh
+```
+
+---
+
+## 4. Gateway-health retention: `OSI_HEALTH_RAW_RETENTION_DAYS` / `OSI_HEALTH_HOURLY_RETENTION_DAYS`
+
+Consumed inline inside the `Gateway Health Rollup` function node in
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json` (runs daily
+at 02:10; ordered migration `database/migrations/ordered/0002__gateway_health.sql`,
+osi-os #68):
+
+```js
+var rawDays = parseInt(String(env.get('OSI_HEALTH_RAW_RETENTION_DAYS') || '14').trim(), 10);
+if (!isFinite(rawDays) || rawDays < 1) { rawDays = 14; }
+var hourlyDays = parseInt(String(env.get('OSI_HEALTH_HOURLY_RETENTION_DAYS') || '365').trim(), 10);
+if (!isFinite(hourlyDays) || hourlyDays < 1) { hourlyDays = 365; }
+```
+
+Defaults: **14 days** raw (`gateway_health_samples`, 1 row/60s heartbeat),
+**365 days** hourly rollup (`gateway_health_hourly`, min/mean/max per closed
+UTC hour). Documented in
+`docs/operations/edge-history-retention.md`.
+
+**Honest status on override plumbing:** `env.get(...)` inside a Node-RED
+function node resolves against that node's/flow's configured Environment
+Variables, falling back to the Node-RED process environment
+(`process.env`) if none is set at the node/flow level. Node-RED's `env.get`
+does **not** read UCI. As of 2026-07-06, `node-red.init`'s `procd_set_param
+env` list (the process-env injection point — see section 1's table) does
+**not** include `OSI_HEALTH_RAW_RETENTION_DAYS` or
+`OSI_HEALTH_HOURLY_RETENTION_DAYS`, there is no `osi-server.cloud.*` UCI key
+for either, and `docs/operations/edge-history-retention.md` documents the
+variable names but not a concrete override mechanism. **Treat these as
+currently unplumbed for live override** — changing them today requires
+editing the literal `'14'`/`'365'` default-fallback string inside flows.json
+(a flows.json edit, subject to `osi-flows-json-editing` + normal review), not
+a runtime knob an operator can flip. If you need a live override, wiring
+`procd_set_param env OSI_HEALTH_RAW_RETENTION_DAYS=...` in `node-red.init`
+plus an `osi-server.cloud.*` UCI default is the natural place to add it (see
+section 8 checklist) — but that plumbing does not exist yet.
+
+This data is local-only (not cloud-synced in v1); this table only summarizes
+retention, it is not the home for gateway-health schema or column semantics
+(see `docs/operations/edge-history-retention.md` for that).
+
+**Re-verify:**
+```
+grep -n "OSI_HEALTH_RAW_RETENTION_DAYS\|OSI_HEALTH_HOURLY_RETENTION_DAYS" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+grep -n "OSI_HEALTH" feeds/chirpstack-openwrt-feed/apps/node-red/files/node-red.init   # expect: no matches (unplumbed)
+grep -n "OSI_HEALTH" docs/operations/edge-history-retention.md
+```
+
+---
+
+## 5. Node-RED `settings.js`
+
+Repo source:
+`feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js` → deployed to
+`/srv/node-red/settings.js` by `deploy.sh`. There is exactly one **deployed**
+`settings.js` in the repo (shared across both hardware profiles — it is not
+duplicated per profile the way flows.json is; a separate, unrelated
+`settings.js` exists under `feeds/chirpstack-openwrt-feed/apps/node-red-node-sqlite/files/`
+but is not the one deploy.sh ships).
+
+Load-bearing settings, verified by reading the file:
+
+| Setting | Value | Why it matters |
+|---|---|---|
+| `functionExternalModules: true` | enabled | Required for function nodes to `require()` external/local npm libraries (the `osi-*-helper` packages, `bcryptjs`, etc.). Without this, most of flows.json's function nodes fail at deploy/runtime. |
+| `httpStatic` / `httpStaticRoot` | `/usr/lib/node-red/gui` served at `/gui` | This is how the React dashboard is served — not a separate web server. |
+| `flowFile` | `"flows.json"` | Relative to `userDir` |
+| `userDir` | `/srv/node-red` | Where Node-RED looks for `flows.json`, `flows_cred.json`, `package.json`, helper packages |
+| `uiPort` | `process.env.PORT \|\| 1880` | Standard Node-RED port; `PORT` env override exists but nothing in the repo sets `PORT` today |
+| `functionGlobalContext` | exposes `os`, `fs`, `cp` (child_process) to every function node | flows.json function nodes rely on `global.get('fs')`/`global.get('cp')` — do not remove these without auditing every consumer |
+| `exportGlobalContextKeys: false` | disabled | Keeps the global context out of the editor's context-data sidebar (cosmetic/security, not functional) |
+| env-file compat loader (top of file, before `module.exports`) | loads `/srv/node-red/.chirpstack.env` into `process.env` for any key **not already set** and **not** in the identity `protectedKeys` set | This is the second-priority fallback in the precedence chain from section 2 — `node-red.init` (procd env) always wins over this loader for the keys it sets, and identity keys can never come from this loader at all |
+
+There is no `credentialSecret` configured in this file — Node-RED will fall
+back to its own auto-generated/stored secret behavior; this skill does not
+document that mechanism further since no explicit value is set here to
+verify.
+
+**Companion fact (pointer only):** `/srv/node-red/package.json` (repo source
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/package.json`)
+must declare `"osi-db-helper": "file:osi-db-helper"` (confirmed present,
+alongside `osi-chameleon-helper`, `osi-chirpstack-helper`, `osi-cloud-http`,
+`osi-dendro-helper`, `osi-history-helper`) or Node-RED refuses to load flows
+that require it. The fix procedure for a live Pi missing this dependency is in
+`osi-live-ops-runbook`.
+
+**Re-verify:**
+```
+grep -n "functionExternalModules\|httpStatic\|protectedKeys" feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js
+grep -n "osi-db-helper" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/package.json
+```
+
+---
+
+## 6. `deploy.sh` knobs
+
+`deploy.sh` (repo root, 687 lines, verified 2026-07-06) runs **on the Pi**,
+fetching artifacts over a tunnelled local HTTP server. Actual tunables and
+decision points, read from the file (no invented ones):
+
+| Knob | What it does |
+|---|---|
+| `$1` (positional arg, default `9876`) | HTTP port the deploy source server is tunnelled on (`PORT="${1:-9876}"`) |
+| `/proc/device-tree/model` | Auto-detects Pi 5 vs Pi 4/400/3/2 vs Pi Zero/Model to pick the matching seed DB path (`detect_seed_db_rel`); unknown models fall back to the bcm2712 (Pi 5) seed as the canonical default |
+| DB seeding gate | `seed_db_if_missing` only copies the bundled seed DB when `/data/db/farming.db` is **absent** *and* no `-wal`/`-shm`/`-journal` sidecar files exist; otherwise it refuses (exits 1) or skips. **Never** overwrite a live DB — full rule and recovery steps are in `osi-live-ops-runbook`. |
+| Live schema repair functions | `ensure_dendro_schema`, `ensure_zone_irrigation_calibration_schema`, `ensure_analysis_views_schema`, `ensure_chameleon_schema`, `ensure_gateway_health_schema` — each is idempotent (checks `PRAGMA table_info` / catches `duplicate column name`) and runs unconditionally on every deploy if `farming.db` exists. `ensure_gateway_health_schema` specifically fetches `database/migrations/ordered/0002__gateway_health.sql` and refuses to apply it unless its first line is `-- risk: additive` — a hard-coded safety gate against ever running a non-additive migration through this path. |
+| `run_communication_preflight` | Fetches `scripts/verify-communication-contract.js` plus copies of flows.json (all three hardware profiles), `node-red.init`, `settings.js`, `chirpstack-bootstrap.js`, `diagnose-pi-communication.sh` into a temp dir and runs the contract verifier against them **before** touching the live install. Aborts the whole deploy on failure. |
+| `npm install --omit=dev --no-fund --no-audit` | Installs Node-RED runtime dependencies on-device from the fetched `package.json`/`package-lock.json`; failure aborts the deploy (last 80 log lines printed to stderr) |
+| `fix_mosquitto_ownership` | Repairs file ownership/permissions on `mosquitto.passwd`/`.acl`/`/var/lib/mosquitto` if mosquitto is installed, using the UCI-configured mosquitto user if set |
+| React GUI swap | Fetches `react_gui.tar.gz`, wipes `/usr/lib/node-red/gui/*` (including dotfiles), extracts fresh bundle |
+
+**What it restarts:** nothing, automatically. `deploy.sh`'s final output
+explicitly tells the operator to run `/etc/init.d/node-red restart`
+manually — confirmed by reading the trailing `echo` block; there is no
+`/etc/init.d/node-red restart` call anywhere in the script itself. ChirpStack
+re-provisioning (`osi-bootstrap`, `START=99`) only happens automatically on
+the next full boot, or can be triggered manually with
+`node /usr/share/node-red/chirpstack-bootstrap.js` (per the script's own
+closing instructions).
+
+**Re-verify:**
+```
+grep -n "^[a-z_]*() {" deploy.sh
+grep -n "restart" deploy.sh   # expect: only in the trailing echo instructions, not an executed command
+```
+
+---
+
+## 7. Feature flags: `/api/system/features`
+
+Served by the `history-api-router-fn` function node in flows.json (node id
+`history-api-router-fn`, HTTP GET node `history-system-features-http`). The
+handler is a hardcoded literal block, not read from UCI/env at all:
+
+```js
+if (requestMethod === 'GET' && requestPath === '/api/system/features') {
+  return respond(200, {
+    generatedAt: nowIso(),
+    features: {
+      historyUxEnabled: true,
+      historyComparisonEnabled: false,
+      historyWorkspacesEnabled: false,
+      historyAdvancedOverlaysEnabled: false,
+      historyCloudAiEnabled: false
+    }
+  });
+}
+```
+
+Verified exact flag set and defaults, as shipped (2026-07-06):
+
+| Flag | Shipped value | Meaning |
+|---|---|---|
+| `historyUxEnabled` | `true` | Master switch for the history dashboard UX |
+| `historyComparisonEnabled` | `false` | Cross-period/zone comparison views |
+| `historyWorkspacesEnabled` | `false` | Saved analysis workspaces |
+| `historyAdvancedOverlaysEnabled` | `false` | Advanced chart overlays |
+| `historyCloudAiEnabled` | `false` | Cloud-AI-assisted interpretation features |
+
+**GUI consumption:** `web/react-gui/src/history/useFeatureFlags.ts` fetches
+this endpoint via SWR and exposes `flags`, `historyEnabled` (`=
+historyUxEnabled`), and `isUnavailable`. Also consumed by
+`web/react-gui/src/services/api.ts` (`systemAPI.getFeatures`, type
+`SystemFeatureFlags`) and rendered in `web/react-gui/src/pages/HistoryDashboard.tsx`.
+The GUI's own `defaultHistoryFeatureFlags` constant defaults every flag to
+`false` (used only while the fetch is loading/failed) — do not confuse that
+client-side loading default with the server's actual shipped defaults above.
+
+**How to toggle:** there is no runtime toggle. Changing a flag means editing
+the literal object inside flows.json's `history-api-router-fn` node — a normal
+code change subject to review, the `osi-flows-json-editing` mechanics, and the
+bcm2709 profile-parity mirror requirement (section 8). There is no sanctioned
+procedure for live-patching this block on a running Pi; if an emergency ever
+forces it, coordinate with the operator, take a backup first, and re-deploy
+properly through review afterward — it is never the path to ship a flag change.
+
+**Re-verify:**
+```
+grep -n "historyUxEnabled\|historyComparisonEnabled\|historyWorkspacesEnabled\|historyAdvancedOverlaysEnabled\|historyCloudAiEnabled" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+grep -n "SystemFeatureFlags\|defaultHistoryFeatureFlags" web/react-gui/src/services/api.ts web/react-gui/src/history/useFeatureFlags.ts
+```
+
+---
+
+## 8. Checklist: adding a new config flag
+
+1. Decide the layer: durable per-installation identity/secret → UCI
+   `osi-server.cloud.*` (add to `96_osi_server_config` with a safe default);
+   ChirpStack-object-derived → follow the `chirpstack-bootstrap.js` pattern
+   (env file + `toUciCloudKey` mapping); pure feature toggle with no
+   per-install variance → flows.json constant (section 7 pattern).
+2. If UCI: add the key with its default to
+   `conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/96_osi_server_config`
+   inside the `uci -q batch` block.
+3. Add the read path: `node-red.init`'s `start_service()` (export as
+   `procd_set_param env`), and/or `chirpstack-bootstrap.js`'s `CFG` object if
+   it's bootstrap-time-only.
+4. If flows.json needs to read it, use `env.get('YOUR_KEY')` inside the
+   relevant function node — follow `osi-flows-json-editing` for the mechanics
+   of adding/wiring nodes.
+5. **Mirror to bcm2709 byte-for-byte.** Any change under
+   `conf/full_raspberrypi_bcm27xx_bcm2712/files/` (including
+   `96_osi_server_config`, `osi-gateway-identity.sh`) must be propagated
+   identically to `conf/full_raspberrypi_bcm27xx_bcm2709/files/` — the
+   *contents* of `feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js`
+   and `node-red.init` are shared (not per-profile), so those two files do not
+   need mirroring, only the `conf/full_raspberrypi_bcm27xx_bcm{2712,2709}`
+   tree does. `scripts/verify-profile-parity.js` (chained from
+   `scripts/verify-sync-flow.js`) enforces this in CI — mechanics and how to
+   run it are documented in `osi-flows-json-editing`.
+6. Update this skill's tables (section 1–7) so the map stays accurate — one
+   home per fact.
+7. If the flag gates safety-relevant behavior (e.g. anything that could touch
+   `farming.db` mutation risk, private-target allowance, or identity), add or
+   extend a verifier/guard (`scripts/verify-communication-contract.js`,
+   `scripts/verify-sync-flow.js`, or a new `scripts/verify-*.js`) rather than
+   relying on manual review alone.
+8. If the fact is durable repo-level knowledge (not a one-off), add a line to
+   `AGENTS.md` — do not duplicate the detail here and there; cross-reference.
+
+---
+
+## 9. Version / identity / broker facts
+
+| Fact | Value | Where set / verified |
+|---|---|---|
+| `firmware_version` default | `0.6.5` (as of 2026-07-06 — bump on release, re-check before quoting) | `96_osi_server_config`, also the inline fallback default in `node-red.init` (`fw_version=$(uci -q get ... || echo "0.6.5")`) |
+| MQTT telemetry broker URL | `wss://server.opensmartirrigation.org/mqtt`, port `443` | **Hardcoded** in the flows.json `mqtt-broker` node named "OSI Cloud Broker" (`broker` field literal) — this is a compile-time constant, not read from `server_host`/UCI/env at all. Its `credentials.user`/`credentials.password` fields use Node-RED's `${DEVICE_EUI}` / `${DEVICE_MQTT_PASSWORD}` template-expansion syntax, resolved from the process env `node-red.init` sets. |
+| `osi-server.cloud.server_host` | separate concern from the broker URL above — it is the cloud host recorded/restored during account-link (`OSI_SERVER_HOST` env var), used for REST sync target bookkeeping, not for the MQTT connection itself | flows.json account-link finalize/rollback/restore nodes |
+| MQTT client ID | `device_${DEVICE_EUI}` template in the broker node config, but also force-rewritten literally into `/srv/node-red/flows.json` on every Node-RED start by an inline Node snippet in `node-red.init` (because Node-RED does not expand `${VAR}` in `clientid ` reliably across versions in this deployment's testing) | `node-red.init`, `start_service()` |
+
+**Re-verify:**
+```
+grep -n '"broker": "wss://' conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+grep -n "fw_version=" feeds/chirpstack-openwrt-feed/apps/node-red/files/node-red.init
+grep -n "firmware_version" conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/96_osi_server_config
+```
+
+---
+
+## Common mistakes
+
+- Assuming `OSI_SERVER_HOST` / `server_host` controls the MQTT telemetry
+  broker. It does not — that URL is hardcoded in flows.json (section 9).
+- Assuming `.chirpstack.env` is dead weight that's safe to delete blindly.
+  It's still the fallback path for every `CHIRPSTACK_*` key that isn't yet in
+  UCI (fresh bootstrap before first successful UCI write, or a key like
+  `CHIRPSTACK_PROFILE_LORAIN` that has no UCI mapping at all) — removing it
+  is correct only for identity keys during a repair, not universally.
+  `osi-live-ops-runbook` has the actual repair sequence.
+- Believing `OSI_HEALTH_*_RETENTION_DAYS` can be tuned per-gateway today. It
+  cannot without a flows.json edit — there is no UCI/env plumbing yet
+  (section 4).
+- Editing `settings.js` or `node-red.init` under
+  `conf/full_raspberrypi_bcm27xx_bcm2712/` — they don't live there. Both are
+  under `feeds/chirpstack-openwrt-feed/apps/node-red/files/` and are shared
+  (not profile-specific), unlike flows.json which is genuinely duplicated
+  per hardware profile.
+- Treating `CHIRPSTACK_PROFILE_CLOVER` as a distinct profile from
+  `CHIRPSTACK_PROFILE_RAK10701`. They are intentionally the same UUID
+  (compatibility alias) — do not "fix" this by giving CLOVER its own profile
+  without understanding why the alias exists.
+- Assuming deploy.sh enforces ChirpStack profile completeness. It doesn't;
+  that's a manual operator check (`diagnose-pi-communication.sh`).
+
+## Provenance and maintenance
+
+This skill embeds knowledge gathered by reading repository source directly
+(uci-defaults, `osi-gateway-identity.sh`, `chirpstack-bootstrap.js`,
+`node-red.init`, `settings.js`, `deploy.sh`, flows.json, `docs/operations/edge-history-retention.md`,
+`AGENTS.md`) on 2026-07-06 against the `feat/agent-skill-library` worktree.
+Nothing here should contradict `AGENTS.md`; if it does, `AGENTS.md` wins and
+this file is stale — re-verify and fix.
+
+Re-verify the whole surface in one pass:
+```
+grep -n "^set " conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/uci-defaults/96_osi_server_config
+diff conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/libexec/osi-gateway-identity.sh conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/libexec/osi-gateway-identity.sh
+grep -n "CFG = {" -A 25 scripts/chirpstack-bootstrap.js
+grep -n "OSI_HEALTH_.*_RETENTION_DAYS" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+grep -n "functionExternalModules\|protectedKeys" feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js
+grep -n "^[a-z_]*() {" deploy.sh
+grep -n "historyUxEnabled" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+node scripts/verify-communication-contract.js
+node scripts/verify-profile-parity.js
+```

--- a/.claude/skills/osi-debugging-playbook/SKILL.md
+++ b/.claude/skills/osi-debugging-playbook/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: osi-debugging-playbook
+description: Use when triaging an OSI OS symptom of unknown root cause — SWT/soil-tension null despite uplinks, "i2c_missing"/"I2C_MISSING", "duplicate column name" from a verifier/upgrade test, EBUSY on /sys/class/pwm, fan not responding, export.csv 401 vs 404, history chart gaps, stale cloud mirror/sync_outbox growth, Node-RED all-routes-404 after deploy, curl exit 52/28 hangs, or "which script checks X".
+---
+
+# OSI Debugging Playbook
+
+## Overview
+
+Symptoms lie about their cause more often than not: a flag named after LoRaWAN can mean a wiring fault, a schema error can mean a stale test baseline, and a 401 can mean "working as intended." Triage by running the cheapest discriminating experiment first — never patch the symptom you were told about before you've confirmed which subsystem actually owns it.
+
+## When to use / when NOT to use
+
+Use this skill when you have an observed symptom (an error string, a null field, a stuck counter, an HTTP status) and need to identify **which subsystem is actually broken** before touching anything.
+
+Do NOT use this skill for:
+- Executing a live-Pi deploy, backup, or stale-fingerprint recovery — see **osi-live-ops-runbook**.
+- Editing `flows.json` itself (node wiring, `libs` bindings, the flows-editor workflow) — see **osi-flows-json-editing**.
+- Making a schema change, migration, or reasoning about seed/bundled-DB parity — see **osi-schema-change-control**.
+- Sensor/agronomy domain semantics (what SWT means agronomically, calibration formulas, wiring physics in depth) — see **osi-agronomy-sensors-reference**.
+- UCI config, env vars, feature flags, or deploy-time knobs — see **osi-config-and-flags**.
+
+This skill only routes you to the right subsystem and the right first command. Once you know the cause class, hand off to the sibling skill that owns the fix.
+
+## Symptom triage table
+
+Read this table top to bottom. Run the "first discriminating experiment" before forming a theory.
+
+| Symptom (exact text) | Likely cause class | First discriminating experiment | Grounding |
+|---|---|---|---|
+| Chameleon soil uplinks arrive on schedule but SWT is null / `i2c_missing=1` in `chameleon_readings` | Device-side I2C acquisition fault (wiring/power) — NOT LoRaWAN, NOT calibration, NOT sync | `SELECT SUM(i2c_missing), SUM(timeout), SUM(data_invalid) FROM chameleon_readings WHERE upper(deveui)=upper('<deveui>') AND recorded_at >= '<window-start>'` — nonzero `i2c_missing` with `timeout=0` and a fixed diagnostic signature (no temp/ID fault) is the signature of the fault, not a probe or radio issue | `docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md` (2026-06-28 field diagnosis); wiring/power root-cause detail lives in **osi-agronomy-sensors-reference** — one-line pointer only |
+| `duplicate column name: <col>` from a schema verifier or upgrade test | Stale upgrade-test baseline (a fixed historical git ref used as the "pre-migration" seed no longer predates the migration it's testing) — NOT the frozen boot-DDL node | Check which ref the test diffs against (e.g. `OSI_HISTORY_BASE_REF` in `scripts/test-sync-history-schema.js`); if `main`'s current `database/seed-blank.sql` already contains the columns the migration tries to `ADD COLUMN`, the base ref is stale, not the schema itself | Issue #84 (closed) — root cause was exactly this: `main:database/seed-blank.sql` absorbed a migration's columns after PR #70 merged, so replaying the migration on top of `main` double-added them. AGENTS.md "Boot-DDL freeze" section documents this exact misattribution risk |
+| `EBUSY` writing `/sys/class/pwm/pwmchip2/pwm3` (fan PWM) | Kernel `pwm-fan` driver owns the raw PWM channel | Check whether `dtparam=cooling_fan=okay` and `kmod-hwmon-pwmfan` are active; if so, the raw sysfs path is owned by the kernel driver — use the hwmon device instead | AGENTS.md "Fan telemetry/control" section: switch fan detection/control to `/sys/class/hwmon/*/pwm1` + `pwm1_enable` |
+| Fan does not respond to `SET_FAN` cloud command | Same class as above, or command-path issue — first rule out the sysfs-ownership class before assuming a command-routing bug | Same discriminator as above | AGENTS.md "Fan telemetry/control" |
+| `GET /api/history/zones/:zoneId/export.csv` returns `401` | HEALTHY — this is an auth-gated route working correctly, not a bug | Confirm the response is `401` (auth-gated) and not `404`/`500`; `401` on this route is a *standard post-deploy pass signal* | Route confirmed in `conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json` ("GET /api/history/zones/:zoneId/export.csv"); part of the standard post-deploy checklist in **osi-live-ops-runbook** |
+| `GET /api/history/zones/:zoneId/export.csv` returns `404` or `500` | Actually broken — route missing or crashing | Diff the live route table against the repo's `flows.json` for this node; check Node-RED logs for the function node's own try/catch | Same route as above; 404/500 is explicitly the "not healthy" branch of the same check |
+| Gaps in sensor history charts | Ambiguous until you separate gateway-down from sensor-down — do this FIRST | Query `gateway_health_samples` / `gateway_health_hourly` for the same time window: a matching gap there means the gateway (or Node-RED) was down, not the sensor | `docs/operations/edge-history-retention.md` "Gateway health telemetry" section; see also `scripts/diagnose-sensor-history-gap.js` below, which diagnoses a *different* thing (edge-vs-cloud row presence, not gateway-down-vs-sensor-down) |
+| Cloud mirror looks stale, `sync_outbox` growing | Sync backlog or broken link — need to know if it's currently healthy before acting | `node scripts/check-sync-parity.js /data/db/farming.db` — exit 0 means the DR net (cloud parity) is current; nonzero means unlinked, rejected events, pending history dirty-keys, or an old undelivered event | `scripts/check-sync-parity.js`, `docs/operations/cloud-parity-dr.md` |
+| Historical data repaired on the edge (e.g. `device_data.swt_*` backfilled from `chameleon_readings`) but charts / cloud mirror still show old/null values | The device_data→outbox sync trigger fires on `INSERT` only; a historical `UPDATE` does not auto-enqueue a sync event | Check `sync_outbox` for `DEVICE_DATA_APPENDED` events covering the repaired rows' `recorded_at` range; if absent, the repair needs to explicitly enqueue them and a rollup rerun | AGENTS.md Chameleon section; confirmed in the 2026-06 field SWT repair (559 backfilled rows needed explicitly enqueued events before the cloud mirror caught up — `docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md`) |
+| All Node-RED HTTP routes return `404` right after a flows deploy, no obvious error in logs | A `libs`-declared npm module (e.g. `osi-db-helper`) is missing from `/srv/node-red/package.json` while `settings.js` has `functionExternalModules: true` — Node-RED fails to load ALL flows silently | Run Node-RED in the foreground: `node-red --userDir /srv/node-red` — the real load error prints there even though the standard log shows nothing useful | Documented pitfall from Pi upgrade history: missing `"osi-db-helper": "file:osi-db-helper"` entry in the userDir `package.json` causes a silent whole-flow load failure; repair procedure lives in **osi-live-ops-runbook** |
+| Edge HTTP endpoint hangs; `curl` exits `52` or `28`; nothing useful in logs | A function node uses an npm module (commonly `sqlite3`) without declaring it in the node's `libs` array — the module is `undefined` at runtime and the async handler never sends a response | Check the node's JSON definition for `"libs": [{"var": "sqlite3", "module": "sqlite3"}]` (or the equivalent for whichever module the handler uses) | Known pitfall: `functionExternalModules: true` enables `require()` in function nodes but does not auto-inject a bound variable — `libs` is the only binding mechanism. Fix pattern and edit workflow live in **osi-flows-json-editing** — pointer only |
+| `npm run test:unit` behaves unexpectedly, or a bare `npx vitest run` gives different/incomplete results | Wrong test invocation — the frontend splits unit tests across two runners | Read `web/react-gui/package.json` `scripts` block directly | See "GUI test invocation" section below |
+
+## GUI test invocation (web/react-gui)
+
+As of 2026-07-06, `web/react-gui/package.json` defines:
+
+```
+"test:unit": "npm run test:unit:tsx-runner && npm run test:unit:vitest",
+"test:unit:tsx-runner": "tsx --test 'tests/**/*.test.ts'",
+"test:unit:vitest": "vitest run src/analysis/__tests__ src/components/analysis/__tests__ src/components/farming/__tests__ src/components/history/__tests__ src/components/__tests__ src/pages/__tests__ src/utils/__tests__ src/channels/__tests__ src/history/__tests__ --passWithNoTests"
+```
+
+`npm run test:unit` is two runners chained: a `tsx --test` pass over `tests/**/*.test.ts`, then a scoped `vitest run` over an explicit list of `src/**/__tests__` directories. A bare `npx vitest run` only runs the vitest half and skips the `tsx --test` suite entirely — it will look "mostly green" while silently omitting a whole test population. Always use `npm run test:unit` (or `cd web/react-gui && npm run test:unit`) for a full signal, never bare `npx vitest run`.
+
+## Diagnostics toolbox
+
+All paths below are relative to the repo root. "Cheap" means: runs against static files or a script-local fixture, no live Pi, no `npm install`, completes in well under a minute.
+
+| Script | Purpose | How to run | Reading the output | Caveats |
+|---|---|---|---|---|
+| `scripts/verify-sync-flow.js` | Master sync/flows verifier; chains device fixtures (S2120, DB-helper transaction semantics) and internally spawns `verify-profile-parity.js` | `node scripts/verify-sync-flow.js` | Prints one `OK <check>` line per assertion, prints `Sync flow verification passed` at the end of its own section, then spawns `verify-profile-parity.js`; a healthy full run ends `All parity checks passed.`, exit 0 | CI-gated (`.github/workflows/verify-sync-flow.yml`). Verified clean in this worktree on 2026-07-06 (all checks OK, includes profile-parity sub-run) |
+| `scripts/verify-profile-parity.js` | Confirms bcm2709 (Pi 4) payload files are byte-identical mirrors of bcm2712 (Pi 5) canonical source | `node scripts/verify-profile-parity.js` | Per-file `OK: <path>` / `OK: absent: <path>` lines, ends `All parity checks passed.`; any `MISMATCH`/`FAIL` blocks a merge | Not its own CI workflow but is invoked from inside `verify-sync-flow.js`, which is CI-gated. Verified clean in this worktree on 2026-07-06 (output shape and check count live in **osi-flows-json-editing** §Profile parity) |
+| `scripts/verify-migrations.js` | Validates the ordered migration set under `database/migrations/ordered/` (naming, checksums/structure) | `node scripts/verify-migrations.js` | One-line summary `verify-migrations: OK (<n> migrations)`; nonzero exit on malformed migration | CI-gated via `.github/workflows/migrations.yml`. Verified clean in this worktree on 2026-07-06: `verify-migrations: OK (2 migrations)` |
+| `scripts/check-mqtt-topics.sh` | Enforces the MQTT-IN topic rule (`application/+/device/+/event/up`, no hardcoded per-install UUIDs) across all shipped `flows.json` profiles | `scripts/check-mqtt-topics.sh` (or `bash scripts/check-mqtt-topics.sh`) | One `OK: <path> — no UUID patterns in MQTT IN topics` line per profile; any hardcoded UUID fails the line | Not wired into a GitHub workflow file directly (no dedicated `.yml`), but is the canonical enforcement AGENTS.md cites for this rule. Verified clean in this worktree on 2026-07-06 across bcm2712/bcm2709/bcm2708 |
+| `scripts/verify-seed-replay.js` | Confirms the seed DB replays cleanly through the migration runner (CI-time only invocation path for `applyPending`) | `node scripts/verify-seed-replay.js` | Pass/fail summary; consult script header for exact format | CI-gated via `migrations.yml`. Not run in this session — no live-device dependency but not in the mandatory cheap set; treat as unverified here |
+| `scripts/verify-runtime-schema-parity.js` | Fails if the shipped boot-DDL flow ever downgrades `database/seed-blank.sql` (devices CHECK / triggers) | `node scripts/verify-runtime-schema-parity.js` | Pass/fail summary | CI-gated via `migrations.yml`. Not run in this session; not in the mandatory cheap set — treat as unverified here |
+| `scripts/verify-devices-rebuild-fence.js` | Guards the fail-closed `devices` table rebuild fence (FK toggle ordering, transaction wrapping) | `node scripts/verify-devices-rebuild-fence.js` | Pass/fail summary | CI-gated via `migrations.yml`. Not run in this session; treat as unverified here |
+| `scripts/check-sync-parity.js` | Fail-safe cloud-parity DR check: is the edge→cloud sync mirror currently current? | `node scripts/check-sync-parity.js /data/db/farming.db` | Prints a JSON object (`linked`, `pending`, `pendingHistory`, `oldestPendingSec`, `rejected`, `lastDelivered`, `healthy`); exit 0 iff `healthy: true` | Needs the `sqlite3` CLI and a real `farming.db` (live Pi copy or pulled backup) — not all Pis ship `sqlite3`; run from a workstation against a pulled copy if so. Not run against a live DB in this session (no target available); logic read and confirmed fail-safe (unhealthy on missing/garbage data, never fail-open) |
+| `scripts/audit-pi-db.js` | Read-only schema/PRAGMA audit of a deployed Pi's `farming.db` against required table/column sets | `node scripts/audit-pi-db.js [/data/db/farming.db]` | JSON audit report; nonzero exit on any required-table/column/PRAGMA failure | Needs `sqlite3` CLI + a live or pulled DB; never writes. Not run against a live target in this session |
+| `scripts/repair-pi-schema.js` | Idempotent live-Pi schema repair (adds missing columns/tables with `IF NOT EXISTS`-style DDL); never overwrites the DB file | `node scripts/repair-pi-schema.js [/data/db/farming.db]` | Prints `WARN:` lines for statements that no-op (already applied) and a repair count | Needs `sqlite3` CLI + a live/pulled DB. This is a repair tool, not a pure diagnostic — read **osi-schema-change-control** first, and take the **osi-live-ops-runbook** pre-repair backup before running it against a live gateway |
+| `scripts/diagnose-sensor-history-gap.js` | Compares two JSON row-dumps (edge vs cloud export) over a time range and reports rows present on edge but missing on cloud | `node scripts/diagnose-sensor-history-gap.js <edge.json> <cloud.json> <rangeStart> <rangeEnd>` | JSON `{edgeCount, cloudCount, missingOnCloud: [{deveui, recordedAt}, ...]}`; exit 0 iff `missingOnCloud` is empty | This diagnoses **edge-vs-cloud row presence**, not "is the gateway down" — for that, use the `gateway_health_samples` discriminator in the triage table above. Needs pre-exported JSON dumps (no live-device or DB dependency itself); not run in this session (no fixture dumps available) |
+| `web/react-gui` — `npm run test:unit` | Frontend unit test suite (see GUI test invocation section above) | `cd web/react-gui && npm run test:unit` | Two-stage pass/fail; both stages must pass | Requires `node_modules` installed — skipped in this session per environment rules (no `npm install`) |
+
+## Debugging method
+
+Distilled from `docs/engineering-playbook.md` §6 ("When you are stuck or debugging") — read that section for the full version:
+
+1. **Reproduce before theorizing.** Run the failing thing yourself; capture exact output. Don't debug a described symptom you haven't seen.
+2. **Read the actual code, not your memory of it.** Line numbers move; claims rot — this is why every row in the triage table above was re-verified against current source before being written down.
+3. **Bisect with history when the cause isn't obvious:** `git log -S "<string>"` finds when a behavior appeared; `git show <ref>:<path>` compares generations without switching branches.
+4. **Test hypotheses empirically and cheaply:** a temp SQLite DB built from the seed, a ten-line Node script in the scratchpad, one `curl`. Minutes, not arguments.
+5. **Root cause, then fix.** A signal that pattern-matches a known failure may have a different cause — the "duplicate column" row above is the canonical example: it looked like a boot-DDL regression and was actually a stale test baseline.
+6. **Fix the class, not the instance,** and grep for siblings once you've found the real cause.
+7. **If your fix fights the harness or the conventions, you misread the system.** Stop and re-read AGENTS.md and the nearest working precedent before continuing.
+
+## Common mistakes
+
+- Assuming `i2c_missing=1` is a LoRaWAN, sync, or calibration problem because "the uplink arrived fine." The uplink and the I2C acquisition are different layers; a fixed diagnostic signature with `timeout=0` and no probe/ID fault means the *acquisition*, not the radio link, failed.
+- Blaming the frozen boot-DDL node for any `duplicate column` error on sight. Verify which seed/ref the failing test is actually diffing against first — issue #84 was exactly this misattribution, corrected only after someone re-read the test's base-ref logic.
+- Treating a `401` on `export.csv` as a failure. It is the expected, healthy response for an auth-gated route; only `404`/`500` indicate breakage.
+- Writing raw PWM sysfs values directly when the kernel `pwm-fan` driver is active — this races the driver and fails `EBUSY`; check for `dtparam=cooling_fan=okay` + `kmod-hwmon-pwmfan` first.
+- Diagnosing a history chart gap as "sensor died" without first checking `gateway_health_samples` for the same window — a gateway outage produces the exact same symptom in the UI.
+- Forgetting that a historical `UPDATE` to `device_data` (e.g. an SWT backfill) does not auto-enqueue a sync event — the trigger is INSERT-only. A repair that looks complete on the edge can still show stale data on the cloud mirror until events are explicitly queued.
+- Running bare `npx vitest run` and treating a clean result as "tests pass" — it silently skips the `tsx --test` half of `npm run test:unit`.
+- Assuming any verifier script works standalone. Several (`check-sync-parity.js`, `audit-pi-db.js`) need the `sqlite3` CLI and a real device DB; `diagnose-sensor-history-gap.js` needs pre-exported JSON dumps. Check the caveats column before running one cold against a live gateway.
+
+## Provenance and maintenance
+
+Re-verify these facts if this skill feels stale (dates below are last-checked, not permanent):
+
+- Re-run the cheap verifier set from repo root: `node scripts/verify-sync-flow.js && node scripts/verify-profile-parity.js && node scripts/verify-migrations.js && scripts/check-mqtt-topics.sh` — all four should exit 0 with the output shapes described above (last confirmed 2026-07-06).
+- Confirm CI gating hasn't changed: `grep -n "verify-\|check-mqtt\|test:unit" .github/workflows/*.yml` — as of 2026-07-06, `verify-sync-flow.js` is gated by `.github/workflows/verify-sync-flow.yml`; `verify-migrations.js`, `verify-seed-replay.js`, `verify-runtime-schema-parity.js`, `verify-devices-rebuild-fence.js` are gated by `.github/workflows/migrations.yml`.
+- Confirm the export.csv route still exists and is still auth-gated: `grep -n "export.csv" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json`.
+- Confirm the Chameleon I2C wiring conclusion still matches the operations doc: re-read `docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md` if a new Chameleon field incident occurs — do not assume the same root cause without re-running the SQL discriminator.
+- Confirm issue #84's fix actually landed (it was closed with a validated fix at write time): `gh issue view 84 --repo Open-Smart-Irrigation/osi-os`; if a *new* "duplicate column" report appears, re-check which base ref the failing test uses before assuming this same root cause.
+- Confirm the fan sysfs guidance against current AGENTS.md: `grep -n "pwm-fan\|EBUSY\|hwmon" AGENTS.md`.
+- Confirm `web/react-gui/package.json` test scripts haven't changed: `grep -n '"test:unit' web/react-gui/package.json`.
+- Confirm `gateway_health_samples`/`gateway_health_hourly` retention/columns haven't changed: re-read `docs/operations/edge-history-retention.md` "Gateway health telemetry" section.

--- a/.claude/skills/osi-flows-json-editing/SKILL.md
+++ b/.claude/skills/osi-flows-json-editing/SKILL.md
@@ -1,0 +1,520 @@
+---
+name: osi-flows-json-editing
+description: Use when editing conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json or its bcm2709 mirror, adding/modifying a Node-RED function node, HTTP endpoint, inject, or MQTT IN node, changing REST routes or the scheduler/sync orchestration logic that lives in flows.json, wiring a new npm module or shared helper into a function node, or touching the edge backend in general.
+---
+
+# OSI Flows.json Editing
+
+## Overview
+
+`flows.json` is the Node-RED flow definition that IS the edge backend for OSI OS:
+REST API routes, the scheduler, sync orchestration, and sensor ingest are all
+nodes in this one JSON array. As of 2026-07-06 the canonical copy at
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json` is 529 nodes,
+1,245,761 bytes, formatted as `JSON.stringify(flows, null, 2) + '\n'`. It must be
+mirrored byte-for-byte into `conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json`
+(same byte count, confirmed identical on 2026-07-06).
+
+This skill covers the mechanics of making a safe, wiring-correct edit to that
+file — not deploying it, diagnosing a live symptom, schema/migration changes,
+sensor semantics, or env-var/flag semantics (see "When NOT to use").
+
+## When to use / When NOT to use
+
+Use this skill when you are about to:
+- Add, remove, or modify a node in either `flows.json` copy (function, http in/out,
+  inject, mqtt in/out, link in/out, etc.).
+- Add a new REST endpoint or scheduler tick.
+- Wire a new npm module or shared helper (`osi-db-helper`, `osi-cloud-http`,
+  `osi-chameleon-helper`, `osi-dendro-helper`) into a function node.
+- Change existing wiring (a node's `wires` array) between nodes.
+
+Do NOT use this skill, and instead go to the named sibling, when you are:
+- Diagnosing a live symptom (hanging endpoint, 404 flood, silent crash on a
+  running Pi) — go to `osi-debugging-playbook` first; come back here once you
+  know which node to change.
+- Deploying an edited `flows.json` to a live or demo Pi — go to
+  `osi-live-ops-runbook`.
+- Changing SQLite schema, adding a migration, or touching the frozen boot-DDL
+  node (`sync-init-fn` / "Sync Init Schema + Triggers") for schema behavior —
+  go to `osi-schema-change-control`. That skill owns the FROZEN boot-DDL policy
+  in full; this skill only tells you not to add schema DDL there.
+- Deciding what a sensor field means, which device type owns which reading, or
+  irrigation/agronomy semantics — go to `osi-agronomy-sensors-reference`.
+- Looking up what an env var or `env.get(...)` flag controls — go to
+  `osi-config-and-flags`.
+
+## The iron rule
+
+**`flows.json` is edited by a one-shot Node script, never by hand, never by
+string patching, never by a text-replacement tool.** The file is machine-formatted
+JSON; a manual edit that looks harmless (wrong quote style, wrong indentation,
+reordered keys) silently breaks the byte-identical profile-parity check or,
+worse, produces JSON Node-RED still parses but with subtly wrong structure.
+
+Canonical procedure, every time:
+
+1. Write a throwaway Node script in your scratchpad (never in the repo).
+2. `JSON.parse` the current file.
+3. Mutate the in-memory node array (push new nodes, edit `wires`, edit `func`,
+   etc.).
+4. `fs.writeFileSync(path, JSON.stringify(flows, null, 2) + '\n')`.
+5. Do this for **both** `conf/full_raspberrypi_bcm27xx_bcm2712/.../flows.json`
+   (canonical) and `conf/full_raspberrypi_bcm27xx_bcm2709/.../flows.json`
+   (mirror) — either by running the mutation twice or by mutating the
+   canonical file then `cp`-ing it over the mirror.
+
+**Before any mutation**, verify the no-op roundtrip is byte-identical: read the
+file, `JSON.parse` it, `JSON.stringify(parsed, null, 2) + '\n'`, and
+`Buffer.compare` against the original bytes. If they are not identical, STOP —
+either the file's real formatting has drifted from this assumption, or your
+script has a serialization bug (e.g. wrong indent width, missing trailing
+newline, a `Map`/`Set` in the mutation that doesn't round-trip). Do not
+proceed with a real mutation until the no-op case is proven byte-identical.
+
+This was actually run against this repo, not assumed:
+
+```
+$ node roundtrip-check.js conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+byte-identical: true   (1,245,761 / 1,245,761 bytes)
+
+$ node roundtrip-check.js conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
+byte-identical: true   (1,245,761 / 1,245,761 bytes)
+```
+
+Verified 2026-07-06 against `origin/main`. Both profile copies pass.
+
+## Complete script skeleton
+
+Save this in your scratchpad (e.g. `flows-edit.js`), read it fully, adapt the
+`MUTATE` section, then run it with plain `node`. It includes the mandatory
+roundtrip guard and writes both profile copies.
+
+```js
+#!/usr/bin/env node
+// One-shot flows.json editor skeleton. Run from the repo root.
+// Usage: node flows-edit.js
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = process.cwd(); // run from repo root; verify with `pwd` first
+const CANONICAL = path.join(
+  REPO_ROOT,
+  'conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json'
+);
+const MIRROR = path.join(
+  REPO_ROOT,
+  'conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json'
+);
+
+function serialize(flows) {
+  return Buffer.from(JSON.stringify(flows, null, 2) + '\n', 'utf8');
+}
+
+function assertRoundtripByteIdentical(filePath) {
+  const original = fs.readFileSync(filePath);
+  const parsed = JSON.parse(original.toString('utf8'));
+  const reserialized = serialize(parsed);
+  if (Buffer.compare(original, reserialized) !== 0) {
+    throw new Error(
+      `Roundtrip guard failed for ${filePath}: file formatting has drifted ` +
+      `from JSON.stringify(x, null, 2) + '\\n'. STOP and investigate before mutating.`
+    );
+  }
+  return parsed;
+}
+
+// --- Step 1: guard, then load canonical ---
+const flows = assertRoundtripByteIdentical(CANONICAL);
+console.log('Roundtrip guard OK. Node count:', flows.length);
+
+// --- Step 2: MUTATE (edit this section for your change) ---
+// Example: add a new, fully self-contained inject + function node pair.
+// Mint a NEW id — never reuse or regenerate an existing id. Real ids in this
+// file are either a 16-lowercase-hex-char Node-RED-generated id (e.g.
+// "062a0f9bf66d9789", the Build Heartbeat node) or a short descriptive slug
+// (e.g. "auth-db-query"). Prefer the hex form for new nodes to avoid clashes;
+// generate one with: node -e "console.log(require('crypto').randomBytes(8).toString('hex'))"
+const NEW_FUNCTION_ID = 'REPLACE_WITH_FRESH_16_HEX_ID';
+const NEW_INJECT_ID = 'REPLACE_WITH_ANOTHER_FRESH_16_HEX_ID';
+
+const exampleFunctionNode = {
+  id: NEW_FUNCTION_ID,
+  type: 'function',
+  z: 'REPLACE_WITH_TARGET_TAB_ID', // copy z from a neighboring node in the same tab
+  name: 'Example Sampler',
+  func: [
+    "let value = null;",
+    "try {",
+    "  const fs = global.get('fs');", // functionGlobalContext local, NOT an npm module — no libs entry needed
+    "  value = parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim());",
+    "} catch (e) {",
+    "  // sampler must never crash the flow: swallow and report null",
+    "}",
+    "msg.payload = { value };",
+    "return msg;",
+  ].join('\n'),
+  outputs: 1,
+  // libs only needed for real npm modules bound via settings.js functionExternalModules,
+  // e.g. [{ var: 'osiDb', module: 'osi-db-helper' }] — see "Function-node conventions" below.
+  libs: [],
+  x: 400,
+  y: 400,
+  wires: [[]],
+};
+
+const exampleInjectNode = {
+  id: NEW_INJECT_ID,
+  type: 'inject',
+  z: 'REPLACE_WITH_TARGET_TAB_ID',
+  name: 'Example Tick (60s)',
+  props: [{ p: 'payload' }],
+  repeat: '60',
+  crontab: '',
+  once: true,
+  onceDelay: 5,
+  topic: '',
+  payload: '',
+  payloadType: 'date',
+  x: 180,
+  y: 400,
+  wires: [[NEW_FUNCTION_ID]],
+};
+
+flows.push(exampleInjectNode, exampleFunctionNode);
+
+// --- Step 3: write canonical, then mirror ---
+fs.writeFileSync(CANONICAL, serialize(flows));
+fs.writeFileSync(MIRROR, serialize(flows));
+console.log('Wrote canonical + mirror. New node count:', flows.length);
+
+// --- Step 4: re-run the roundtrip guard on what you just wrote ---
+assertRoundtripByteIdentical(CANONICAL);
+assertRoundtripByteIdentical(MIRROR);
+console.log('Post-write roundtrip guard OK on both profiles.');
+```
+
+After running this, always run the full pre-commit checklist (below) before
+considering the edit done.
+
+## Function-node conventions (verified against real nodes in this repo)
+
+### npm modules: bind via `libs`, not `functionExternalModules` alone
+
+`feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js` sets
+`functionExternalModules: true`. That flag only permits a function node's
+`libs` array to bind an npm module into scope — **it does not auto-inject
+anything.** If a function node's code references a module-backed variable
+(e.g. `osiDb`, `bcrypt`) without a matching `libs` entry, that variable is
+`undefined` at runtime. Because most of these handlers are `async`, the
+failure is a silent hang: no HTTP response, `curl` exits 52 or 28, nothing is
+logged.
+
+Real working precedent — node `auth-db-query` ("Lookup Auth User"):
+
+```json
+"libs": [{ "var": "osiDb", "module": "osi-db-helper" }]
+```
+
+and its `func` opens with `const db = new osiDb.Database('/data/db/farming.db');`.
+Verify any node's `libs` binding with:
+
+```bash
+node -e "
+const flows = require('./conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json');
+const n = flows.find(x => x.id === 'auth-db-query');
+console.log(JSON.stringify(n.libs));
+"
+```
+
+### Guarded shared-module locals: `global.get(...)`, not `libs`
+
+A second, different pattern exists for the small set of built-in Node.js
+modules that `settings.js` pre-loads into `functionGlobalContext`:
+
+```js
+// feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js
+functionGlobalContext: {
+    os: require('os'),
+    fs: require('fs'),
+    cp: require('child_process'),
+},
+```
+
+Function nodes that need `fs`, `os`, or `cp` bind them with
+`global.get('fs')` / `global.get('os')` / `global.get('cp')` at the top of the
+function — **not** via `libs`, because these are context globals, not
+`functionExternalModules`-loaded npm packages. Real precedent, node
+`sys-stats-fn` ("System Stats"):
+
+```js
+var os = global.get('os');
+var fs = global.get('fs');
+```
+
+Do not add `fs`/`os`/`cp` to a node's `libs` array — that binding mechanism is
+for npm modules declared in `settings.js`'s external-modules allowlist, and
+mixing the two patterns on the same variable is confusing and redundant.
+
+### Every opened DB handle must be closed
+
+Any function node that does `new osiDb.Database(...)` must also call
+`.close(` somewhere in the same function body. This is enforced by
+`scripts/test-flows-wiring.js`, in the "WS2/WS3 osiDb.Database close audit"
+section: it scans every `function` node whose `func` matches
+`/new\s+osiDb\.Database/` and fails if that same `func` does not also match
+`/\.close\s*\(/`. On failure it prints:
+
+```
+FAIL: N function node(s) open osiDb.Database without closing it:
+  - <node name> [<node id>]
+```
+
+Real precedent for the close call, node `write-strega-expectation`:
+
+```js
+const __close = () => new Promise((res) => db.close(() => res()));
+```
+
+The same script also has a separate "function-node library declaration audit"
+that fails if a node's `func` references `osiDb.`, `osiCloudHttp.`,
+`chameleon.`, or `dendro.` without a matching `libs` entry — this is the
+automated form of the npm-module rule above.
+
+### Function nodes must never crash the flow
+
+Wrap every sysfs/file/subprocess read in its own `try/catch` that resolves to
+`null` for that one reading — a sampler failing to read one sysfs path must
+never take down the rest of the function or the flow. Real precedent, node
+`062a0f9bf66d9789` ("Build Heartbeat", part of the frozen heartbeat cluster —
+read it for the pattern, do not edit it casually):
+
+```js
+var cpuTemp = null, memPercent = null, load1 = null, load5 = null, load15 = null, fanValue = null;
+
+try { cpuTemp = Math.round(parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim()) / 100) / 10; } catch(e) {}
+try {
+    var tm = os.totalmem(), fm = os.freemem();
+    memPercent = Math.round(((tm - fm) / tm) * 100);
+} catch(e) {}
+```
+
+**The let-before-try scoping trap:** a `const` (or `let`) declared *inside* a
+`try { }` block is block-scoped and invisible outside that block. If later
+code (including code in the same function, after the `catch`) references that
+name, you get a `ReferenceError` — and in an `async` handler with no outer
+catch, that error can be silent: no response sent, nothing logged, the flow
+just stops producing output for that path. This has previously killed a
+nightly compute job (a `const` inside a weather-API `try` block was
+referenced later in an INSERT). The fix pattern:
+
+```js
+let zoneTimezone = 'UTC';       // safe default, declared OUTSIDE try
+let phenoMod = null;
+try {
+  zoneTimezone = await lookupTimezone(zoneId);   // assignment, not declaration
+  phenoMod = await lookupPhenoMod(zoneId);
+} catch (e) {
+  // zoneTimezone/phenoMod keep their safe defaults; nothing downstream breaks
+}
+// zoneTimezone and phenoMod are both safely usable here
+```
+
+Always declare-with-default before the `try`, assign inside it, and never
+`const`/`let` a name inside `try{}` that anything outside the block needs.
+
+### Stable node ids
+
+Never regenerate or reuse an existing node's `id` — every `wires` array in
+every other node references ids directly, so changing one breaks wiring
+silently (Node-RED will not error; the edge from the old id just stops
+being a target). Real ids observed in this file take one of two forms:
+16-lowercase-hex-character Node-RED-generated ids (124 of 529 nodes, e.g.
+`062a0f9bf66d9789`, `c2b43a6c6e7d2c11`) or short descriptive slugs (the
+remaining 405, e.g. `auth-db-query`, `sync-init-fn`, `write-strega-expectation`).
+For a new node, mint a fresh 16-hex id
+(`node -e "console.log(require('crypto').randomBytes(8).toString('hex'))"`)
+or a new, clearly-unique descriptive slug if you are extending a named
+subsystem — but never copy an id from an existing node "to be safe."
+
+### Placement: additive over teeing
+
+Prefer a self-contained new inject + new function node (own timer, own
+handler) over adding a new output/wire into an existing shared node. Two
+independent additive changes land in either order with at most an adjacency
+conflict in the JSON array; two changes that both tee into the same shared
+node collide on the `wires` array itself.
+
+Two clusters are explicitly hot/frozen and need a blast-radius check before
+any touch:
+- The **heartbeat cluster** (`Build Heartbeat` / `062a0f9bf66d9789` and its
+  MQTT wiring) — read for precedent, do not modify without checking who else
+  reads/writes it.
+- The **`sync-init-fn`** boot-DDL node ("Sync Init Schema + Triggers") — fully
+  FROZEN for new schema behavior. Policy and the narrow sanctioned exception
+  (guarded `devices` rebuild) live in `osi-schema-change-control`; this skill
+  only tells you to route there.
+
+Before editing any shared node, run a blast-radius grep:
+
+```bash
+node -e "
+const flows = require('./conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json');
+const targetId = 'PUT_TARGET_NODE_ID_HERE';
+for (const n of flows) {
+  const wires = JSON.stringify(n.wires || []);
+  if (wires.includes(targetId)) console.log('wired FROM:', n.id, n.name);
+  if (n.id === targetId) console.log('target node:', n.id, n.name, n.type);
+}
+"
+```
+
+## Guard tests: `scripts/test-flows-wiring.js`
+
+Run with plain `node scripts/test-flows-wiring.js` (not `node --test` — the
+file is a plain script with hand-rolled assertions, not a `node:test` suite).
+It pins four kinds of wiring contract, all against the canonical
+(bcm2712) `flows.json` only:
+
+1. **STREGA actuation wiring** (labelled WS1, tags C5/H2/L1/M8) — exact
+   `wires` arrays for specific node ids (e.g. `5974306566e99a92` must wire to
+   exactly `072f29aa8760340a` and `write-strega-expectation`, and not directly
+   to Build STREGA downlink), a required string
+   (`STALE_OPEN_OBSERVED`) inside `strega-reconciliation-monitor`'s `func`,
+   an absence check (must NOT contain `flow.get('command_types') || {}`), and
+   node-existence checks for the today-liters HTTP trio.
+2. **`osiDb.Database` close audit** (WS2/WS3) — described above.
+3. **Function-node `libs` declaration audit** — described above.
+4. **Misc WS2/WS3 wiring invariants** — a handful of `node.id === '...'` checks
+   for specific required substrings in specific nodes (gateway migration
+   preflight's parameterized `q`/`run` helpers, `sync-force-build`'s timeout
+   guard, `command-ack-build-batch`'s bootstrap gate, `s2120-zones-put-auth-fn`'s
+   zone-id validation).
+
+On failure it prints one `FAIL: N flow wiring regression(s):` line followed by
+a bulleted list, then `process.exit(1)`; on success, one `OK` line per check
+plus a final `PASS: STREGA wiring + osiDb close + WS2/WS3 wiring guards all
+passed`.
+
+**When you intend a wiring change that this file pins, update the pin in the
+same commit, with a commit message explaining why the wiring changed.** A
+guard test that silently gets "fixed" to match new behavior stops being a
+guard.
+
+## Profile parity
+
+`bcm2712` is canonical; `bcm2709` must mirror it byte-for-byte. Either write
+your edit script to update both paths (as in the skeleton above) or mutate
+the canonical file then `cp` it over the mirror — do not hand-edit the
+mirror separately, and do not let the two diverge even by a trailing newline.
+
+Enforced by `node scripts/verify-profile-parity.js`, which is chained from
+`node scripts/verify-sync-flow.js` (it runs as the final step, via
+`spawnSync`). Real output shape, run 2026-07-06 against this worktree:
+
+```
+=== conf/full_raspberrypi_bcm27xx_bcm2709 ===
+OK:   files/etc/board.d/02_network
+... (25 OK: / absent: lines total — 20 file-parity checks incl. flows.json, 5 absence checks)
+
+All parity checks passed.
+```
+
+On a mismatch it instead prints `FAIL: files/usr/share/flows.json: content
+differs between conf/full_raspberrypi_bcm27xx_bcm2712 and
+conf/full_raspberrypi_bcm27xx_bcm2709` and exits non-zero.
+
+## MQTT IN topic rule
+
+Every `mqtt in` node in `flows.json` must subscribe to the literal topic
+`application/+/device/+/event/up`. Confirmed by inspecting all 6 `mqtt in`
+nodes in the canonical file on 2026-07-06 (`Local Device Uplinks`, `MQTT IN
+(Field Testing)`, `Local Sensor Uplinks`, `LSN50 IN`, `S2120 IN`, `LoRain IN`)
+— all 6 use exactly that topic string. ChirpStack generates a fresh
+per-installation application UUID at bootstrap; a topic hardcoded to one
+gateway's UUID (e.g. `application/<uuid>/device/+/event/up`) will silently
+never match on any other gateway — no error, just zero uplinks. Device-type
+discrimination happens downstream of the MQTT IN node via
+`CHIRPSTACK_PROFILE_*` env vars and `deviceProfileName` fallback matching
+(semantics documented in `osi-config-and-flags`, not here).
+
+Enforced by `scripts/check-mqtt-topics.sh`, which checks all three flow
+copies (bcm2712, bcm2709, and a legacy bcm2708 path) for both a UUID-shaped
+regex in any MQTT IN topic and an exact-string match against the expected
+topic. Run 2026-07-06:
+
+```
+OK: conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json — no UUID patterns in MQTT IN topics
+OK: conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json — no UUID patterns in MQTT IN topics
+OK: conf/full_raspberrypi_bcm27xx_bcm2708/files/usr/share/flows.json — no UUID patterns in MQTT IN topics
+```
+exit 0.
+
+## Pre-commit checklist
+
+Run every row before committing a `flows.json` change. All commands below run
+from the repo root.
+
+| Check | Command | Pass signal |
+|---|---|---|
+| Roundtrip byte-check ran on both profiles (before AND after your mutation) | your scratchpad roundtrip script | `byte-identical: true` for both `.../bcm2712/.../flows.json` and `.../bcm2709/.../flows.json` |
+| Both profile copies updated | `git status --short` shows both `flows.json` paths changed together | both paths listed, never just one |
+| Profile parity | `node scripts/verify-profile-parity.js` | ends `All parity checks passed.`, exit 0 |
+| Sync flow verification (chains schema/history/parity checks) | `node scripts/verify-sync-flow.js` | prints `Sync flow verification passed` at the end of its own section, then chains profile parity; a healthy full run ends `All parity checks passed.`, exit 0 — verified clean on this worktree 2026-07-06 (no open `duplicate column` failure; that was issue #84, already fixed on `main`) |
+| MQTT topic compliance | `scripts/check-mqtt-topics.sh` | three `OK:` lines, one per flow copy, exit 0 |
+| Flow wiring guards | `node scripts/test-flows-wiring.js` | ends `PASS: STREGA wiring + osiDb close + WS2/WS3 wiring guards all passed`, exit 0 |
+
+If you intentionally changed a pinned wiring contract, update
+`scripts/test-flows-wiring.js` in the same commit and say why in the commit
+message — do not just make the test pass by weakening the assertion.
+
+This checklist is the mechanical gate only. Non-trivial flows.json changes
+still go through the engineering-playbook loop (`docs/engineering-playbook.md`
+§2: written plan, adversarial review, independent verification by a
+non-author) — §8 defines done, not a green checklist.
+
+## Common mistakes
+
+- Editing `flows.json` with a text editor or an Edit-tool string replacement.
+  Even a single reformatted line can break the byte-identical parity check or
+  subtly corrupt adjacent JSON.
+- Forgetting the bcm2709 mirror. `verify-profile-parity.js` will catch this,
+  but it is cheaper to write both copies in the same script than to discover
+  the CI failure later.
+- Adding an npm-module-backed variable to a function node without a matching
+  `libs` entry — the node "works" in that Node-RED loads it without error,
+  but any code path through the undefined variable hangs silently.
+- Confusing the `libs` binding (npm modules) with the `global.get(...)`
+  binding (built-ins pre-loaded into `functionGlobalContext`: `fs`, `os`,
+  `cp`). Adding `fs` to `libs` is not wrong per se but is not how any existing
+  node does it, and the "helper globals" audit in `test-flows-wiring.js` only
+  checks the npm-module list (`osiDb`, `osiCloudHttp`, `chameleon`, `dendro`) —
+  it will not catch a missing `global.get('fs')`.
+- Declaring a variable with `const`/`let` inside a `try{}` block, then
+  referencing it after the block. Silent `ReferenceError`, no log line, no
+  crash report — the symptom is just "this stopped updating."
+- Reusing or "tidying up" an existing node id. Every reference lives in some
+  other node's `wires` array; renaming breaks those edges without any error.
+- Teeing a new feature into an existing shared node (especially the
+  heartbeat cluster or `sync-init-fn`) instead of adding an own inject + own
+  function node.
+- Trusting `functionExternalModules: true` alone to make a module available.
+  It only enables the *mechanism*; each node still needs its own `libs` entry.
+- Adding schema DDL inside `sync-init-fn` because "it's just one more ADD
+  COLUMN" — that node is frozen; see `osi-schema-change-control`.
+
+## Provenance and maintenance
+
+Re-verify these before trusting them again, especially after any large flows.json refactor:
+
+- Node count / byte size of canonical `flows.json`: `node -e "const f=require('./conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json'); console.log(f.length)"` and `wc -c conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json`.
+- Roundtrip byte-identity claim: re-run a roundtrip script like the one in "The iron rule" against both profile copies.
+- `libs` binding precedent (`auth-db-query`): `node -e "const f=require('./conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json'); console.log(JSON.stringify(f.find(n=>n.id==='auth-db-query').libs))"`.
+- `global.get` precedent (`sys-stats-fn`, `062a0f9bf66d9789`): same pattern, swap the id, inspect `.func`.
+- `functionGlobalContext` keys: `grep -n -A5 "functionGlobalContext" feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js`.
+- MQTT IN topic compliance: `bash scripts/check-mqtt-topics.sh`.
+- Wiring guard behavior and pass/fail text: `node scripts/test-flows-wiring.js`.
+- Profile parity behavior and pass/fail text: `node scripts/verify-profile-parity.js`.
+- Full chained verifier and current baseline health: `node scripts/verify-sync-flow.js`.
+- Node id format distribution (16-hex vs slug counts): re-run the id-length-distribution one-liner from this skill's authoring session, or `node -e "const f=require('./conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json'); const ids=f.filter(n=>n.id).map(n=>n.id); console.log(ids.filter(i=>/^[0-9a-f]{16}$/.test(i)).length,'/',ids.length)"`.

--- a/.claude/skills/osi-hardest-problem-campaign/SKILL.md
+++ b/.claude/skills/osi-hardest-problem-campaign/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: osi-hardest-problem-campaign
+description: Placeholder only — do not load for operational work. Reserved slot for a future deep-dive campaign on the hardest live problem in the OSI fleet.
+---
+
+# osi-hardest-problem-campaign (deferred stub)
+
+Deferred: awaiting the maintainer's answer to "what is the hardest live problem";
+candidates #92/#87/#56; do not author without that answer + change-control review.

--- a/.claude/skills/osi-live-ops-runbook/SKILL.md
+++ b/.claude/skills/osi-live-ops-runbook/SKILL.md
@@ -1,0 +1,501 @@
+---
+name: osi-live-ops-runbook
+description: Use when deploying OSI OS to a live or previously provisioned Raspberry Pi gateway, repairing a live Pi's Node-RED/ChirpStack/database state, taking a pre-repair backup, recovering from schema fingerprint drift, SSHing into a live gateway, restarting Node-RED on a farm device, testing STREGA valves on live hardware, or judging whether an operation is safe against a running farm or the production cloud host.
+---
+
+# OSI Live Ops Runbook
+
+## Overview
+
+This skill is the procedure for touching a **live** OSI OS gateway: a Raspberry Pi
+running at a real farm with an irreplaceable `/data/db/farming.db`. It covers the
+deploy flow, backup-before-repair, post-deploy verification, known BusyBox/ash traps,
+and a set of concrete live-repair recipes. It does not cover how to design a schema
+migration, how to edit `flows.json` internals, or agronomy semantics — see "When NOT
+to use" below.
+
+Every rule here traces back to `AGENTS.md` ("Live-deploy safety rules", "Production
+cloud access") and `docs/engineering-playbook.md` §1 (Prime directives). If anything
+in this skill ever conflicts with those files, the repo files win — re-read them.
+
+## When to use / When NOT to use
+
+Use this skill when the task involves a **live or previously provisioned** Pi
+gateway: deploying a build, restarting services, inspecting or repairing
+`farming.db`, recovering from a crash mid-migration, or SSHing into a gateway at all.
+
+Route elsewhere when the task is actually about:
+
+| Task | Use instead |
+|---|---|
+| Diagnosing a symptom on a live system (which log, which query, which experiment) | `osi-debugging-playbook` |
+| Editing `flows.json` node logic, adding a route, changing a function node | `osi-flows-json-editing` |
+| Designing a schema migration, understanding the migration risk classes, seed/bundled-DB parity | `osi-schema-change-control` |
+| Agronomy meaning of SWT/VWC/dendrometer values, sensor decoding semantics | `osi-agronomy-sensors-reference` |
+| UCI option names, env var / feature-flag semantics, what a flag does | `osi-config-and-flags` |
+
+This skill assumes those siblings for anything beyond "how do I safely get bits onto
+a live Pi and confirm it didn't break the farm." Do not duplicate their content here;
+follow the pointers inline.
+
+---
+
+## Prime safety rules (read first)
+
+### 1. Never overwrite or reseed `farming.db` on a live Pi
+
+`deploy.sh` (repo root) contains this literal comment at the top:
+
+```
+# Safety invariant: this script must never overwrite /data/db/farming.db.
+# The edge database is live user data and osi-os is the operational source of
+# truth. The bundled seed database is only copied when the target DB is absent.
+```
+
+The actual guard, in `seed_db_if_missing()`:
+
+1. If `/data/db/farming.db` already exists → **SKIP**, log "existing live database
+   preserved", return success. Nothing is written.
+2. Else if any SQLite sidecar file exists (`farming.db-wal`, `farming.db-shm`,
+   `farming.db-journal`) but the main file is absent → **ERROR and refuse**, exit
+   non-zero. This is the "DB file missing but the journal isn't" state — it usually
+   means something went wrong (mid-crash, mid-copy, a bad manual `rm`), and seeding
+   over it would silently discard whatever the sidecars were protecting.
+3. Only when the target is truly absent **and** no sidecars exist does it fetch the
+   profile-matched seed DB, integrity-check it (`PRAGMA integrity_check` via
+   `sqlite3` if available), re-check the target is still absent (race guard), then
+   `mv` the seed into place.
+
+Rationale (from `docs/engineering-playbook.md` §1): **a wrong chart annoys someone;
+a wiped `farming.db` destroys months of irreplaceable field data.** The asymmetry is
+absolute — treat every farming.db as one-way-destructible.
+
+**Forbidden, no exceptions:**
+```bash
+# NEVER do this against a live or previously provisioned Pi:
+scp .../db/farming.db root@<pi-ip>:/data/db/farming.db
+```
+This bypasses every guard above and unconditionally destroys the live database. If
+you find yourself about to run an `scp`/`cp` whose destination is
+`/data/db/farming.db` on anything that has ever been provisioned, stop.
+
+Schema changes on a live Pi go through migrations or idempotent repair SQL — never
+through replacing the file. The migration model itself (risk classes, the runner,
+fingerprint stamping mechanics) lives in `osi-schema-change-control`; this skill only
+covers the live-ops side (backup, verification, stale-fingerprint recovery).
+
+### 2. Backup before any risky repair
+
+Before hand-repairing schema, editing rows directly, or touching ChirpStack's
+SQLite config on a live Pi, take a timestamped backup. BusyBox `ash` has no `bash`,
+so keep this POSIX:
+
+```sh
+# Run on the Pi (ash-compatible)
+TS=$(date +%Y%m%d-%H%M%S)
+LABEL="pre-repair"          # e.g. "pre-eui-fix", "pre-fingerprint-restamp"
+BK="/data/db/backups/${LABEL}-${TS}"
+mkdir -p "$BK"
+cp -a /data/db/farming.db "$BK/farming.db" 2>/dev/null || true
+cp -a /data/db/farming.db-wal "$BK/farming.db-wal" 2>/dev/null || true
+cp -a /data/db/farming.db-shm "$BK/farming.db-shm" 2>/dev/null || true
+cp -a /srv/node-red/flows.json "$BK/flows.json"
+cp -a /srv/node-red/settings.js "$BK/settings.js"
+mkdir -p "$BK/gui"
+cp -a /usr/lib/node-red/gui/. "$BK/gui/" 2>/dev/null || true
+echo "Backup at $BK"
+ls -la "$BK"
+```
+
+This matches `AGENTS.md` "Live-deploy safety rules": a timestamped backup under
+`/data/db/backups/osi-os-<timestamp>` covering `/data/db/`, `/srv/node-red/`
+(`flows.json`, `settings.js`), and `/usr/lib/node-red/gui/`. Use a descriptive label
+prefix instead of the literal `osi-os-` if it helps you find the right backup later
+— what matters is that it is timestamped and covers those three areas.
+
+### 3. Production-cloud access gate
+
+`osicloud.ch` is the production OSI Server. Per `AGENTS.md` "Production cloud
+access":
+
+- Treat any SSH access to that host — including through a local alias or an
+  already-loaded SSH key — as restricted production access.
+- Do not connect to it, inspect its files, read its environment, copy secrets from
+  it, or run commands there **unless the user explicitly asks for production /
+  `osicloud.ch` access in the current turn.**
+- A working SSH key or a successful `ssh` connectivity check is **not** consent.
+- Ambiguous phrasing like "the other server" is not enough — clarify with the user,
+  or default to the test host `server.opensmartirrigation.org` instead.
+
+This gate is about the cloud counterpart, not the edge gateways — but it governs the
+same class of decision this skill is otherwise all about, so it is repeated here as
+a hard stop before any cross-system live-ops session.
+
+### 4. Never reset credentials to unblock yourself
+
+If a login, verifier, or API token is blocking you on a live system, **ask the
+operator** rather than resetting or overwriting the credential. Resetting a password
+or regenerating a secret to get past a block destroys the original credential and
+has caused real incidents. The one sanctioned exception is the DEVICE_EUI-linked
+offline verifier repair in "Live-repair recipes" below — that regenerates a verifier
+that is *supposed* to change because the EUI itself was wrong, not a shortcut around
+an unknown credential.
+
+---
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Build GUI | `cd web/react-gui && npm run build` |
+| Bundle GUI | `tar czf react_gui.tar.gz -C web/react-gui/build .` |
+| Serve repo root | `python3 -m http.server 9876 --bind 127.0.0.1` |
+| Deploy over reverse tunnel | see "Deploy runbook" step 4 below |
+| Restart Node-RED | `/etc/init.d/node-red restart` |
+| Free a leaked local port | `pkill -9 -f 'http.server 9876'` |
+| SSH to a gateway | `ssh -i ~/.ssh/<key> -o IdentitiesOnly=yes root@<pi-ip>` |
+| Filter SSH banner noise | pipe through `grep -v "post-quantum\|store now"` |
+| Re-baseline a drifted fingerprint | `node scripts/restamp-fingerprints.js /data/db/farming.db` (on-Pi path) |
+
+---
+
+## Deploy runbook (reverse-tunnel flow)
+
+This is the standard way to push a new build to a live gateway without exposing the
+Pi to the internet or needing a registry. Numbered, copy-pasteable, run from your
+dev workstation unless noted.
+
+1. **Build the GUI.**
+   ```bash
+   cd web/react-gui && npm run build
+   ```
+
+2. **Bundle it.** `react_gui.tar.gz` at the repo root is disposable — `deploy.sh`
+   fetches it by that exact name (see the "React GUI" step in deploy.sh) and nothing
+   else references it after the deploy completes.
+   ```bash
+   cd /path/to/osi-os
+   tar czf react_gui.tar.gz -C web/react-gui/build .
+   ```
+
+3. **Serve the repo root locally**, bound to loopback only:
+   ```bash
+   python3 -m http.server 9876 --bind 127.0.0.1
+   ```
+   Port 9876 must be free before this step. If a previous run leaked a server:
+   ```bash
+   pkill -9 -f 'http.server 9876'
+   ```
+
+4. **Open a reverse tunnel and run the deploy script on the Pi**, downloading first
+   instead of piping into `sh`:
+   ```bash
+   ssh -R 9876:localhost:9876 root@<pi-ip> \
+     'curl -fsSL http://localhost:9876/deploy.sh -o /tmp/osi-os-deploy.sh && sh /tmp/osi-os-deploy.sh; rc=$?; rm -f /tmp/osi-os-deploy.sh; exit "$rc"'
+   ```
+   **Why download-then-run instead of `curl ... | sh`:** in a pipe, the shell's exit
+   status is the last command's (`sh`'s), not `curl`'s. If `curl` 404s (local
+   `http.server` already exited, tunnel dropped), `sh` gets empty stdin, exits 0, and
+   the pipeline reports success — a deploy that fetched nothing can print "Deploy
+   complete" and exit 0. Same failure class as `git push | tail -1` hiding a failed
+   push behind `tail`'s exit code (engineering playbook §1). Download-then-run makes
+   `curl`'s failure set `$rc`, so a 404'd deploy fails loudly over the SSH exit code.
+   `deploy.sh`'s own header comment still shows the shorter piped form as a
+   convenience one-liner — prefer the hardened form above for anything you need to
+   trust.
+
+5. **Restart Node-RED** on the Pi (this step is inside the SSH session, or a second
+   SSH call):
+   ```bash
+   /etc/init.d/node-red restart
+   ```
+   ChirpStack reprovisioning happens automatically — `osi-bootstrap`
+   (`conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap`, `START=99`)
+   runs on every boot, checks a stamp file (`/etc/osi-bootstrap.done` plus a
+   `CHIRPSTACK_APP_SENSORS=` line in `/srv/node-red/.chirpstack.env`), and only
+   re-runs `chirpstack-bootstrap.js` when that stamp is invalid or ChirpStack's
+   gRPC port isn't answering yet. No manual bootstrap step is needed after a normal
+   restart on an already-provisioned gateway. Manual re-provision, if ever needed:
+   ```bash
+   node /usr/share/node-red/chirpstack-bootstrap.js
+   ```
+
+### What `deploy.sh` actually does end-to-end
+
+Reading straight through the script, in order:
+
+1. Detects the Pi model from `/proc/device-tree/model` to pick the matching seed DB
+   profile (`bcm2712` for Pi 5, `bcm2709` for Pi 4/400/3/2, `bcm2708` for Pi Zero/1;
+   unknown models fall back to `bcm2712`, the canonical source-of-truth profile).
+2. Runs a **communication preflight**: fetches `flows.json` for all three hardware
+   profiles plus the Node-RED init script, `settings.js`, `chirpstack-bootstrap.js`,
+   and the diagnose script into a temp dir, fails loudly if any fetched artifact is
+   empty, then runs `verify-communication-contract.js` against them before touching
+   anything live.
+3. Deploys `settings.js`, the Node-RED init script, the gateway identity helper
+   (both `chmod 755`), removes a legacy GPS sidecar service if present, deploys
+   `flows.json`.
+4. Runs `seed_db_if_missing` — the guarded, non-destructive DB step above.
+5. Deploys the Node-RED runtime `package.json`/`package-lock.json`, every helper
+   module (`osi-chirpstack-helper`, `osi-db-helper`, `osi-dendro-helper`,
+   `osi-history-helper`, `osi-chameleon-helper`, `osi-cloud-http`), the bootstrap
+   script, and the four device codecs (STREGA, LSN50, S2120, LoRain).
+6. Runs `npm install --omit=dev --no-fund --no-audit` in `/srv/node-red`, exiting
+   non-zero on failure.
+7. Runs a fixed sequence of **idempotent, additive schema-repair steps** against the
+   live DB if it exists: dendrometer calibration columns, zone irrigation
+   calibration table, `analysis_views` table, the Chameleon SWT column/table set,
+   and the gateway-health tables (this last one executes the actual ordered-
+   migration SQL file and refuses to apply it unless its header line is exactly
+   `-- risk: additive`). Each step swallows only `duplicate column name` errors or
+   uses `CREATE TABLE IF NOT EXISTS`, and verifies its own postcondition before
+   printing `OK`. None of these run if `/data/db/farming.db` doesn't exist yet (they
+   SKIP — a brand-new Pi ends up at exactly the bundled seed schema, not
+   seed-plus-repairs). The general migration model these are instances of — risk
+   classes, the runner, fingerprint stamping — is `osi-schema-change-control`'s
+   territory; this script predates and coexists with that runner for these specific
+   historical repairs.
+8. Fixes mosquitto file ownership/permissions if mosquitto is installed.
+9. Deploys the React GUI: fetches `react_gui.tar.gz`, wipes
+   `/usr/lib/node-red/gui/` (including dotfiles), extracts the new bundle in place.
+10. Prints next-step reminders (restart Node-RED, open `/gui`, bootstrap note).
+
+**When `deploy.sh` refuses to proceed:** missing/empty preflight artifact,
+integrity-check failure on the seed DB, `farming.db` absent but WAL/SHM/journal
+sidecars present, `npm install` failing, a gateway-health migration file whose
+header isn't `-- risk: additive`, or any schema-repair postcondition check failing.
+All `exit 1` rather than continuing partially.
+
+---
+
+## Post-deploy verification checklist
+
+Run these after every live deploy. Each has an expected "healthy" output — treat any
+deviation as a signal to stop and investigate before telling the operator it's done.
+
+| Check | Command | Expected |
+|---|---|---|
+| `farming.db` preserved | `sqlite3 /data/db/farming.db "SELECT COUNT(*) FROM device_data;"` before/after | Same or larger count, never smaller or zero after a non-empty prior count |
+| Fresh telemetry | `sqlite3 /data/db/farming.db "SELECT deveui, recorded_at FROM device_data ORDER BY recorded_at DESC LIMIT 5;"` | Timestamps within the last few minutes (gateway-dependent uplink cadence) |
+| GUI bundle rotated | `ls /usr/lib/node-red/gui/assets/` | New `index-<hash>.js` filename different from the pre-deploy listing (Vite content-hashes build output; `web/react-gui/vite.config.js` sets `base: '/gui/'`) |
+| Node-RED up | `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:1880/gui` | `301` (redirect into the SPA route) |
+| Zone CSV export route auth-gated | `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:1880/api/history/zones/1/export.csv` | `401` — this route (`GET /api/history/zones/:zoneId/export.csv` in `flows.json`, tab `history-api-tab`) requires a Bearer token via `verifyBearer`; `401` without a token means the route loaded and is enforcing auth correctly. `404`/`500` means the route or its router function failed to load — treat as broken, not healthy. |
+| ChirpStack profile env vars present | `grep -E 'CHIRPSTACK_PROFILE_(RAK10701|S2120)' /srv/node-red/.chirpstack.env` (path/semantics) | Both present. Flag semantics and full variable list: `osi-config-and-flags`. |
+| Gateway health samples fresh | `sqlite3 /data/db/farming.db "SELECT gateway_device_eui, sampled_at FROM gateway_health_samples ORDER BY sampled_at DESC LIMIT 3;"` | Rows within the last ~60 s (the 60 s heartbeat inject also persists this table; schema at `database/migrations/ordered/0002__gateway_health.sql`) |
+
+Use `127.0.0.1`, not `localhost`, for every on-Pi curl (see BusyBox traps below).
+
+---
+
+## Stale-fingerprint recovery
+
+`scripts/restamp-fingerprints.js` re-baselines `schema_object_fingerprints` to
+whatever the live schema currently is:
+
+```bash
+node scripts/restamp-fingerprints.js /data/db/farming.db
+```
+
+**Only run this when both are true:**
+- `applyPending`/`verifyHead` (the migration runner's own checks) report fingerprint
+  drift specifically because of a crash between a migration's commit and its
+  fingerprint stamp — not because the schema is actually wrong.
+- You (or the operator) have independently confirmed the live schema is correct for
+  the intended migration state.
+
+The script refuses to run against a nonexistent path (it deliberately does not let
+`sqlite3` silently create-and-restamp an empty DB at a typo'd path). It has no other
+guard: it does not verify the schema is correct itself, it only re-stamps whatever
+is there. That judgment call is the operator's, not the script's.
+
+This is the **only** sanctioned way to overwrite the fingerprint baseline. Never
+hand-edit rows in `schema_object_fingerprints` directly. After running it, run
+`verifyHead` again and confirm `ok:true` before considering the drift resolved. The
+migration model this fingerprint mechanism belongs to (what a "commit" vs "stamp"
+step is, what drift means structurally) is `osi-schema-change-control`'s territory.
+
+---
+
+## BusyBox / ash traps on the Pi
+
+The Pi image runs BusyBox `ash`, not `bash`. These are field-verified operator
+knowledge (label: operator-procedure, not independently re-derivable from this repo
+alone):
+
+- **No bash.** Don't use `[[ ]]`, arrays, `local` in places bash allows but POSIX
+  doesn't, or bashisms in any one-liner you paste onto the Pi. Stick to POSIX `sh`/
+  `ash` syntax, as `deploy.sh` itself does (`#!/bin/sh`, `set -eu`).
+- **Case conversion:** use `tr 'abcdef' 'ABCDEF'`, not `tr '[:lower:]' '[:upper:]'`
+  — the POSIX character-class form is unreliable on this image. This is also called
+  out in `AGENTS.md` under "Conventions".
+- **`localhost` resolves to IPv6 `::1` first** under the minimal `wget`/resolver on
+  this image, which often has nothing listening on `::1`. Always target `127.0.0.1`
+  explicitly in on-Pi curl/wget calls, including in the verification checklist
+  above and in the reverse-tunnel deploy command.
+- **The SSH "post-quantum" banner is harmless.** Every SSH connection to these
+  gateways prints a post-quantum key exchange notice from the server side. Filter it
+  out of scripted output rather than treating it as an error:
+  ```bash
+  ssh ... 2>&1 | grep -v "post-quantum\|store now"
+  ```
+
+---
+
+## Live-repair recipes
+
+### Stale `.chirpstack.env` overriding runtime identity
+
+`/srv/node-red/.chirpstack.env` can carry a stale `DEVICE_EUI*` value that overrides
+the runtime identity even after UCI has been corrected. During an identity repair,
+remove or regenerate this file so the helper/UCI path (canonical, uppercase EUI)
+is what actually takes effect. Full flag semantics and where this file's other
+variables come from: `osi-config-and-flags`.
+
+### Changing DEVICE_EUI breaks linked login
+
+The offline verifier is `bcrypt(password::DEVICE_EUI)` (see `AGENTS.md` "Security").
+If the EUI changes (fixing a wrong one, replacing hardware), every stored verifier
+for that gateway stops matching and logins fail. Repair sequence:
+
+1. Fix the UCI value:
+   ```bash
+   uci set osi-server.cloud.device_eui='<CORRECT_EUI_UPPERCASE>'
+   uci commit osi-server
+   ```
+2. Regenerate the verifier on the Pi with `bcryptjs` (placeholders `<password>` /
+   `<eui>` — uppercase EUI, same delimiter):
+   ```bash
+   node -e "const b=require('/srv/node-red/node_modules/bcryptjs'); console.log(b.hashSync('<password>::<eui>', 10))"
+   ```
+3. Write the new hash into the DB:
+   ```bash
+   sqlite3 /data/db/farming.db "UPDATE users SET server_offline_verifier = '<hash>' WHERE username = '<username>';"
+   ```
+4. Restart Node-RED, then have the operator unlink and re-link the cloud account so
+   a fresh sync token issues for the corrected EUI.
+
+Also check `irrigation_zones` rows created before the fix — a sync trigger applies a
+`COALESCE(gateway_device_eui, <fallback>)` only on `INSERT`, so already-existing zone
+rows keep whatever EUI they were created with and need an explicit `UPDATE`.
+
+### ChirpStack v4 has no plain REST API
+
+ChirpStack v4.x is gRPC-web only; `curl http://127.0.0.1:8080/api/...` 404s
+regardless of payload. To inspect or change ChirpStack config on a live Pi:
+
+- **Read:** `sqlite3 /srv/chirpstack/chirpstack.sqlite "SELECT ...;"`
+- **Write:** stop ChirpStack first (the DB is locked while it runs), modify via
+  `sqlite3`, then start it again:
+  ```bash
+  /etc/init.d/chirpstack stop
+  sqlite3 /srv/chirpstack/chirpstack.sqlite "UPDATE ... ;"
+  /etc/init.d/chirpstack start
+  ```
+
+### Flows fail to load / all routes 404
+
+`functionExternalModules: true` is set in `settings.js` (confirmed at
+`feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js`). If a function
+node's `libs` array references a helper module (e.g. `osi-db-helper`) not declared
+in `/srv/node-red/package.json`, Node-RED tries to `npm install` it, fails (not a
+published package), and refuses to load **all** flows — every route returns 404
+with nothing obviously wrong in standard logs. Fix: ensure `package.json` declares
+it as a `file:` dependency, e.g.:
+```json
+"osi-db-helper": "file:osi-db-helper"
+```
+`deploy.sh` deploys this file itself, so this mostly bites hand-edited or
+partially-deployed Pis. To see the real error, run Node-RED in the foreground:
+```bash
+node-red --userDir /srv/node-red
+```
+Triage tables for narrowing down *which* symptom you're looking at belong to
+`osi-debugging-playbook`; this recipe is specifically the "declared helper module
+missing from package.json" root cause.
+
+### Live valve testing (STREGA)
+
+STREGA valves accept `OPEN_FOR_DURATION` only in normal operation; the valve closes
+itself when the commanded duration elapses. There is no safe bare `CLOSE` in this
+model — the reconciliation monitor (`strega-reconciliation-monitor` in `flows.json`)
+explicitly does not emit a CLOSE downlink on timer elapse, "STREGA self-closes" per
+its own comment.
+
+- Never send a bare `CLOSE` command during testing or debugging.
+- Use short durations (60 s) when reproducing a valve-open bug; let it auto-close.
+- Operator-driven cancellation of an in-progress duration is a real, separate path:
+  ```bash
+  curl -X POST http://127.0.0.1:1880/api/v1/valves/<deveui>/cancel
+  ```
+  (confirmed route: `POST /api/v1/valves/:deveui/cancel`, node
+  `cancel-valve-http-in` in `flows.json`, tab `device-api-tab`). Reserve this for
+  genuine operator cancel intent, not as test cleanup.
+
+---
+
+## SSH access pattern
+
+Key-based root SSH to gateways over the operator's VPN/tailnet is the standard
+access path:
+
+```bash
+ssh -i ~/.ssh/<key> -o IdentitiesOnly=yes root@<pi-ip>
+```
+
+Live device inventory (which hostnames/IPs correspond to which farm, which key to
+use where) lives in the operator's private notes, not in this repo or this skill —
+do not hardcode gateway hostnames, Tailscale IPs, EUIs, or cloud usernames anywhere
+in runbooks, docs, or scripts.
+
+---
+
+## Common mistakes
+
+- Running `curl ... | sh` for the deploy step instead of download-then-run, then
+  trusting a printed "Deploy complete" without checking the actual SSH/curl exit
+  code — a 404'd fetch can still exit the pipeline at 0.
+- Treating `export.csv` returning `401` as a failure. It is the healthy state for an
+  unauthenticated request; `404`/`500` is the actual failure signal.
+- `scp`-ing any `farming.db` onto a Pi that has ever been provisioned — there is no
+  scenario in normal operations where this is correct.
+- Using `localhost` in an on-Pi curl/wget call and getting a confusing connection
+  refusal that's actually an IPv6 resolution artifact, not a dead service.
+- Sending a bare `CLOSE` to a STREGA valve "to be safe" — it is not part of the
+  supported command set; use a short `OPEN_FOR_DURATION` or the cancel endpoint.
+- Resetting a password or token to get unblocked instead of asking the operator.
+- Treating a loaded SSH key or working `ssh` check against `osicloud.ch` as
+  permission to proceed there.
+- Hand-editing `schema_object_fingerprints` instead of using
+  `restamp-fingerprints.js`, or running that script without first confirming the
+  live schema is actually correct.
+- Forgetting `ensure_*_schema` steps in `deploy.sh` only run when `farming.db`
+  already exists — on a brand-new Pi they SKIP, so a fresh gateway ends up exactly
+  at the bundled seed schema, not at seed-plus-repairs.
+
+---
+
+## Provenance and maintenance
+
+Re-verify these if this skill feels stale (the deploy flow and safety rules change
+rarely, but do change):
+
+- Seeding guard logic: `grep -n "seed_db_if_missing" -A 25 deploy.sh` (repo root).
+- Download-then-run tunnel command still matches practice: check the current
+  operator wrapper behavior contract (not in this repo) or re-derive from
+  `deploy.sh`'s own header comment plus this skill's rationale.
+- `osi-bootstrap` stamp/START logic:
+  `cat conf/full_raspberrypi_bcm27xx_bcm2712/files/etc/init.d/osi-bootstrap`.
+- `export.csv` route + auth gate: `grep -n "export.csv" -A2` and
+  `grep -n "function verifyBearer" -A15` against
+  `conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json`.
+- STREGA cancel route: `grep -n "valves/:deveui/cancel"` against the same
+  `flows.json`.
+- `restamp-fingerprints.js` behavior: `sed -n '1,30p' scripts/restamp-fingerprints.js`.
+- Gateway-health table/migration: `sed -n '1,10p' database/migrations/ordered/0002__gateway_health.sql`.
+- package.json helper declarations: `grep -n "file:" conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/package.json`.
+- `functionExternalModules` flag: `grep -n functionExternalModules feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js`.
+- Prime directives / asymmetry framing: `sed -n '13,32p' docs/engineering-playbook.md`.
+- Production-cloud gate wording: `sed -n '/Production cloud access/,/^---/p' AGENTS.md`.
+- Cross-check this file still matches `AGENTS.md` "Live-deploy safety rules" verbatim
+  intent — if that section is edited, this skill's Prime Safety Rules section needs
+  a matching pass.

--- a/.claude/skills/osi-live-ops-runbook/SKILL.md
+++ b/.claude/skills/osi-live-ops-runbook/SKILL.md
@@ -164,7 +164,7 @@ an unknown credential.
 | Restart Node-RED | `/etc/init.d/node-red restart` |
 | Free a leaked local port | `pkill -9 -f 'http.server 9876'` |
 | SSH to a gateway | `ssh -i ~/.ssh/<key> -o IdentitiesOnly=yes root@<pi-ip>` |
-| Filter SSH banner noise | pipe through `grep -v "post-quantum\|store now"` |
+| Filter SSH banner noise | pipe through `grep -v -e 'post-quantum' -e 'store now'` (portable; BusyBox grep lacks BRE alternation) |
 | Re-baseline a drifted fingerprint | `node scripts/restamp-fingerprints.js /data/db/farming.db` (on-Pi path) |
 
 ---
@@ -201,7 +201,7 @@ dev workstation unless noted.
    instead of piping into `sh`:
    ```bash
    ssh -R 9876:localhost:9876 root@<pi-ip> \
-     'curl -fsSL http://localhost:9876/deploy.sh -o /tmp/osi-os-deploy.sh && sh /tmp/osi-os-deploy.sh; rc=$?; rm -f /tmp/osi-os-deploy.sh; exit "$rc"'
+     'curl -fsSL http://127.0.0.1:9876/deploy.sh -o /tmp/osi-os-deploy.sh && sh /tmp/osi-os-deploy.sh; rc=$?; rm -f /tmp/osi-os-deploy.sh; exit "$rc"'
    ```
    **Why download-then-run instead of `curl ... | sh`:** in a pipe, the shell's exit
    status is the last command's (`sh`'s), not `curl`'s. If `curl` 404s (local
@@ -290,7 +290,7 @@ deviation as a signal to stop and investigate before telling the operator it's d
 | GUI bundle rotated | `ls /usr/lib/node-red/gui/assets/` | New `index-<hash>.js` filename different from the pre-deploy listing (Vite content-hashes build output; `web/react-gui/vite.config.js` sets `base: '/gui/'`) |
 | Node-RED up | `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:1880/gui` | `301` (redirect into the SPA route) |
 | Zone CSV export route auth-gated | `curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:1880/api/history/zones/1/export.csv` | `401` — this route (`GET /api/history/zones/:zoneId/export.csv` in `flows.json`, tab `history-api-tab`) requires a Bearer token via `verifyBearer`; `401` without a token means the route loaded and is enforcing auth correctly. `404`/`500` means the route or its router function failed to load — treat as broken, not healthy. |
-| ChirpStack profile env vars present | `grep -E 'CHIRPSTACK_PROFILE_(RAK10701|S2120)' /srv/node-red/.chirpstack.env` (path/semantics) | Both present. Flag semantics and full variable list: `osi-config-and-flags`. |
+| ChirpStack profile env vars present | `grep -e 'CHIRPSTACK_PROFILE_RAK10701' -e 'CHIRPSTACK_PROFILE_S2120' /srv/node-red/.chirpstack.env` (path/semantics; pipe-free form keeps this table row rendering) | Both present. Flag semantics and full variable list: `osi-config-and-flags`. |
 | Gateway health samples fresh | `sqlite3 /data/db/farming.db "SELECT gateway_device_eui, sampled_at FROM gateway_health_samples ORDER BY sampled_at DESC LIMIT 3;"` | Rows within the last ~60 s (the 60 s heartbeat inject also persists this table; schema at `database/migrations/ordered/0002__gateway_health.sql`) |
 
 Use `127.0.0.1`, not `localhost`, for every on-Pi curl (see BusyBox traps below).
@@ -346,7 +346,7 @@ alone):
   gateways prints a post-quantum key exchange notice from the server side. Filter it
   out of scripted output rather than treating it as an error:
   ```bash
-  ssh ... 2>&1 | grep -v "post-quantum\|store now"
+  ssh ... 2>&1 | grep -v -e 'post-quantum' -e 'store now'
   ```
 
 ---
@@ -358,8 +358,12 @@ alone):
 `/srv/node-red/.chirpstack.env` can carry a stale `DEVICE_EUI*` value that overrides
 the runtime identity even after UCI has been corrected. During an identity repair,
 remove or regenerate this file so the helper/UCI path (canonical, uppercase EUI)
-is what actually takes effect. Full flag semantics and where this file's other
-variables come from: `osi-config-and-flags`.
+is what actually takes effect. **Save a copy first**: the same file carries the
+`CHIRPSTACK_APP_*`/`CHIRPSTACK_PROFILE_*` values, and `CHIRPSTACK_PROFILE_LORAIN`
+reaches the Node-RED runtime ONLY through this file (`node-red.init` does not
+export it from UCI) — a regenerated env missing it silently breaks LoRain ingest
+until the ChirpStack bootstrap rewrites the file. Full flag semantics and where
+this file's other variables come from: `osi-config-and-flags`.
 
 ### Changing DEVICE_EUI breaks linked login
 

--- a/.claude/skills/osi-live-ops-runbook/SKILL.md
+++ b/.claude/skills/osi-live-ops-runbook/SKILL.md
@@ -96,11 +96,21 @@ TS=$(date +%Y%m%d-%H%M%S)
 LABEL="pre-repair"          # e.g. "pre-eui-fix", "pre-fingerprint-restamp"
 BK="/data/db/backups/${LABEL}-${TS}"
 mkdir -p "$BK"
-cp -a /data/db/farming.db "$BK/farming.db" 2>/dev/null || true
-cp -a /data/db/farming.db-wal "$BK/farming.db-wal" 2>/dev/null || true
-cp -a /data/db/farming.db-shm "$BK/farming.db-shm" 2>/dev/null || true
+# Primary DB: prefer a consistent ONLINE backup (safe while Node-RED writes);
+# fall back to a fail-FAST raw copy. Never silence a failed primary backup.
+sqlite3 /data/db/farming.db ".backup '$BK/farming.db'" \
+  || cp -a /data/db/farming.db "$BK/farming.db" \
+  || { echo "FATAL: primary DB backup failed - do NOT proceed with the repair"; exit 1; }
+# For a raw copy of a live DB, stop writers first (/etc/init.d/node-red stop) or
+# accept that the sidecars below are required to make the copy consistent.
+for f in farming.db-wal farming.db-shm farming.db-journal; do
+  [ -e "/data/db/$f" ] && cp -a "/data/db/$f" "$BK/$f"
+done
 cp -a /srv/node-red/flows.json "$BK/flows.json"
 cp -a /srv/node-red/settings.js "$BK/settings.js"
+cp -a /srv/node-red/flows_cred.json "$BK/flows_cred.json" 2>/dev/null || true  # MQTT credentials
+# ChirpStack state — REQUIRED before any direct chirpstack.sqlite edit
+[ -e /srv/chirpstack/chirpstack.sqlite ] && cp -a /srv/chirpstack/chirpstack.sqlite "$BK/chirpstack.sqlite"
 mkdir -p "$BK/gui"
 cp -a /usr/lib/node-red/gui/. "$BK/gui/" 2>/dev/null || true
 echo "Backup at $BK"

--- a/.claude/skills/osi-schema-change-control/SKILL.md
+++ b/.claude/skills/osi-schema-change-control/SKILL.md
@@ -528,7 +528,7 @@ node --test lib/osi-migrate/__tests__/*.test.js         # runner unit tests (ris
 find . -name farming.db -not -path '*/node_modules/*'  | sort   # should list exactly 7 paths
 ls database/migrations/ordered/                         # current migration set (0001, 0002 as of 2026-07-06)
 ls .github/workflows/ && cat .github/workflows/migrations.yml .github/workflows/verify-sync-flow.yml   # what CI actually gates (both workflows)
-grep -rn "osi-migrate\|applyPending\|bootstrapFresh\|verifyHead" --include=*.js --include=*.sh . | grep -v node_modules   # re-confirm the runner has no on-device caller
+grep -rn "osi-migrate\|applyPending\|bootstrapFresh\|verifyHead" scripts/ lib/ deploy.sh conf/ feeds/chirpstack-openwrt-feed/apps/node-red/files/ --exclude-dir=node_modules   # re-confirm no on-device caller (covers flows.json + init files, not just *.js/*.sh)
 ```
 
 All commands above were run against this worktree on 2026-07-06 and returned the

--- a/.claude/skills/osi-schema-change-control/SKILL.md
+++ b/.claude/skills/osi-schema-change-control/SKILL.md
@@ -79,7 +79,7 @@ outside the one sanctioned exception.
 | Backfill / data correction against existing rows | New `data` ordered migration | Backup + normal transaction; no FK fence; no writers-stopped gate; must be idempotent against the pre-migration row shape. |
 | `devices.type_id` CHECK needs a new device type on a **live** Pi today | The guarded fail-closed rebuild already shipped in `sync-init-fn` (sanctioned exception) + `scripts/repair-pi-schema.js` entry | Do not add a second rebuild path; extend the existing `REQUIRED_TYPES` set and its parity surfaces (`verify-runtime-schema-parity.js`, `verify-db-schema-consistency.js`) — subject to the full boot-node merge gate below (four verifiers + production-copy rehearsal). |
 | Idempotent additive repair needed on live Pis at deploy time (e.g. a new column) | `deploy.sh` `ensure_*` function | Follows the `ensure_dendro_schema` / `ensure_gateway_health_schema` precedent: `ALTER TABLE ... ADD COLUMN`, catching `duplicate column name` as a no-op. Never used for anything destructive. |
-| Any other on-device schema mutation | Not currently supported without a boot-path project | See "Option B" below; do not invent a new ad hoc mutation path. |
+| Any other on-device schema mutation | Not currently supported without a boot-path project | See the Option B boot-path project in the ADR (`docs/adr/2026-06-30-schema-and-contract-ownership.md`); do not invent a new ad hoc mutation path. |
 
 ## The model: ownership, migrations, risk classes
 
@@ -455,8 +455,11 @@ that live without also reading `osi-live-ops-runbook`.
    `database/migrations/ordered/0003__your_slug.sql` (next contiguous 4-digit
    version) with a `-- risk: additive` header as the first line, then your
    `CREATE TABLE`/`ALTER TABLE ... ADD COLUMN`/`CREATE INDEX`/`CREATE TRIGGER`
-   statements. Prefer `IF NOT EXISTS` on new objects so the file is safely
-   re-runnable, matching the `0002` precedent.
+   statements. Prefer `IF NOT EXISTS` on object-creation statements (tables,
+   indexes, triggers) so the file is safely re-runnable, matching the `0002`
+   precedent. `ALTER TABLE ... ADD COLUMN` has no `IF NOT EXISTS` in SQLite —
+   its live-Pi delivery goes through a deploy-time `ensure_*` function that
+   treats `duplicate column name` as a no-op (see the decision table above).
 2. **Update `database/seed-blank.sql`.** Append the equivalent DDL so a fresh
    database created from the seed ends up schema-identical to one built by
    replaying all ordered migrations. `verify-seed-replay.js` is the automatic

--- a/.claude/skills/osi-schema-change-control/SKILL.md
+++ b/.claude/skills/osi-schema-change-control/SKILL.md
@@ -1,0 +1,536 @@
+---
+name: osi-schema-change-control
+description: Use when adding/changing a SQLite table, column, index, trigger, or view on the OSI OS edge; editing seed-blank.sql or a bundled farming.db; writing database/migrations/ordered/NNNN__slug.sql; touching lib/osi-migrate; a migration verifier fails (verify-migrations, verify-seed-replay, verify-runtime-schema-parity, verify-db-schema-consistency, verify-devices-rebuild-fence); schema_object_fingerprints drift; or touching the frozen sync-init-fn boot node.
+---
+
+# OSI Schema Change Control
+
+## Overview
+
+OSI OS edge state lives in one SQLite file per gateway, `/data/db/farming.db`. This
+file survives for the operational life of a Pi and cannot be safely reseeded —
+farm history (irrigation events, sensor readings, dendrometer calibration) is
+irreplaceable. Because of that, edge SQLite schema is under change control, not
+free-form DDL.
+
+As of 2026-07-06 there are two overlapping mechanisms with different scopes:
+
+1. **The ordered migration runner** (`lib/osi-migrate` + `database/migrations/ordered/`) —
+   the *governed, executable schema authority* per
+   `docs/adr/2026-06-30-schema-and-contract-ownership.md`. It is CI/tooling-time
+   only today (see "Key fact" below); it does not run on a booting Pi.
+2. **The Node-RED boot node `sync-init-fn`** ("Sync Init Schema + Triggers") — a
+   legacy inline-DDL block that runs on every boot on every live Pi. It is FROZEN
+   for new schema behavior (one narrow, sanctioned exception below).
+
+Both must stay in fingerprint/column parity with `database/seed-blank.sql`, which
+is the schema source of truth for a fresh database. Getting any of this wrong on a
+live Pi is a farm-data-loss incident, not a bug.
+
+## When to use
+
+- Adding/removing/renaming a table, column, index, trigger, or view anywhere edge
+  SQLite touches (`database/seed-blank.sql`, bundled `farming.db` copies,
+  `database/migrations/ordered/`, or the boot node).
+- Writing a new `database/migrations/ordered/NNNN__slug.sql` file and choosing its
+  risk class.
+- A migration/parity verifier is red: `verify-migrations.js`,
+  `verify-seed-replay.js`, `verify-runtime-schema-parity.js`,
+  `verify-db-schema-consistency.js`, `verify-devices-rebuild-fence.js`,
+  `rehearse-devices-rebuild.test.js`.
+- `schema_object_fingerprints` drift, a `repair_required` row in
+  `schema_migrations`, or a "checksum mismatch" error from the runner.
+- Any proposed edit to the `sync-init-fn` boot node's DDL/rebuild logic.
+- Deciding whether a device-type or column addition needs a `devices.type_id`
+  CHECK rebuild.
+
+## When NOT to use — route to the sibling skill
+
+| Situation | Use instead |
+|---|---|
+| "duplicate column" or other verifier failure and you haven't yet found the root cause | `osi-debugging-playbook` (symptom triage) first, then come back here once you know it's a schema-ownership question |
+| Deploying to a live/provisioned Pi, running the on-device restamp recovery (`scripts/restamp-fingerprints.js`) during an incident, or any live-Pi repair procedure | `osi-live-ops-runbook` |
+| Mechanics of how to script-edit `flows.json` safely (parse/mutate/verify round-trip) | `osi-flows-json-editing` — this skill tells you *what* schema change is allowed in `sync-init-fn`, that skill tells you *how* to make the JSON edit |
+| Sensor/device domain semantics (what a column means agronomically, SWT canonicalization, calibration math) | `osi-agronomy-sensors-reference` |
+| Env vars, UCI flags, deploy-time knobs unrelated to schema | `osi-config-and-flags` |
+
+This skill never routes around change control: it does not grant permission to
+hand-edit ledger tables, reseed a live DB, or add schema behavior to the boot node
+outside the one sanctioned exception.
+
+## NEVER-do list
+
+| Never | Why |
+|---|---|
+| Hand-edit `schema_object_fingerprints` | It is a computed baseline (SHA-256 over live DDL + `PRAGMA table_xinfo`/`foreign_key_list`/`index_list`/`index_xinfo`). A hand edit desyncs the stamp from the real schema and the next `applyPending` either falsely passes or falsely refuses. The only sanctioned re-baseline is `scripts/restamp-fingerprints.js` (see below). |
+| Reseed or overwrite `/data/db/farming.db` on a provisioned Pi | `deploy.sh`'s `seed_db_if_missing` only seeds when the file is absent *and* no WAL/SHM/journal sidecars exist; it refuses otherwise. Overwriting destroys irreplaceable farm history. |
+| Add new schema behavior to `sync-init-fn` (the boot node) | It is FROZEN (AGENTS.md "Boot-DDL freeze"). New schema goes through the migration runner's ordered files, even though the runner doesn't execute on-device yet — freezing the boot node is what makes eventual cutover (Option B) tractable. |
+| Modify an already-merged `database/migrations/ordered/NNNN__slug.sql` file | Migrations are checksummed (SHA-256 of the raw file bytes, `lib/osi-migrate/migrations-loader.js`). Changing a merged file makes the ledger's stored checksum mismatch the file on next apply, which the runner treats as `repair_required` and refuses to proceed past. |
+| Update `seed-blank.sql` or one bundled DB without the others | `verify-seed-replay.js` and `verify-db-schema-consistency.js` both fail if any of the 7 bundled copies drifts from the seed/migration-replay schema. One home for the fact: keep all copies byte/fingerprint-identical in the same commit. |
+| Rebuild a parent table (drop/rename swap) without the FK fence | Without `PRAGMA foreign_keys=OFF` held across the swap, `ON DELETE CASCADE` on child tables (`device_data`, `chameleon_readings`) silently wipes their rows when the parent is dropped. This caused a documented field history-loss incident (`docs/operations/edge-history-retention.md`). |
+| Run a `destructive`-class migration without writers stopped | `runner.js` enforces this in code — it throws `refuse to run unless writers are stopped (deploy/pre-start)` — because a table rebuild racing a live Node-RED writer can corrupt or lose in-flight rows. |
+
+## Decision table: which mechanism do I use?
+
+| Change | Mechanism | Notes |
+|---|---|---|
+| New table, column, index, view, or trigger (append-only) | New `additive` ordered migration + `seed-blank.sql` + all 7 bundled DBs | No backup, no writers-stopped gate required by the runner itself, but you still must keep parity surfaces in sync (see Walkthrough). |
+| Drop/rename/rebuild a table, or alter a CHECK/constraint that SQLite can't `ALTER` in place | New `destructive` ordered migration | Requires `writersStopped=true`; take a backup; FK fence. Since the runner does not run on-device today, on-device destructive changes are not currently supported outside the one sanctioned devices-CHECK rebuild (below) — anything else requires the Option B boot-path project; do not invent an ad hoc path (`ensure_*` functions are additive-only). |
+| Backfill / data correction against existing rows | New `data` ordered migration | Backup + normal transaction; no FK fence; no writers-stopped gate; must be idempotent against the pre-migration row shape. |
+| `devices.type_id` CHECK needs a new device type on a **live** Pi today | The guarded fail-closed rebuild already shipped in `sync-init-fn` (sanctioned exception) + `scripts/repair-pi-schema.js` entry | Do not add a second rebuild path; extend the existing `REQUIRED_TYPES` set and its parity surfaces (`verify-runtime-schema-parity.js`, `verify-db-schema-consistency.js`) — subject to the full boot-node merge gate below (four verifiers + production-copy rehearsal). |
+| Idempotent additive repair needed on live Pis at deploy time (e.g. a new column) | `deploy.sh` `ensure_*` function | Follows the `ensure_dendro_schema` / `ensure_gateway_health_schema` precedent: `ALTER TABLE ... ADD COLUMN`, catching `duplicate column name` as a no-op. Never used for anything destructive. |
+| Any other on-device schema mutation | Not currently supported without a boot-path project | See "Option B" below; do not invent a new ad hoc mutation path. |
+
+## The model: ownership, migrations, risk classes
+
+### Ownership (ADR 2026-06-30)
+
+`docs/adr/2026-06-30-schema-and-contract-ownership.md` (Accepted, 2026-06-30) sets
+a hard three-layer boundary:
+
+1. **Edge SQLite DDL is owned by osi-os ordered migrations + a ledger** — the
+   *only* executable schema authority on the edge. Migrations are versioned,
+   idempotent, checksummed, transactional where possible, applied exactly once,
+   recorded in a `schema_migrations` ledger.
+2. **Cloud Postgres DDL is owned by osi-server Flyway**, independently — the two
+   databases differ on booleans, timestamps, CHECK handling, trigger languages,
+   FK enforcement, and JSON storage and are not forced into one shared model.
+3. **Cross-repo compatibility is owned by versioned sync event/payload schemas**,
+   not shared DDL — extending `docs/contracts/sync-schema/`.
+
+The ADR rejected a single YAML DSL generating SQLite DDL, Flyway migrations, Java
+entities, TypeScript types, and channel manifests from one model: the cross-dialect
+gap plus the need for imperative, order-sensitive migration logic (table rebuilds,
+FK fences, backfills, partial-failure recovery) made a declarative final-state
+generator unsafe for a live production edge DB. (The draft it supersedes,
+`docs/superpowers/specs/2026-06-30-schema-driven-codegen-design.md`, is referenced
+by the ADR but was never committed to the repo — do not go looking for it.)
+
+### Ordered migrations: format and risk-class declaration
+
+Files live at `database/migrations/ordered/NNNN__slug.sql` — currently
+`0001__baseline.sql` (the full schema equivalent of `seed-blank.sql` at the time
+the runner was introduced) and `0002__gateway_health.sql`. The filename format is
+enforced by a regex in `lib/osi-migrate/migrations-loader.js`:
+`^(\d{4})__([a-z0-9_]+)\.sql$` — four-digit version, double underscore, lowercase
+slug. Versions must be unique and are sorted numerically, not lexically.
+
+**The risk class is declared in a mandatory file header, not inferred from
+content or filename.** `migrations-loader.js` requires the first non-blank line
+(a UTF-8 BOM and leading blank lines are tolerated) to match
+`-- risk: additive|destructive|data`. A migration missing this header throws
+`migration <file> missing '-- risk: additive|destructive|data' header` and is
+rejected before it can run. Example, verbatim from `0002__gateway_health.sql`:
+
+```sql
+-- risk: additive
+-- 0002: Persist aggregated gateway CPU health reporting (osi-os issue #68).
+```
+
+Each migration file is also SHA-256 checksummed over its **raw bytes**
+(`crypto.createHash('sha256').update(raw)` in `migrations-loader.js`) and that
+checksum is stored in the `schema_migrations` ledger row on success. If a
+previously-applied migration's on-disk checksum no longer matches the stored one,
+`applyPending` marks it `repair_required` and throws — this is the enforcement
+mechanism behind "never modify a merged migration."
+
+### Risk-class semantics, verified against `lib/osi-migrate/runner.js`
+
+- **`additive`** — append-only schema (new tables/columns/indexes/views/triggers).
+  No backup is taken. No transaction fence: it runs as a plain
+  `BEGIN IMMEDIATE; <sql>; <ledger insert>; COMMIT;` block (see the final `else`
+  branch of the risk dispatch in `applyPending`).
+- **`destructive`** — schema mutation (drop/rename/rebuild/alter). The runner
+  refuses to even start unless the caller passed `writersStopped: true` (deploy
+  pre-start), throwing `migration <name> is destructive; refuse to run unless
+  writers are stopped (deploy/pre-start)` otherwise. It takes an online backup
+  first (`backupDb`), then runs `composeDestructiveScript`, which toggles
+  `PRAGMA foreign_keys` **outside** the transaction (SQLite treats
+  `PRAGMA foreign_keys` as a no-op inside an open transaction, so it must bracket
+  it) and fences the actual DDL inside `BEGIN IMMEDIATE`/`COMMIT` between the
+  `OFF`/`ON` toggle: `PRAGMA foreign_keys=OFF; BEGIN IMMEDIATE; <sql>; <ledger
+  insert>; COMMIT; PRAGMA foreign_keys=ON;`.
+- **`data`** — backfill/mutation of existing rows. Takes an online backup (same
+  as destructive), then applies in a normal transaction — `BEGIN IMMEDIATE; <sql>;
+  <ledger insert>; COMMIT;` — with **no** FK toggle and **no** writers-stopped
+  gate. The code comment in `runner.js` is explicit: "Write data migrations
+  idempotently vs the old format." Data migrations are meant to run at deploy
+  time specifically because a long-running backfill would otherwise hold the
+  write lock past the Node-RED runtime's busy timeout (5 s, `PRAGMA
+  busy_timeout=5000` in `osi-db-helper`; the CLI runner itself uses a 30 s
+  `.timeout`) if it ran during normal operation.
+
+All three classes run `postflight` after commit: `PRAGMA integrity_check` must
+return `ok`, and `PRAGMA foreign_key_check` must return zero rows, or the
+migration is treated as failed even though its DDL already committed (see
+"mid-batch failure" below).
+
+**Per-migration fingerprint stamping.** After each migration's transaction
+commits, `applyPending` calls `syncFingerprints` for *that migration alone*,
+before attempting the next one in the batch — this is outside the `try`/`catch`
+on purpose (a stamp failure must not retroactively mark an otherwise-successful
+migration `repair_required`). This means a batch of N migrations that fails on
+migration k leaves migrations `1..k-1` correctly stamped; the retry's drift
+preflight (see below) then sees a consistent world and does not spuriously wedge
+the whole batch. Before this was added, a mid-batch failure could leave the
+fingerprint baseline representing "nothing applied" while the DB already had
+`1..k-1` committed, which the next run's drift check would reject as corruption
+rather than progress.
+
+**Preflight drift check.** Before applying anything, `applyPending` recomputes
+live fingerprints and compares them to the stored baseline; if they differ it
+refuses with `schema drift detected before applying migrations ... Refuse to
+proceed`, pointing at `restamp-fingerprints.js` as the recovery path if the live
+schema is known-good.
+
+**Backup retention.** `lib/osi-migrate/backup.js`'s `backupDb` takes an online
+backup via the `sqlite3` CLI's `.backup` dot-command (safe under an active WAL),
+verifies the copy's `PRAGMA integrity_check`, then calls `pruneBackups(dbPath,
+keep=5)` — ISO-timestamped `<db>.bak-<stamp>` files are sorted lexically
+(equivalent to chronologically) and all but the newest 5 are deleted. Pruning is
+per-file resilient (one un-removable sibling logs and continues) and the whole
+prune step is wrapped so a directory-level failure never fails an
+already-integrity-checked backup.
+
+### Key fact: the runner does not run on a booting Pi
+
+Verified by grep: `applyPending`, `bootstrapFresh`, and `verifyHead` (the only
+exports of `lib/osi-migrate/index.js`) are referenced **only** inside
+`lib/osi-migrate/` itself, its `__tests__/`, and three scripts:
+`scripts/verify-seed-replay.js` (calls `bootstrapFresh` against a scratch DB and
+compares fingerprints to `seed-blank.sql`, `appVersion: 'ci'`),
+`scripts/restamp-fingerprints.js` (calls `syncFingerprints` directly, not the
+apply path, for the stale-stamp recovery verb), and the runner's own test suite.
+`deploy.sh` and `flows.json`/`init.d` contain **zero** references to
+`osi-migrate`/`applyPending` — confirmed by grepping the whole repo. `deploy.sh`'s
+own `ensure_gateway_health_schema` function fetches
+`database/migrations/ordered/0002__gateway_health.sql` and executes its raw SQL
+directly via a small inline Node/`sqlite3` script, guarded by a regex that refuses
+to run anything except an `additive`-headed file — it does not call the ledgered
+runner at all. So today there is no dormant on-boot migration risk: the runner is
+strictly a CI/tooling-time mechanism (`.github/workflows/migrations.yml` runs
+`verify-migrations.js`, `verify-seed-replay.js`, and the runner's own
+`node --test` suite on every push/PR to `main`/`master`).
+
+## Boot-DDL freeze (the other schema path, and why it's frozen)
+
+The Node-RED node **"Sync Init Schema + Triggers"** (node id `sync-init-fn`,
+present byte-identically in both
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json` and the
+`bcm2709` mirror) performs inline DDL on every boot: verified count is **93**
+`ADD COLUMN` statements in the function body, the large majority idempotent
+against a schema that already has the column (errors from these are swallowed in
+a `try {...} catch (_) {}` sweep). This node is **FROZEN**: do not add new schema
+behavior to it. New schema changes go through the ordered-migration runner's
+files even though, per the Key Fact above, nothing executes those files on a live
+Pi yet — the migration files remain the durable, checksummed record of intended
+schema even while the boot path itself is still the inline node.
+
+### Incident history (one line each, factual)
+
+- **PR #79** restored the `devices.type_id` CHECK list plus a runtime↔seed parity
+  guard after the boot rebuild had silently recreated `devices` with the CHECK
+  missing `AQUASCOPE_LORAIN` on every restart (fixed in `a646efe3`).
+- **Issue #84 / "duplicate column" verifier failures**: recurring `duplicate
+  column` errors were, in writing, blamed on the boot DDL node. The real root
+  cause was a stale upgrade-test baseline — the misattribution itself had to be
+  corrected (`docs/superpowers/plans/2026-07-04-fix-history-schema-upgrade-baseline.md`).
+  Lesson embedded in the playbook (`docs/engineering-playbook.md` §6): "a signal
+  that pattern-matches a known failure may have a different cause."
+- **PR #86 (2026-07)** shipped the guarded, fail-closed `devices` table rebuild —
+  the one sanctioned exception to the freeze, because it is a safety fix rather
+  than new schema behavior. Details below.
+
+### The sanctioned exception: guarded fail-closed `devices` rebuild
+
+Verified directly in `sync-init-fn`'s function body (both flows files, byte
+identical). The rebuild:
+
+1. Reads the live `devices` table's CHECK clause and extracts the current
+   `type_id` set with a regex.
+2. Compares it by **set equality** against the six canonical types —
+   `KIWI_SENSOR`, `STREGA_VALVE`, `DRAGINO_LSN50`, `TEKTELIC_CLOVER`,
+   `SENSECAP_S2120`, `AQUASCOPE_LORAIN` (named `REQUIRED_TYPES` in the code). If
+   the live set is missing a type *or* has an extra/drifted type, `needsRebuild`
+   is true — this is stricter than "missing-only," which was a P2 review finding
+   fixed before merge (an extra drifted type must also trigger convergence, not
+   just an omission).
+3. Only if a rebuild is needed: `PRAGMA foreign_keys=OFF`, then inside
+   `_db.transaction(...)` — one `operationQueue` slot, `BEGIN IMMEDIATE`,
+   auto-`ROLLBACK` on any throw — it drops any stale `devices_new` left from a
+   prior crash, creates `devices_new` with the corrected CHECK, copies rows with
+   a **plain `INSERT`** (not `INSERT OR IGNORE`), drops `devices_old` if present,
+   renames `devices`→`devices_old`→drop, renames `devices_new`→`devices`, and
+   recreates the four `devices` indexes. Because the copy is a plain `INSERT`,
+   any row that violates the new CHECK throws inside the transaction and rolls
+   back the whole rebuild — `devices` is left untouched, not silently missing
+   rows. This replaces the old `INSERT OR IGNORE` behavior, exactly the class of
+   bug that caused the AQUASCOPE_LORAIN regression above.
+4. `PRAGMA foreign_keys=ON` (and `legacy_alter_table=OFF`) are restored in a
+   `finally` block that guards each restore independently, so one failing
+   restore can't skip the other, on **every** exit path including a caught
+   rebuild error. Errors are surfaced via `node.error('devices rebuild ABORTED
+   (devices left intact): ' + e.message)` — never swallowed silently, unlike the
+   ~93 ADD COLUMN sweep above it in the same function.
+
+**FK fence rationale:** rebuilding a parent table via a drop/rename swap without
+`PRAGMA foreign_keys=OFF` held across the swap lets `ON DELETE CASCADE` on child
+tables (`device_data`, `chameleon_readings`) fire the moment the old `devices` is
+dropped, silently wiping those child rows. This is the documented cause of a real
+field history-loss incident (`docs/operations/edge-history-retention.md`); the
+fence is what prevents it from recurring.
+
+### Merge gate for any further touch to this block
+
+Verified present and passing in this worktree on 2026-07-06:
+
+```
+node scripts/verify-runtime-schema-parity.js     # OK (2 flows: devices CHECK + trigger parity)
+node scripts/verify-profile-parity.js            # All parity checks passed.
+node scripts/verify-devices-rebuild-fence.js     # OK (2 flows)
+node --test scripts/rehearse-devices-rebuild.test.js   # 4/4 pass
+```
+
+`rehearse-devices-rebuild.js` executes the **actual shipped function text**
+(via `new Function('osiDb','env','node','msg', funcText())`) against a
+facade-compatible shim over Node's built-in `node:sqlite` (`DatabaseSync`) — a
+real engine, not a fake — across four seeded cases: `healthy` (guard must skip,
+rows preserved), `would-drop` (a row the new CHECK would reject must never be
+silently dropped, and the abort must be surfaced), `legit-upgrade` (rebuild
+succeeds, CHECK gains `AQUASCOPE_LORAIN`), and `extra-type` (a drifted extra type
+with no offending rows must still trigger a rebuild that converges the CHECK back
+to exactly the six canonical types). `verify-devices-rebuild-fence.js` statically
+greps both flows files for the fail-closed shape: no `INSERT OR IGNORE INTO
+devices_new`, rebuild inside `_db.transaction(`, guarded by
+`REQUIRED_TYPES`/`needsRebuild`, `finally` before `foreign_keys=ON`, a
+`DROP TABLE IF EXISTS devices_new` pre-clean, and — a Node-RED-specific
+deadlock hazard — no `_db.*` calls (only `t.*`) inside the transaction executor
+(a facade-level `_db.*` call from inside an open transaction deadlocks on-device,
+a separate `operationQueue` slot waiting on the in-flight transaction).
+
+Three of the four are wired into `.github/workflows/migrations.yml`
+(`verify-runtime-schema-parity.js`, `verify-devices-rebuild-fence.js`, and the
+rehearse test); `verify-profile-parity.js` is CI-gated via the
+`verify-sync-flow.yml` workflow (chained from `verify-sync-flow.js`). A
+production-copy rehearsal is additionally expected before rollout to a live
+gateway (see `osi-live-ops-runbook` for the actual on-Pi procedure).
+
+**Additional gate:** `scripts/verify-sync-flow.js` is green on `main` (verified
+in this worktree 2026-07-06, exit 0) and CI-gated by its own workflow,
+`.github/workflows/verify-sync-flow.yml` — separate from `migrations.yml`. It
+chains `verify-db-schema-consistency.js` and `verify-profile-parity.js`: a full
+run prints `Sync flow verification passed` at the end of the sync section and
+terminates with `All parity checks passed.`. (An older plan document described it as RED at baseline; that was the
+stale upgrade-test baseline fixed via the issue #84 pin — treat any RED result
+today as a real regression, not a known baseline.)
+
+## Parity surfaces
+
+`database/seed-blank.sql` is the schema source of truth for a **fresh** database.
+It must stay in parity with every bundled `farming.db` copy. As of 2026-07-06,
+`find . -name farming.db -not -path '*/node_modules/*'` returns exactly 7 files:
+
+```
+conf/base_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db
+conf/base_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db
+conf/full_raspberrypi_bcm27xx_bcm2708/files/usr/share/db/farming.db
+conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db
+conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db
+database/farming.db
+web/react-gui/farming.db
+```
+
+(Note: this is broader than just the two `full_*` bcm2712/bcm2709 shipping
+profiles — it also includes the `base_*` profiles and the legacy `bcm2708`
+directory, plus the two dev-convenience copies under `database/` and
+`web/react-gui/`. All 7 are covered by `verify-db-schema-consistency.js`.)
+
+Four verifiers each check a different slice, all confirmed green in this
+worktree on 2026-07-06:
+
+| Verifier | What it checks | Run output |
+|---|---|---|
+| `scripts/verify-migrations.js` | Every ordered migration file is well-formed; versions contiguous from `0001` | `verify-migrations: OK (2 migrations)` |
+| `scripts/verify-seed-replay.js` | Replays `bootstrapFresh` over the ordered migrations into a scratch DB and diffs its computed fingerprints (tables/indexes/triggers, excluding the ledger's own bookkeeping tables) against fingerprints from `seed-blank.sql` applied fresh — keeps the migration set and seed honestly equivalent | `verify-seed-replay: OK` |
+| `scripts/verify-runtime-schema-parity.js` | Compares `sync-init-fn`'s `devices_new` CHECK type-set and each flow file's whole trigger set (both profiles) against the canonical set derived from `seed-blank.sql` — fails if the boot node ever *downgrades* the seed | `verify-runtime-schema-parity: OK (2 flows: devices CHECK + trigger parity)` |
+| `scripts/verify-db-schema-consistency.js` | Hand-maintained column/index/trigger-fragment contract checked against all 7 bundled DB copies (defaults to the 7-path list above; accepts explicit paths as CLI args), plus an `EXPLAIN QUERY PLAN` check that a history query actually uses `idx_device_data_deveui_recorded_at`. Widest and slowest-changing — must be hand-extended whenever the contract changes (see Walkthrough) | all 7 paths `OK`, then `DB schema consistency verification passed` |
+
+Two related, non-schema-content parity checks this area depends on:
+`scripts/verify-devices-rebuild-fence.js` + `node --test
+scripts/rehearse-devices-rebuild.test.js` (covered under Boot-DDL freeze above),
+and `scripts/verify-profile-parity.js` (byte-for-byte hash comparison of
+canonical payload files, including `files/usr/share/db` and
+`files/usr/share/flows.json`, between the `bcm2712` source-of-truth profile and
+the `bcm2709` mirror — confirmed green here).
+
+All of the above ran clean (exit 0) in this worktree on 2026-07-06 with no
+working-tree changes as a side effect.
+
+## `deploy.sh` idempotent repair
+
+`deploy.sh` never reseeds a provisioned Pi (see NEVER-do list). What it *does* do
+is repair schema drift on an already-provisioned live DB, at deploy time, via a
+family of `ensure_*` functions (`ensure_dendro_schema`,
+`ensure_zone_irrigation_calibration_schema`, `ensure_analysis_views_schema`,
+`ensure_chameleon_schema`, `ensure_gateway_health_schema`), all invoked
+unconditionally near the end of the script. Each:
+
+1. Skips entirely if `$DB_PATH` (`/data/db/farming.db`) doesn't exist yet (a
+   fresh device gets the full schema from the seed instead).
+2. `ensure_gateway_health_schema` fetches
+   `database/migrations/ordered/0002__gateway_health.sql` and executes its raw
+   SQL directly, after asserting the file's header is exactly `-- risk:
+   additive` ("Single source of DDL truth: execute the ordered-migration file
+   itself") and hard-refusing (`process.exit(1)`) otherwise — the one place an
+   `ensure_*` function reuses a migration file verbatim rather than hand-writing
+   SQL inline.
+3. Other `ensure_*` functions (e.g. `ensure_dendro_schema`) hand-write
+   idempotent `ALTER TABLE ... ADD COLUMN` statements in an inline
+   Node/`sqlite3` heredoc, explicitly catching and ignoring a `duplicate column
+   name` error so re-running deploy on an already-repaired Pi is a no-op, then
+   backfill newly-added columns from existing data, then assert (throw if not)
+   the expected columns exist afterward.
+4. Sets `busy_timeout=5000` before any statement, matching the Node-RED runtime
+   helper's 5 s busy timeout.
+
+**Boundary:** `deploy.sh` repairs an existing live DB; it does not create one over
+an existing file, and none of the `ensure_*` functions are destructive-class
+(table rebuild/drop) — that class is only handled today by the sanctioned
+boot-node exception. The actual live-deploy procedure (how to run `deploy.sh`
+against a specific Pi, safely) is out of scope here — see `osi-live-ops-runbook`.
+
+## Restamp rules
+
+`scripts/restamp-fingerprints.js` is the **only** sanctioned way to re-baseline
+`schema_object_fingerprints`. It takes a DB path, refuses if the path doesn't
+exist (specifically to avoid the `sqlite3` CLI silently creating an empty file at
+a typoed path and "successfully" restamping that instead), and calls
+`syncFingerprints` directly — recomputing live fingerprints and replacing the
+whole `schema_object_fingerprints` table with them.
+
+**When it applies:** only after a crash between a migration's schema commit and
+its fingerprint stamp, where the live schema has been independently confirmed
+correct (e.g. via `PRAGMA integrity_check` and a manual review of what the
+migration was supposed to produce). It is a recovery verb for a known-safe state,
+not a way to silence a real drift preflight failure. The actual on-Pi recovery
+procedure/runbook for when and how to run this against a live gateway is owned by
+`osi-live-ops-runbook`; this skill only states the rule of when the tool is
+appropriate to reach for at all.
+
+## Common mistakes
+
+- **Assuming the migration runner is "live."** It is CI/tooling-time only today
+  (Key Fact above); nothing on-device calls `applyPending`. A `destructive`/`data`
+  migration will not run automatically on the next Pi boot.
+- **Treating `sync-init-fn`'s 93 `ADD COLUMN`s as a template to copy.** Frozen
+  legacy debt (81 redundant with the seed, per AGENTS.md), not a pattern to
+  extend — new additive schema goes in an ordered migration, not ADD COLUMN #94.
+- **Confusing "missing-only" with the actual guard semantics.** The `devices`
+  rebuild guard is **set-equality**: an extra/drifted type must also trigger a
+  rebuild-and-converge, not just a missing type. A weaker missing-only guard was
+  a real P2 review finding caught before merge.
+- **Blaming the boot DDL node for a "duplicate column" verifier failure without
+  checking the test baseline first.** Issue #84 shows this exact misattribution
+  happened and had to be corrected in writing.
+- **Updating `seed-blank.sql` (or one bundled DB) without the rest.** The
+  verifiers above will catch it, but catching it in CI after the fact is more
+  expensive than doing the "apply to all 7 copies + mirror" step in one commit.
+- **Hand-writing SQL against `schema_object_fingerprints` or
+  `schema_migrations`.** Both are runner-owned bookkeeping tables
+  (`lib/osi-migrate/ledger.js`, `ensureLedger`), not part of `seed-blank.sql` or
+  the bundled DBs. Exactly one sanctioned tool exists for fingerprints
+  (`restamp-fingerprints.js`); none for hand-editing `schema_migrations` rows.
+- **Forgetting the FK fence direction/order.** `PRAGMA foreign_keys` is a no-op
+  inside an already-open transaction — set it `OFF` *before* `BEGIN`, restore it
+  `ON` in a `finally` so it fires even when the rebuild throws.
+
+## Walkthrough: adding a column end-to-end
+
+This is the additive case (new column/table/index/trigger). For a CHECK
+change or table rebuild, everything below still applies but you are in
+`destructive`-class territory (writers-stopped gate, FK fence) — do not attempt
+that live without also reading `osi-live-ops-runbook`.
+
+1. **Write the migration.** Create
+   `database/migrations/ordered/0003__your_slug.sql` (next contiguous 4-digit
+   version) with a `-- risk: additive` header as the first line, then your
+   `CREATE TABLE`/`ALTER TABLE ... ADD COLUMN`/`CREATE INDEX`/`CREATE TRIGGER`
+   statements. Prefer `IF NOT EXISTS` on new objects so the file is safely
+   re-runnable, matching the `0002` precedent.
+2. **Update `database/seed-blank.sql`.** Append the equivalent DDL so a fresh
+   database created from the seed ends up schema-identical to one built by
+   replaying all ordered migrations. `verify-seed-replay.js` is the automatic
+   check for this; don't skip manual review just because the verifier exists.
+3. **Regenerate all 7 bundled `farming.db` copies.** Apply your new migration
+   file to each of the six non-mirrored copies with the `sqlite3` CLI, then copy
+   the `bcm2712` full profile's DB over the `bcm2709` mirror so profile parity
+   stays byte-for-byte (this is the exact pattern used for `0002`):
+   ```bash
+   cd "$(git rev-parse --show-toplevel)" && for db in \
+     conf/base_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db \
+     conf/base_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db \
+     conf/full_raspberrypi_bcm27xx_bcm2708/files/usr/share/db/farming.db \
+     conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db \
+     database/farming.db \
+     web/react-gui/farming.db
+   do sqlite3 -bail "$db" < database/migrations/ordered/0003__your_slug.sql && echo "OK $db"; done \
+     && cp conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db \
+           conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db \
+     && echo "OK mirror copy"
+   ```
+4. **Extend `scripts/verify-db-schema-consistency.js`'s hand-maintained
+   `schemaContract`** (and `requiredIndexes`/`requiredTriggerSqlFragments` if
+   applicable) with the new column/table/index so this widest verifier actually
+   enforces the new shape going forward — it does not infer the contract from
+   the migration file.
+5. **Add TypeScript types** in `web/react-gui/src/types/farming.ts` if the new
+   column/table is GUI-visible.
+6. **If a live Pi needs the column before its next full schema catch-up**, add or
+   extend a `deploy.sh` `ensure_*` function following the `ensure_gateway_health_schema`
+   / `ensure_dendro_schema` precedent (idempotent `ADD COLUMN`, catch `duplicate
+   column name`, assert presence afterward). This is optional and only needed for
+   changes that must reach already-provisioned Pis outside a full reseed.
+7. **Run the verifier set** and confirm each prints its OK line:
+   ```bash
+   node scripts/verify-migrations.js
+   node scripts/verify-seed-replay.js
+   node scripts/verify-runtime-schema-parity.js
+   node scripts/verify-db-schema-consistency.js
+   node scripts/verify-profile-parity.js
+   ```
+   If your change also touches `sync-init-fn` or the `devices` CHECK, add:
+   ```bash
+   node scripts/verify-devices-rebuild-fence.js
+   node --test scripts/rehearse-devices-rebuild.test.js
+   ```
+8. **Both-profile parity.** Confirm `bcm2712` and `bcm2709` payload files
+   (flows.json, bundled DB) are still byte-identical —
+   `verify-profile-parity.js` in step 7 already covers this; do not hand-wave it.
+9. **PR evidence per `docs/engineering-playbook.md` §8** ("Definition of done"):
+   re-verify the original issue/claim against current code, keep the written
+   plan and its review in the repo, include every gate's real output as re-run
+   by a non-author, confirm both profiles/seeds are in parity, and write the PR
+   body with root cause, tradeoffs, and evidence — not just a green checkmark.
+
+## Provenance and maintenance
+
+Re-run these to catch drift in the facts above:
+
+```bash
+node scripts/verify-migrations.js                      # migration file well-formedness + contiguous versions
+node scripts/verify-seed-replay.js                      # migrations replay == seed-blank.sql
+node scripts/verify-runtime-schema-parity.js            # boot node devices CHECK + triggers == seed
+node scripts/verify-db-schema-consistency.js            # all 7 bundled DBs match hand-maintained contract
+node scripts/verify-profile-parity.js                   # bcm2712 == bcm2709 byte-for-byte
+node scripts/verify-devices-rebuild-fence.js            # boot-node rebuild is still fail-closed
+node --test scripts/rehearse-devices-rebuild.test.js    # boot-node rebuild behaves correctly against 4 seeded cases
+node --test lib/osi-migrate/__tests__/*.test.js         # runner unit tests (risk classes, atomicity, drift preflight, partial-batch retry)
+find . -name farming.db -not -path '*/node_modules/*'  | sort   # should list exactly 7 paths
+ls database/migrations/ordered/                         # current migration set (0001, 0002 as of 2026-07-06)
+ls .github/workflows/ && cat .github/workflows/migrations.yml .github/workflows/verify-sync-flow.yml   # what CI actually gates (both workflows)
+grep -rn "osi-migrate\|applyPending\|bootstrapFresh\|verifyHead" --include=*.js --include=*.sh . | grep -v node_modules   # re-confirm the runner has no on-device caller
+```
+
+All commands above were run against this worktree on 2026-07-06 and returned the
+outputs quoted in this document, with a clean `git status --short` afterward
+(read-only verification, no tracked-file side effects).

--- a/.github/workflows/verify-sync-flow.yml
+++ b/.github/workflows/verify-sync-flow.yml
@@ -27,5 +27,7 @@ jobs:
       # history schema/worker tests, history API contract, helper tests, and
       # profile parity). Must end with "All parity checks passed."
       - run: node scripts/verify-sync-flow.js
+      - name: Skill-library symlink parity (.agents/skills must alias .claude/skills)
+        run: test "$(readlink .agents/skills)" = "../.claude/skills"
       - name: Guard against silent upgrade-leg skip
         run: node scripts/test-sync-history-schema.js 2>&1 | tee /tmp/schema.out && grep -q "base seed + history migration" /tmp/schema.out

--- a/.github/workflows/verify-sync-flow.yml
+++ b/.github/workflows/verify-sync-flow.yml
@@ -28,6 +28,10 @@ jobs:
       # profile parity). Must end with "All parity checks passed."
       - run: node scripts/verify-sync-flow.js
       - name: Skill-library symlink parity (.agents/skills must alias .claude/skills)
-        run: test "$(readlink .agents/skills)" = "../.claude/skills"
+        run: |
+          test "$(readlink .agents/skills)" = "../.claude/skills"
+          # gitignore must stay narrow: arbitrary .agents/ files ignored, symlink tracked
+          git check-ignore -q .agents/notes.txt
+          git ls-files --error-unmatch .agents/skills > /dev/null
       - name: Guard against silent upgrade-leg skip
         run: node scripts/test-sync-history-schema.js 2>&1 | tee /tmp/schema.out && grep -q "base seed + history migration" /tmp/schema.out

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,7 @@
 !/.claude/skills/
 # .agents/skills is a committed symlink to .claude/skills for .agents-convention
 # tools (Codex, Gemini CLI, ...); OpenCode reads .claude/skills directly.
+# Only the skills symlink is tracked; everything else under .agents/ stays ignored.
 !/.agents/
+/.agents/*
+!/.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 
 # Track CI workflows / .github content (the /.* rule would otherwise ignore them)
 !/.github/
+
+# Track the agent skill library only; keep the rest of .claude/ (settings, local state) ignored
+!/.claude/
+/.claude/*
+!/.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 !/.claude/
 /.claude/*
 !/.claude/skills/
+# .agents/skills is a committed symlink to .claude/skills for .agents-convention
+# tools (Codex, Gemini CLI, ...); OpenCode reads .claude/skills directly.
+!/.agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,18 @@ Read the repo-owned `architect.yaml` and `RULES.yaml` overlays before edits. See
 
 ---
 
+## Agent skills
+
+Field manuals for agents live in `.claude/skills/` (Agent Skills spec: SKILL.md + `name`/`description` frontmatter). Claude Code and OpenCode auto-discover that path; `.agents/skills` is a committed symlink to it for `.agents`-convention tools (Codex, Gemini CLI, …) — never materialize a copy there. Index:
+
+- `osi-debugging-playbook` — symptom→triage table + verifier toolbox; load when investigating any edge failure or data gap.
+- `osi-live-ops-runbook` — deploy/repair/post-check procedures for live Pis; load before touching a real gateway.
+- `osi-flows-json-editing` — script-only flows.json editing rules; load before ANY Node-RED flow change.
+- `osi-schema-change-control` — migrations, risk classes, frozen boot DDL, parity gates; load before ANY schema change.
+- `osi-agronomy-sensors-reference` — domain pack (SWT/pF, Chameleon, dendrometry, rain, LoRaWAN as used here); load when touching sensor semantics or displays.
+- `osi-config-and-flags` — UCI/env/flag catalog incl. DEVICE_EUI resolution; load when configuring or provisioning.
+- `osi-hardest-problem-campaign` — deferred stub; do not author without maintainer input.
+
 ## Session closeout
 
 When the user says `finish the session`:


### PR DESCRIPTION
## What

Adds `.claude/skills/` — six ground-truth-verified onboarding skills for agents and engineers working on OSI OS, one deferred stub, and a narrowly-scoped `.gitignore` exception (`!/.claude/` + `/.claude/*` + `!/.claude/skills/`) so the skill tree is tracked while the rest of `.claude/` (settings, local state) stays ignored.

## Inventory

| Skill | One-line description |
|---|---|
| `osi-debugging-playbook` | Symptom → triage table (i2c_missing, duplicate-column, EBUSY fan, export.csv 401-vs-404, history gaps, sync stalls, all-routes-404, hanging endpoints) with discriminating experiments, plus a verifier/diagnostic toolbox with interpretation guides |
| `osi-live-ops-runbook` | Reverse-tunnel deploy flow with post-deploy checks, backup-before-repair, restamp-fingerprints recovery, BusyBox/ash traps, the never-reseed-farming.db rule with rationale, production-cloud access gate |
| `osi-flows-json-editing` | Script-only flows.json editing: byte-identical roundtrip guard, `libs`/`global.get` function-node conventions, `.close(` lint, wiring guard tests, bcm2712→bcm2709 byte mirror |
| `osi-schema-change-control` | Ordered migrations (NNNN__slug, additive/destructive/data risk classes), boot-DDL freeze with #79/#84/#86 incident history, seed + 7-bundled-DB parity, verifier matrix, restamp rules, NEVER-do list |
| `osi-agronomy-sensors-reference` | Domain semantics as implemented: SWT kPa conventions + pF formula (verified against `web/react-gui/src/utils/swt.ts`), Chameleon calibration model, dendrometry edge/cloud ownership, rain aggregation rules, device catalog, STREGA OPEN_FOR_DURATION semantics |
| `osi-config-and-flags` | Config-surface map: UCI `osi-server.cloud.*`, DEVICE_EUI resolution chain + `.chirpstack.env` staleness trap, `CHIRPSTACK_PROFILE_*`, `OSI_HEALTH_*` retention, settings.js, deploy.sh knobs, feature flags, new-flag checklist |
| `osi-hardest-problem-campaign` | Deliberate stub — deferred pending the maintainer's answer to "what is the hardest live problem" (candidates #92/#87/#56); not to be authored without that answer + change-control review |

## Process and verification

- Authored against `origin/main` @ `22cffe6d` in an isolated worktree; six independent authors, each required to verify every command/path/flag against the repo before stating it.
- Three independent review passes over the complete set: **factual** (re-ran verifiers, re-read runner/deploy/init/flows sources; ~105 tool calls), **doctrine** (AGENTS.md / engineering-playbook / ADR conflicts, change-control gating, privacy audit), **usability** (trigger quality, one-home-per-fact, self-containedness). All BLOCKING and IMPORTANT findings were applied and spot-checked; highlights:
  - Corrected a stale "verify-sync-flow.js is RED at baseline / not a real gate" claim (it is green and CI-gated via `.github/workflows/verify-sync-flow.yml`; the RED note traced to a superseded 2026-07-03 plan doc).
  - Corrected CI-wiring detail (three of the four boot-node gates run in `migrations.yml`; profile parity is gated via `verify-sync-flow.yml`).
  - Corrected an inverted `CHIRPSTACK_PROFILE_LORAIN` claim (the UCI mapping exists; the real asymmetry is `node-red.init` not exporting it) and the gateway-identity MAC-demotion semantics (runtime source is unconditionally authoritative).
  - Normalized verifier output-line quotes to observed reality (`Sync flow verification passed` ends the sync section; a full run ends `All parity checks passed.`).
- Verifiers actually run green in the branch worktree on 2026-07-06: `verify-sync-flow.js` (exit 0), `verify-profile-parity.js`, `verify-migrations.js` (`OK (2 migrations)`), `check-mqtt-topics.sh`, plus a byte-identical no-op roundtrip check of both flows.json copies.
- Secret scan of the skill tree: zero hits for Tailscale IPs (100.x), `*.ts.net`, SSH key paths, tokens, per-gateway EUIs, cloud usernames, or gateway nicknames outside the one committed doc path (`docs/operations/kaba100-chameleon1-i2c-outage-analysis-2026-06-28.md`). Only placeholders (`<pi-ip>`, `<eui>`, `~/.ssh/<key>`) and repo-public hostnames appear.
- `git ls-files .claude/` confirms all seven SKILL.md files are tracked (the `/.*` gitignore rule previously swallowed them silently — hence the scoped exception).

## Known remaining uncertainties (labeled as such in the skills)

- Device-only claims that cannot be verified without a live Pi are explicitly marked (BusyBox `localhost`→IPv6 wget behavior, `tr` character-class unreliability, SSH banner noise, ChirpStack v4 no-plain-REST behavior, curl exit-code symptoms).
- `verify-seed-replay.js`, `verify-runtime-schema-parity.js`, `verify-devices-rebuild-fence.js` were not executed in this session (CI covers them); their toolbox rows say so.
- KIWI/CLOVER "decoded vendor-side" claim is not provable from this repo alone; labeled accordingly.
- Usability MINORs deliberately not applied (structural preferences): very wide table rows in two skills, quick-reference placement in live-ops, hoisting the flows pre-commit checklist. Can be follow-ups if wanted.

## Deferred campaign note

`osi-hardest-problem-campaign` is intentionally an empty slot: it keeps the seventh skill visible without inventing a campaign. Do not author it until the maintainer answers "what is the hardest live problem" (candidates #92/#87/#56) and the result passes change-control review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new OSI skill runbooks and references for live operations, debugging triage, schema change control, safe flows.json editing, config/feature-flag surfaces, and agronomy/sensor value semantics.
  * Added a placeholder entry for a future “hardest problem” campaign.
  * Updated the agent skills index and guidance for where these field manuals live.
* **Chores**
  * Adjusted version-control rules to ignore most local Claude artifacts while keeping skill content tracked (including the committed skill symlink).
* **Tests**
  * Updated the CI sync-flow verification to confirm the skills symlink and gitignore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->