### PR TITLE
feat(agroscope): forward edge dendro uplinks to Agroscope IoT (opt-in)

### DIFF
--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
@@ -2648,7 +2648,8 @@
     "y": 160,
     "wires": [
       [
-        "83b9d39aac66b765"
+        "83b9d39aac66b765",
+        "agroscope-forward-fn"
       ]
     ]
   },
@@ -10640,5 +10641,70 @@
         "record-error-link-out-lorain"
       ]
     ]
+  },
+  {
+    "id": "agroscope-mqtt-broker",
+    "type": "mqtt-broker",
+    "name": "Agroscope IoT Broker",
+    "broker": "127.0.0.1",
+    "port": "1883",
+    "clientid": "",
+    "autoConnect": true,
+    "usetls": false,
+    "protocolVersion": "4",
+    "keepalive": "60",
+    "cleansession": true,
+    "birthTopic": "",
+    "birthQos": "0",
+    "birthPayload": "",
+    "birthMsg": {},
+    "closeTopic": "",
+    "closeQos": "0",
+    "closePayload": "",
+    "closeMsg": {},
+    "willTopic": "",
+    "willQos": "0",
+    "willPayload": "",
+    "willMsg": {},
+    "userProps": "",
+    "sessionExpiry": ""
+  },
+  {
+    "id": "agroscope-forward-fn",
+    "type": "function",
+    "z": "49e87447205bb849",
+    "name": "Forward Agroscope Dendro",
+    "func": "const enabled = String(env.get('AGROSCOPE_FORWARD_ENABLED') || '').trim().toLowerCase();\nif (!['1', 'true', 'yes', 'on'].includes(enabled)) {\n  node.status({ fill: 'grey', shape: 'ring', text: 'Agroscope forwarding disabled' });\n  return null;\n}\n\nlet data = msg.payload;\nif (typeof data === 'string') {\n  try {\n    data = JSON.parse(data);\n  } catch (error) {\n    node.error('Agroscope forward invalid JSON: ' + error.message, msg);\n    return null;\n  }\n}\nif (!data || !data.deviceInfo) return null;\n\nconst info = data.deviceInfo || {};\nconst profileName = String(info.deviceProfileName || data.deviceProfileName || '').toUpperCase();\nif (profileName.indexOf('DENDRO') < 0 && profileName.indexOf('LSN50') < 0 && profileName.indexOf('DRAGINO') < 0) {\n  return null;\n}\n\nlet transform;\ntry {\n  transform = require('/srv/node-red/codecs/agroscope_uplink_transform');\n} catch (error) {\n  node.error('Agroscope transform unavailable: ' + error.message, msg);\n  return null;\n}\n\nconst result = transform.toAgroscopeUplink(data);\nif (!result) return null;\n\nmsg.topic = result.topic;\nmsg.payload = result.payload;\nmsg.qos = 1;\nnode.status({ fill: 'blue', shape: 'dot', text: result.topic });\nreturn msg;",
+    "outputs": 1,
+    "timeout": "",
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 390,
+    "y": 320,
+    "wires": [
+      [
+        "agroscope-mqtt-out"
+      ]
+    ]
+  },
+  {
+    "id": "agroscope-mqtt-out",
+    "type": "mqtt out",
+    "z": "49e87447205bb849",
+    "name": "Dendro to Agroscope IoT",
+    "topic": "",
+    "qos": "1",
+    "retain": "false",
+    "respTopic": "",
+    "contentType": "application/json",
+    "userProps": "",
+    "correl": "",
+    "expiry": "",
+    "broker": "agroscope-mqtt-broker",
+    "x": 660,
+    "y": 320,
+    "wires": []
   }
 ]

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/codecs/agroscope_uplink_transform.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/codecs/agroscope_uplink_transform.js
@@ -1,0 +1,89 @@
+'use strict';
+
+function numberOrNull(value) {
+  var numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function firstFinite(source, keys) {
+  for (var i = 0; i < keys.length; i += 1) {
+    if (Object.prototype.hasOwnProperty.call(source, keys[i])) {
+      var numeric = numberOrNull(source[keys[i]]);
+      if (numeric !== null) return numeric;
+    }
+  }
+  return null;
+}
+
+function normalizeDevEui(value) {
+  var normalized = String(value || '').trim().replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+  return normalized || null;
+}
+
+function payloadHex(base64Payload) {
+  if (!base64Payload) return null;
+  try {
+    return Buffer.from(String(base64Payload), 'base64').toString('hex');
+  } catch (_) {
+    return null;
+  }
+}
+
+function hasChameleonPayload(decoded) {
+  return Object.prototype.hasOwnProperty.call(decoded, 'Chameleon_Payload_Version')
+    || Object.prototype.hasOwnProperty.call(decoded, 'Chameleon_Array_ID');
+}
+
+function isDendrometerProfile(deviceInfo, decoded) {
+  var profileName = String(
+    (deviceInfo && deviceInfo.deviceProfileName)
+      || ''
+  ).toUpperCase();
+
+  if (!profileName) return false;
+  if (profileName.indexOf('CHAMELEON') >= 0 || hasChameleonPayload(decoded)) return false;
+  if (profileName.indexOf('DENDRO') >= 0) return true;
+  return profileName.indexOf('LSN50') >= 0 || profileName.indexOf('DRAGINO') >= 0;
+}
+
+function toAgroscopeUplink(chirpstackMsg) {
+  var data = chirpstackMsg || {};
+  var deviceInfo = data.deviceInfo || {};
+  var decoded = data.object && typeof data.object === 'object' ? data.object : {};
+
+  if (!isDendrometerProfile(deviceInfo, decoded)) return null;
+
+  var devEui = normalizeDevEui(deviceInfo.devEui || data.devEui);
+  var hex = payloadHex(data.data);
+  var time = String(data.time || '').trim();
+  var adcVoltage = firstFinite(decoded, ['VDC_intput_V', 'VDC_input_V', 'ADC_CH0V', 'adc_ch0v']);
+  if (!devEui || !hex || !time || adcVoltage === null) return null;
+
+  var payload = {
+    VDC_intput_V: adcVoltage,
+  };
+  var battery = firstFinite(decoded, ['Bat_V', 'BatV', 'bat_v', 'Battery', 'battery']);
+  if (battery !== null) {
+    payload = {
+      Bat_V: battery,
+      VDC_intput_V: adcVoltage,
+    };
+  }
+
+  return {
+    topic: 'OSI_dendro/' + devEui + '/uplink',
+    payload: {
+      DevEUI_uplink: {
+        Time: time,
+        DevEUI: devEui,
+        FPort: String(data.fPort != null ? data.fPort : ''),
+        payload_hex: hex,
+        payload: payload,
+      },
+    },
+  };
+}
+
+module.exports = {
+  toAgroscopeUplink: toAgroscopeUplink,
+};

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
@@ -2648,7 +2648,8 @@
     "y": 160,
     "wires": [
       [
-        "83b9d39aac66b765"
+        "83b9d39aac66b765",
+        "agroscope-forward-fn"
       ]
     ]
   },
@@ -10640,5 +10641,70 @@
         "record-error-link-out-lorain"
       ]
     ]
+  },
+  {
+    "id": "agroscope-mqtt-broker",
+    "type": "mqtt-broker",
+    "name": "Agroscope IoT Broker",
+    "broker": "127.0.0.1",
+    "port": "1883",
+    "clientid": "",
+    "autoConnect": true,
+    "usetls": false,
+    "protocolVersion": "4",
+    "keepalive": "60",
+    "cleansession": true,
+    "birthTopic": "",
+    "birthQos": "0",
+    "birthPayload": "",
+    "birthMsg": {},
+    "closeTopic": "",
+    "closeQos": "0",
+    "closePayload": "",
+    "closeMsg": {},
+    "willTopic": "",
+    "willQos": "0",
+    "willPayload": "",
+    "willMsg": {},
+    "userProps": "",
+    "sessionExpiry": ""
+  },
+  {
+    "id": "agroscope-forward-fn",
+    "type": "function",
+    "z": "49e87447205bb849",
+    "name": "Forward Agroscope Dendro",
+    "func": "const enabled = String(env.get('AGROSCOPE_FORWARD_ENABLED') || '').trim().toLowerCase();\nif (!['1', 'true', 'yes', 'on'].includes(enabled)) {\n  node.status({ fill: 'grey', shape: 'ring', text: 'Agroscope forwarding disabled' });\n  return null;\n}\n\nlet data = msg.payload;\nif (typeof data === 'string') {\n  try {\n    data = JSON.parse(data);\n  } catch (error) {\n    node.error('Agroscope forward invalid JSON: ' + error.message, msg);\n    return null;\n  }\n}\nif (!data || !data.deviceInfo) return null;\n\nconst info = data.deviceInfo || {};\nconst profileName = String(info.deviceProfileName || data.deviceProfileName || '').toUpperCase();\nif (profileName.indexOf('DENDRO') < 0 && profileName.indexOf('LSN50') < 0 && profileName.indexOf('DRAGINO') < 0) {\n  return null;\n}\n\nlet transform;\ntry {\n  transform = require('/srv/node-red/codecs/agroscope_uplink_transform');\n} catch (error) {\n  node.error('Agroscope transform unavailable: ' + error.message, msg);\n  return null;\n}\n\nconst result = transform.toAgroscopeUplink(data);\nif (!result) return null;\n\nmsg.topic = result.topic;\nmsg.payload = result.payload;\nmsg.qos = 1;\nnode.status({ fill: 'blue', shape: 'dot', text: result.topic });\nreturn msg;",
+    "outputs": 1,
+    "timeout": "",
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 390,
+    "y": 320,
+    "wires": [
+      [
+        "agroscope-mqtt-out"
+      ]
+    ]
+  },
+  {
+    "id": "agroscope-mqtt-out",
+    "type": "mqtt out",
+    "z": "49e87447205bb849",
+    "name": "Dendro to Agroscope IoT",
+    "topic": "",
+    "qos": "1",
+    "retain": "false",
+    "respTopic": "",
+    "contentType": "application/json",
+    "userProps": "",
+    "correl": "",
+    "expiry": "",
+    "broker": "agroscope-mqtt-broker",
+    "x": 660,
+    "y": 320,
+    "wires": []
   }
 ]

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/agroscope_uplink_transform.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/agroscope_uplink_transform.js
@@ -1,0 +1,89 @@
+'use strict';
+
+function numberOrNull(value) {
+  var numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function firstFinite(source, keys) {
+  for (var i = 0; i < keys.length; i += 1) {
+    if (Object.prototype.hasOwnProperty.call(source, keys[i])) {
+      var numeric = numberOrNull(source[keys[i]]);
+      if (numeric !== null) return numeric;
+    }
+  }
+  return null;
+}
+
+function normalizeDevEui(value) {
+  var normalized = String(value || '').trim().replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+  return normalized || null;
+}
+
+function payloadHex(base64Payload) {
+  if (!base64Payload) return null;
+  try {
+    return Buffer.from(String(base64Payload), 'base64').toString('hex');
+  } catch (_) {
+    return null;
+  }
+}
+
+function hasChameleonPayload(decoded) {
+  return Object.prototype.hasOwnProperty.call(decoded, 'Chameleon_Payload_Version')
+    || Object.prototype.hasOwnProperty.call(decoded, 'Chameleon_Array_ID');
+}
+
+function isDendrometerProfile(deviceInfo, decoded) {
+  var profileName = String(
+    (deviceInfo && deviceInfo.deviceProfileName)
+      || ''
+  ).toUpperCase();
+
+  if (!profileName) return false;
+  if (profileName.indexOf('CHAMELEON') >= 0 || hasChameleonPayload(decoded)) return false;
+  if (profileName.indexOf('DENDRO') >= 0) return true;
+  return profileName.indexOf('LSN50') >= 0 || profileName.indexOf('DRAGINO') >= 0;
+}
+
+function toAgroscopeUplink(chirpstackMsg) {
+  var data = chirpstackMsg || {};
+  var deviceInfo = data.deviceInfo || {};
+  var decoded = data.object && typeof data.object === 'object' ? data.object : {};
+
+  if (!isDendrometerProfile(deviceInfo, decoded)) return null;
+
+  var devEui = normalizeDevEui(deviceInfo.devEui || data.devEui);
+  var hex = payloadHex(data.data);
+  var time = String(data.time || '').trim();
+  var adcVoltage = firstFinite(decoded, ['VDC_intput_V', 'VDC_input_V', 'ADC_CH0V', 'adc_ch0v']);
+  if (!devEui || !hex || !time || adcVoltage === null) return null;
+
+  var payload = {
+    VDC_intput_V: adcVoltage,
+  };
+  var battery = firstFinite(decoded, ['Bat_V', 'BatV', 'bat_v', 'Battery', 'battery']);
+  if (battery !== null) {
+    payload = {
+      Bat_V: battery,
+      VDC_intput_V: adcVoltage,
+    };
+  }
+
+  return {
+    topic: 'OSI_dendro/' + devEui + '/uplink',
+    payload: {
+      DevEUI_uplink: {
+        Time: time,
+        DevEUI: devEui,
+        FPort: String(data.fPort != null ? data.fPort : ''),
+        payload_hex: hex,
+        payload: payload,
+      },
+    },
+  };
+}
+
+module.exports = {
+  toAgroscopeUplink: toAgroscopeUplink,
+};

--- a/deploy.sh
+++ b/deploy.sh
@@ -626,6 +626,10 @@ fetch_required "LoRain codec" \
     "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/aquascope_lorain_decoder.js" \
     "/srv/node-red/codecs/aquascope_lorain_decoder.js"
 
+fetch_required "Agroscope uplink transform" \
+    "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/agroscope_uplink_transform.js" \
+    "/srv/node-red/codecs/agroscope_uplink_transform.js"
+
 echo "--- Node-RED runtime dependencies ---"
 npm_log="$TMP_DIR/npm-install.log"
 if cd /srv/node-red && npm install --omit=dev --no-fund --no-audit >"$npm_log" 2>&1; then

--- a/docs/operations/agroscope-iot-forwarding.md
+++ b/docs/operations/agroscope-iot-forwarding.md
@@ -1,0 +1,165 @@
+# Agroscope IoT Dendrometer Forwarding
+
+## Status
+
+Slice B forwards OSI dendrometer uplinks from the edge to the Agroscope/FiBL
+MQTT broker. It is an opt-in, publish-only egress path for raw dendrometer
+data. It does not subscribe to Agroscope topics, does not actuate valves, and
+does not pull Agroscope processed results back into OSI.
+
+Tasks deferred outside this edge-firmware slice:
+
+- End-to-end confirmation with live Agroscope credentials.
+- Pulling Agroscope processed results back into OSI Server.
+
+## Contract
+
+| Field | Value |
+|---|---|
+| Broker host | `51.107.5.147` |
+| Broker port | `1883` |
+| Transport | Plaintext MQTT |
+| Direction | OSI edge to Agroscope only |
+| Source topic | Local ChirpStack MQTT `application/+/device/+/event/up` |
+| Publish topic | `OSI_dendro/<DevEUI>/uplink` |
+| Payload shape | Swisscom/ThingPark-style `DevEUI_uplink` JSON |
+| Delivery | Live-only best-effort; no backfill or durable retry queue |
+| QoS | `1` |
+| Default state | Disabled until explicitly enabled per gateway |
+
+Published payload:
+
+```json
+{
+  "DevEUI_uplink": {
+    "Time": "2026-07-07T09:48:32.101+02:00",
+    "DevEUI": "A840413A10601D75",
+    "FPort": "2",
+    "payload_hex": "0d3e...",
+    "payload": {
+      "Bat_V": 3.39,
+      "VDC_intput_V": 0
+    }
+  }
+}
+```
+
+`VDC_intput_V` intentionally uses Agroscope's existing misspelled dendrometer
+column name. OSI carries the LSN50 ADC voltage there; Agroscope's
+`dendro_processing` converts voltage to micrometers.
+
+## Dendrometer Inventory
+
+The Node-RED branch computes the publish topic directly from the uplink DevEUI.
+Keep the enabled dendrometer inventory here when a gateway is enrolled.
+
+| Gateway | OSI device DevEUI | Agroscope topic | Sensor type | Status |
+|---|---|---|---|---|
+| TBD | TBD | `OSI_dendro/<DevEUI>/uplink` | Dendrometer LSN50 ADC voltage | Pending enrollment |
+
+Dendrometer identification is heuristic: the transform forwards LSN50/Dragino
+profile uplinks that contain decoded ADC voltage and explicitly drops
+Chameleon-tagged payloads. Future non-dendrometer analog LSN50 uses, such as
+Watermark-on-ADC, need their own exclusion or profile tag before enabling this
+forwarder.
+
+## Configuration
+
+The forwarding branch is disabled by default. Enrollment must provide:
+
+| Setting | Purpose | Example |
+|---|---|---|
+| `AGROSCOPE_FORWARD_ENABLED` | Opt-in gate for publishing | `true` |
+| `AGROSCOPE_MQTT_HOST` | Broker host override for staging or loopback | `51.107.5.147` |
+| `AGROSCOPE_MQTT_PORT` | Broker port override for staging or loopback | `1883` |
+| MQTT username/password | Agroscope-provisioned credentials | Stored in `flows_cred.json` |
+
+Secrets are never committed to the repo or firmware image. Store MQTT
+credentials in `/srv/node-red/flows_cred.json` during enrollment, rotate them
+there, and restart Node-RED after credential changes.
+
+On the Pi, enrollment can provide the same values through UCI:
+
+```bash
+uci set osi-server.cloud.agroscope_forward_enabled='true'
+uci set osi-server.cloud.agroscope_mqtt_host='51.107.5.147'
+uci set osi-server.cloud.agroscope_mqtt_port='1883'
+uci set osi-server.cloud.agroscope_mqtt_username='<provided-by-agroscope>'
+uci set osi-server.cloud.agroscope_mqtt_password='<provided-by-agroscope>'
+uci commit osi-server
+```
+
+`node-red.init` also accepts the equivalent keys in
+`/srv/node-red/.chirpstack.env` as a compatibility fallback. At startup it
+merges the Agroscope credential entry into `/srv/node-red/flows_cred.json` under
+the `agroscope-mqtt-broker` node id and rewrites that broker node's host/port in
+`/srv/node-red/flows.json`. When forwarding is disabled, the broker host remains
+local (`127.0.0.1`); the live Agroscope host is written only after
+`AGROSCOPE_FORWARD_ENABLED` is truthy. The username and password are not
+exported to the Node-RED function runtime.
+
+## Enable
+
+1. Confirm the gateway is authorized to share dendrometer data with Agroscope.
+2. Add the gateway's dendrometer DevEUIs to the inventory table above.
+3. Add Agroscope MQTT credentials to `/srv/node-red/flows_cred.json`.
+4. Set `AGROSCOPE_FORWARD_ENABLED=true`.
+5. Set broker overrides only for staging or loopback tests.
+6. Restart Node-RED.
+7. Watch Node-RED logs for MQTT connection or credential errors.
+
+## Disable
+
+1. Set `AGROSCOPE_FORWARD_ENABLED=false`.
+2. Restart Node-RED.
+3. Confirm no messages arrive on `OSI_dendro/#`.
+
+## Verify With Loopback
+
+Use a local broker before enabling the live broker:
+
+```bash
+mosquitto_sub -h localhost -p 1883 -t 'OSI_dendro/#' -v
+```
+
+Configure the gateway for loopback:
+
+```bash
+AGROSCOPE_FORWARD_ENABLED=true
+AGROSCOPE_MQTT_HOST=localhost
+AGROSCOPE_MQTT_PORT=1883
+```
+
+Or via UCI:
+
+```bash
+uci set osi-server.cloud.agroscope_forward_enabled='true'
+uci set osi-server.cloud.agroscope_mqtt_host='localhost'
+uci set osi-server.cloud.agroscope_mqtt_port='1883'
+uci commit osi-server
+/etc/init.d/node-red restart
+```
+
+Replay a recorded ChirpStack v4 dendrometer uplink into the local
+`application/+/device/+/event/up` topic. The subscriber should receive an
+`OSI_dendro/<DevEUI>/uplink` message containing `DevEUI_uplink`.
+
+## Operational Limits
+
+- This path is live-only best-effort. If Node-RED or the broker is offline, OSI
+  does not backfill missed Agroscope publishes.
+- OSI remains authoritative for edge state and actuation.
+- Agroscope receives observations only.
+- Use the OSI local ChirpStack uplink as the source of truth; do not republish
+  derived cloud data from this slice.
+
+## Observe-Only Guard
+
+Agroscope's instance is observe-only on OSI farms. The edge forwards
+dendrometer observations to Agroscope and never consumes Agroscope actuator
+topics or commands. OSI actuation stays on the existing STREGA-via-ChirpStack
+path, including OSI Server pending commands and local edge scheduling.
+
+The firmware flow has one Agroscope MQTT broker node and one MQTT-out node. It
+has no MQTT-in node attached to `agroscope-mqtt-broker`, no subscription to
+`AGS/<farm>/Actuator/#`, and no inbound bridge from Agroscope.

--- a/feeds/chirpstack-openwrt-feed/apps/node-red/files/node-red.init
+++ b/feeds/chirpstack-openwrt-feed/apps/node-red/files/node-red.init
@@ -100,39 +100,109 @@ start_service() {
     local cs_profile_clover=$(resolve_chirpstack_value osi-server.cloud.chirpstack_profile_clover CHIRPSTACK_PROFILE_CLOVER)
     local cs_profile_rak10701=$(resolve_chirpstack_value osi-server.cloud.chirpstack_profile_rak10701 CHIRPSTACK_PROFILE_RAK10701)
     local cs_profile_s2120=$(resolve_chirpstack_value osi-server.cloud.chirpstack_profile_s2120 CHIRPSTACK_PROFILE_S2120)
+    local agroscope_forward_enabled=$(resolve_chirpstack_value osi-server.cloud.agroscope_forward_enabled AGROSCOPE_FORWARD_ENABLED)
+    local agroscope_mqtt_host=$(resolve_chirpstack_value osi-server.cloud.agroscope_mqtt_host AGROSCOPE_MQTT_HOST)
+    local agroscope_mqtt_port=$(resolve_chirpstack_value osi-server.cloud.agroscope_mqtt_port AGROSCOPE_MQTT_PORT)
+    local agroscope_mqtt_username=$(resolve_chirpstack_value osi-server.cloud.agroscope_mqtt_username AGROSCOPE_MQTT_USERNAME)
+    local agroscope_mqtt_password=$(resolve_chirpstack_value osi-server.cloud.agroscope_mqtt_password AGROSCOPE_MQTT_PASSWORD)
+    [ -n "$agroscope_forward_enabled" ] || agroscope_forward_enabled="0"
+    [ -n "$agroscope_mqtt_host" ] || agroscope_mqtt_host="51.107.5.147"
+    [ -n "$agroscope_mqtt_port" ] || agroscope_mqtt_port="1883"
+    local agroscope_forward_normalized
+    local agroscope_runtime_mqtt_host="127.0.0.1"
+    local agroscope_runtime_mqtt_port="1883"
+    agroscope_forward_normalized="$(printf '%s' "$agroscope_forward_enabled" | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')"
+    case "$agroscope_forward_normalized" in
+        1|true|yes|on)
+            agroscope_runtime_mqtt_host="$agroscope_mqtt_host"
+            agroscope_runtime_mqtt_port="$agroscope_mqtt_port"
+            ;;
+    esac
 
-    # Auto-provision flows_cred.json with OSI Cloud MQTT broker credentials.
+    # Auto-provision flows_cred.json with MQTT broker credentials.
     # Node-RED does not expand env vars in credential fields or MQTT client IDs,
-    # so we write the credential file and concrete client ID from UCI values.
-    # Only written when both EUI and password are set.
+    # so we write credential entries and concrete broker runtime values here.
     local cred_file="/srv/$PACKAGE_NAME/flows_cred.json"
     local flow_file="/srv/$PACKAGE_NAME/flows.json"
-    local broker_node_id="ec43625ea99685a6"
-    if [ -n "$device_eui" ] && [ -n "$mqtt_password" ]; then
-        local expected_creds="{\"${broker_node_id}\":{\"user\":\"${device_eui}\",\"password\":\"${mqtt_password}\"}}"
-        local current_creds=""
-        [ -f "$cred_file" ] && current_creds=$(cat "$cred_file" 2>/dev/null)
-        if [ "$current_creds" != "$expected_creds" ]; then
-            printf '%s' "$expected_creds" > "$cred_file"
-        fi
-        if [ -f "$flow_file" ]; then
-            FLOW_FILE="$flow_file" BROKER_NODE_ID="$broker_node_id" DEVICE_EUI_VALUE="$device_eui" node <<'NODE'
+    local cloud_broker_node_id="ec43625ea99685a6"
+    local agroscope_broker_node_id="agroscope-mqtt-broker"
+    if [ -f "$flow_file" ]; then
+        FLOW_FILE="$flow_file" \
+        CRED_FILE="$cred_file" \
+        CLOUD_BROKER_NODE_ID="$cloud_broker_node_id" \
+        DEVICE_EUI_VALUE="$device_eui" \
+        DEVICE_MQTT_PASSWORD_VALUE="$mqtt_password" \
+        AGROSCOPE_BROKER_NODE_ID="$agroscope_broker_node_id" \
+        AGROSCOPE_MQTT_HOST_VALUE="$agroscope_runtime_mqtt_host" \
+        AGROSCOPE_MQTT_PORT_VALUE="$agroscope_runtime_mqtt_port" \
+        AGROSCOPE_MQTT_USERNAME_VALUE="$agroscope_mqtt_username" \
+        AGROSCOPE_MQTT_PASSWORD_VALUE="$agroscope_mqtt_password" \
+        node <<'NODE'
 const fs = require('fs');
 const flowFile = process.env.FLOW_FILE;
-const brokerNodeId = process.env.BROKER_NODE_ID;
+const credFile = process.env.CRED_FILE;
+const cloudBrokerNodeId = process.env.CLOUD_BROKER_NODE_ID;
 const deviceEui = process.env.DEVICE_EUI_VALUE;
+const deviceMqttPassword = process.env.DEVICE_MQTT_PASSWORD_VALUE;
+const agroscopeBrokerNodeId = process.env.AGROSCOPE_BROKER_NODE_ID;
+const agroscopeHost = process.env.AGROSCOPE_MQTT_HOST_VALUE || '127.0.0.1';
+const agroscopePort = process.env.AGROSCOPE_MQTT_PORT_VALUE || '1883';
+const agroscopeUsername = process.env.AGROSCOPE_MQTT_USERNAME_VALUE || '';
+const agroscopePassword = process.env.AGROSCOPE_MQTT_PASSWORD_VALUE || '';
+
+function readJson(filePath, fallback) {
+  try {
+    if (fs.existsSync(filePath)) return JSON.parse(fs.readFileSync(filePath, 'utf8') || '{}');
+  } catch (_) {}
+  return fallback;
+}
+
 try {
   const flows = JSON.parse(fs.readFileSync(flowFile, 'utf8'));
-  const broker = flows.find((node) => node && node.id === brokerNodeId);
-  if (broker && broker.clientid !== `device_${deviceEui}`) {
-    broker.clientid = `device_${deviceEui}`;
-    fs.writeFileSync(flowFile, JSON.stringify(flows, null, 2));
+  const creds = readJson(credFile, {});
+  let credsChanged = false;
+  let flowsChanged = false;
+
+  if (deviceEui && deviceMqttPassword) {
+    const nextCloudCreds = { user: deviceEui, password: deviceMqttPassword };
+    if (JSON.stringify(creds[cloudBrokerNodeId] || {}) !== JSON.stringify(nextCloudCreds)) {
+      creds[cloudBrokerNodeId] = nextCloudCreds;
+      credsChanged = true;
+    }
   }
+
+  if (agroscopeUsername && agroscopePassword) {
+    const nextAgroscopeCreds = { user: agroscopeUsername, password: agroscopePassword };
+    if (JSON.stringify(creds[agroscopeBrokerNodeId] || {}) !== JSON.stringify(nextAgroscopeCreds)) {
+      creds[agroscopeBrokerNodeId] = nextAgroscopeCreds;
+      credsChanged = true;
+    }
+  }
+
+  const cloudBroker = flows.find((node) => node && node.id === cloudBrokerNodeId);
+  if (cloudBroker && deviceEui && cloudBroker.clientid !== `device_${deviceEui}`) {
+    cloudBroker.clientid = `device_${deviceEui}`;
+    flowsChanged = true;
+  }
+
+  const agroscopeBroker = flows.find((node) => node && node.id === agroscopeBrokerNodeId);
+  if (agroscopeBroker) {
+    if (agroscopeBroker.broker !== agroscopeHost) {
+      agroscopeBroker.broker = agroscopeHost;
+      flowsChanged = true;
+    }
+    if (agroscopeBroker.port !== agroscopePort) {
+      agroscopeBroker.port = agroscopePort;
+      flowsChanged = true;
+    }
+  }
+
+  if (credsChanged) fs.writeFileSync(credFile, JSON.stringify(creds));
+  if (flowsChanged) fs.writeFileSync(flowFile, JSON.stringify(flows, null, 2) + '\n');
 } catch (error) {
-  console.error('[node-red.init] unable to update OSI Cloud MQTT client ID:', error.message);
+  console.error('[node-red.init] unable to update MQTT runtime config:', error.message);
 }
 NODE
-        fi
     fi
 
     procd_open_instance
@@ -163,7 +233,10 @@ NODE
         CHIRPSTACK_PROFILE_LSN50="$cs_profile_lsn50" \
         CHIRPSTACK_PROFILE_CLOVER="$cs_profile_clover" \
         CHIRPSTACK_PROFILE_RAK10701="$cs_profile_rak10701" \
-        CHIRPSTACK_PROFILE_S2120="$cs_profile_s2120"
+        CHIRPSTACK_PROFILE_S2120="$cs_profile_s2120" \
+        AGROSCOPE_FORWARD_ENABLED="$agroscope_forward_enabled" \
+        AGROSCOPE_MQTT_HOST="$agroscope_runtime_mqtt_host" \
+        AGROSCOPE_MQTT_PORT="$agroscope_runtime_mqtt_port"
     procd_set_param respawn 3600 5 -1
     procd_close_instance
 }

--- a/scripts/verify-agroscope-uplink-transform.js
+++ b/scripts/verify-agroscope-uplink-transform.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const transformPath = path.join(
+  __dirname,
+  '../conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/agroscope_uplink_transform.js'
+);
+
+const { toAgroscopeUplink } = require(transformPath);
+
+const flowPath = path.join(
+  __dirname,
+  '../conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json'
+);
+const deployPath = path.join(__dirname, '../deploy.sh');
+const nodeRedInitPath = path.join(
+  __dirname,
+  '../feeds/chirpstack-openwrt-feed/apps/node-red/files/node-red.init'
+);
+
+const rawPayload = Buffer.from('0d3e0001', 'hex');
+const dendroUplink = {
+  deviceInfo: {
+    devEui: 'a840413a10601d75',
+    deviceProfileName: 'OSI Dragino LSN50',
+  },
+  time: '2026-07-07T09:48:32.101+02:00',
+  fPort: 2,
+  data: rawPayload.toString('base64'),
+  object: {
+    BatV: 3.39,
+    ADC_CH0V: 1.234,
+    Work_mode: 'IIC',
+  },
+};
+
+assert.deepStrictEqual(toAgroscopeUplink(dendroUplink), {
+  topic: 'OSI_dendro/A840413A10601D75/uplink',
+  payload: {
+    DevEUI_uplink: {
+      Time: '2026-07-07T09:48:32.101+02:00',
+      DevEUI: 'A840413A10601D75',
+      FPort: '2',
+      payload_hex: '0d3e0001',
+      payload: {
+        Bat_V: 3.39,
+        VDC_intput_V: 1.234,
+      },
+    },
+  },
+});
+
+const untimedDendroUplink = JSON.parse(JSON.stringify(dendroUplink));
+delete untimedDendroUplink.time;
+assert.strictEqual(
+  toAgroscopeUplink(untimedDendroUplink),
+  null,
+  'dendrometer uplinks without ChirpStack time are dropped'
+);
+
+assert.strictEqual(
+  toAgroscopeUplink({
+    deviceInfo: {
+      devEui: '70b3d57ed006abcd',
+      deviceProfileName: 'OSI Aqua-Scope LoRain',
+    },
+    time: '2026-07-07T09:49:00.000+02:00',
+    fPort: 10,
+    data: Buffer.from('060100cd', 'hex').toString('base64'),
+    object: { rain_mm_delta: 1.5 },
+  }),
+  null
+);
+
+assert.strictEqual(
+  toAgroscopeUplink({
+    deviceInfo: {
+      devEui: 'a840413a1060cafe',
+      deviceProfileName: 'OSI Dragino LSN50',
+    },
+    time: '2026-07-07T09:50:00.000+02:00',
+    fPort: 2,
+    data: Buffer.from('01020304', 'hex').toString('base64'),
+    object: {
+      Chameleon_Payload_Version: 1,
+      ADC_CH0V: 1.111,
+      BatV: 3.42,
+    },
+  }),
+  null,
+  'Chameleon payloads share the LSN50 profile but must not be forwarded as dendrometers'
+);
+
+const flows = JSON.parse(fs.readFileSync(flowPath, 'utf8'));
+const findNode = (id) => flows.find((node) => node && node.id === id);
+const localUplink = findNode('e73a11a2a36aab22');
+const forwardFn = findNode('agroscope-forward-fn');
+const mqttOut = findNode('agroscope-mqtt-out');
+const broker = findNode('agroscope-mqtt-broker');
+const agroscopeInboundNodes = flows.filter((node) => node && node.type === 'mqtt in' && (
+  node.broker === 'agroscope-mqtt-broker'
+    || /agroscope|ags\//i.test(String(node.name || '') + ' ' + String(node.topic || ''))
+    || /actuator/i.test(String(node.topic || ''))
+));
+
+assert.ok(localUplink, 'local ChirpStack uplink node exists');
+assert.strictEqual(localUplink.topic, 'application/+/device/+/event/up');
+assert.ok(
+  Array.isArray(localUplink.wires) && Array.isArray(localUplink.wires[0]) && localUplink.wires[0].includes('agroscope-forward-fn'),
+  'local uplink node fans out to the Agroscope forward branch'
+);
+
+assert.ok(forwardFn, 'Agroscope forward function exists');
+assert.match(forwardFn.func, /AGROSCOPE_FORWARD_ENABLED/, 'forward branch is opt-in gated');
+assert.match(forwardFn.func, /deviceProfileName/, 'forward branch has a deviceProfileName guard');
+assert.ok(
+  forwardFn.func.includes("require('/srv/node-red/codecs/agroscope_uplink_transform')"),
+  'forward branch loads the pure transform'
+);
+assert.match(forwardFn.func, /toAgroscopeUplink/, 'forward branch calls toAgroscopeUplink');
+
+assert.ok(mqttOut, 'Agroscope MQTT-out node exists');
+assert.strictEqual(mqttOut.broker, 'agroscope-mqtt-broker');
+assert.strictEqual(mqttOut.qos, '1');
+
+assert.ok(broker, 'Agroscope MQTT broker config exists');
+assert.strictEqual(broker.broker, '127.0.0.1');
+assert.strictEqual(broker.port, '1883');
+assert.strictEqual(broker.usetls, false);
+assert.deepStrictEqual(
+  agroscopeInboundNodes.map((node) => ({ id: node.id, name: node.name, topic: node.topic, broker: node.broker })),
+  [],
+  'Agroscope integration is publish-only with no inbound MQTT subscription'
+);
+
+const deploySource = fs.readFileSync(deployPath, 'utf8');
+assert.match(
+  deploySource,
+  /agroscope_uplink_transform\.js/,
+  'deploy.sh copies the Agroscope transform codec to /srv/node-red/codecs'
+);
+
+const nodeRedInitSource = fs.readFileSync(nodeRedInitPath, 'utf8');
+assert.match(
+  nodeRedInitSource,
+  /resolve_chirpstack_value osi-server\.cloud\.agroscope_forward_enabled AGROSCOPE_FORWARD_ENABLED/,
+  'node-red.init resolves the Agroscope forwarding opt-in flag'
+);
+assert.match(
+  nodeRedInitSource,
+  /resolve_chirpstack_value osi-server\.cloud\.agroscope_mqtt_host AGROSCOPE_MQTT_HOST/,
+  'node-red.init resolves the Agroscope broker host override'
+);
+assert.match(
+  nodeRedInitSource,
+  /resolve_chirpstack_value osi-server\.cloud\.agroscope_mqtt_port AGROSCOPE_MQTT_PORT/,
+  'node-red.init resolves the Agroscope broker port override'
+);
+assert.match(
+  nodeRedInitSource,
+  /agroscope-mqtt-broker/,
+  'node-red.init provisions credentials for the Agroscope broker node'
+);
+assert.match(
+  nodeRedInitSource,
+  /AGROSCOPE_FORWARD_ENABLED="\$agroscope_forward_enabled"/,
+  'node-red.init exports the Agroscope opt-in flag to Node-RED'
+);
+assert.match(
+  nodeRedInitSource,
+  /agroscope_runtime_mqtt_host="127\.0\.0\.1"/,
+  'node-red.init keeps the Agroscope broker target local when forwarding is disabled'
+);
+assert.match(
+  nodeRedInitSource,
+  /agroscope_forward_normalized.*\n[\s\S]*1\|true\|yes\|on\)[\s\S]*agroscope_runtime_mqtt_host="\$agroscope_mqtt_host"/,
+  'node-red.init only rewrites the real Agroscope broker host when forwarding is enabled'
+);
+assert.match(
+  nodeRedInitSource,
+  /AGROSCOPE_MQTT_HOST_VALUE="\$agroscope_runtime_mqtt_host"/,
+  'node-red.init rewrites the flow broker with the gated runtime host'
+);
+assert.match(
+  nodeRedInitSource,
+  /AGROSCOPE_MQTT_PORT="\$agroscope_runtime_mqtt_port"/,
+  'node-red.init exports the gated Agroscope broker port to Node-RED'
+);
+
+console.log('Agroscope uplink transform checks passed');


### PR DESCRIPTION
Edge Node-RED branch that reshapes ChirpStack-v4 dendrometer uplinks into Swisscom `DevEUI_uplink` and publishes them to `OSI_dendro/<DevEUI>/uplink` on the Agroscope IoT broker (51.107.5.147:1883, plaintext) so Agroscope's live stack can ingest OSI's dendro data.

**Gated & safe:** opt-in per gateway at the *connection* (broker ships `127.0.0.1`; real host injected only when `AGROSCOPE_FORWARD_ENABLED` is truthy) — a disabled gateway makes no Agroscope connection. Observe-only (no inbound). Chameleon-SWT guard (shares the LSN50 profile) + untimed-uplink drop. Creds via `flows_cred.json`, never the repo. Both Pi profiles mirrored (parity check passes).

**Transform:** `agroscope_uplink_transform.js` (pure, unit-tested via `scripts/verify-agroscope-uplink-transform.js`) maps devEui→DevEUI, base64→payload_hex, dendro ADC voltage→`VDC_intput_V`.

**Reviewed twice** (blocker — always-on broker connection — fixed and verified). **E2E delivery still gated on Agroscope** confirming they ingest the `OSI_dendro/…` prefix and register `VDC_intput_V` as the dendro column (Task 5, external). Planning docs are in the osi-os docs PR #109.

Follow-up (non-blocking): dendrometer identification is a breadth heuristic — no per-DevEUI allowlist; harden before enabling on a mixed-sensor gateway.