### PR TITLE
feat: add forge skill set for stage one

### DIFF
--- a/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
+++ b/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
@@ -10,9 +10,9 @@ description: Use when interpreting soil water tension (SWT) kPa or pF values, Ch
 This skill is the domain model for how OSI OS represents soil, plant-water, and
 weather measurements in the database, the scheduler, and the dashboard. It
 answers "what does this number mean and where does it live", not general
-agronomy theory. Every claim below was checked against the code or docs named
-next to it, as of 2026-07-06 (worktree `feat/agent-skill-library`,
-`osi-os` HEAD `22cffe6d`).
+agronomy theory. Claims are tied to the code or docs named next to them; when
+using this skill for implementation, re-check drift-prone facts in the current
+branch before treating them as completion evidence.
 
 ## When to use / When NOT to use
 
@@ -31,6 +31,8 @@ Do NOT use this skill for (route instead):
 - Mechanically editing `flows.json` (node shapes, wiring function nodes) — **osi-flows-json-editing**.
 - Adding/altering a table, column, or migration — **osi-schema-change-control**.
 - `CHIRPSTACK_PROFILE_*` env vars, device-profile provisioning, feature flags — **osi-config-and-flags**.
+- Pure layout, spacing, copy, or styling changes that do not alter sensor
+  semantics, units, decoder fields, thresholds, or displayed measurement meaning.
 
 ## Device catalog and units quick-reference
 
@@ -97,12 +99,12 @@ between them.
   `trigger_metric = 'DENDRO'` the same column instead holds an **encoded
   1-4 stress level** (1=mild … 4=severe), not a kPa value — do not treat
   `threshold_kpa` as kPa when the metric is DENDRO.
-- **Known schema gap (informational, not this skill's fix):** the shipped
-  `irrigation_schedules` CHECK constraint (`database/seed-blank.sql`) still
-  only allows `trigger_metric IN ('SWT_WM1','SWT_WM2','SWT_AVG')`, while the
-  API/GUI have accepted `SWT_1`/`SWT_2`/`SWT_3`/`DENDRO` since 2026-06-24/25.
-  This is a live P0 tracked as osi-os issue #92 — a schema/migration concern,
-  see **osi-schema-change-control**, not an agronomy modeling question.
+- **Trigger-metric CHECK is a schema contract, not agronomy semantics.** If
+  `irrigation_schedules.trigger_metric` accepts or rejects the wrong symbolic
+  metrics, verify the current seed and ordered migrations before planning:
+  `grep -n "trigger_metric" database/seed-blank.sql` and
+  `ls database/migrations/ordered/`. Route any CHECK change through
+  **osi-schema-change-control**; this skill only explains what the metrics mean.
 
 **Depth columns:** `devices.chameleon_swt1_depth_cm`, `chameleon_swt2_depth_cm`,
 `chameleon_swt3_depth_cm` record the physical burial depth of each Chameleon
@@ -441,7 +443,7 @@ sed -n '1,50p' conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/os
 sed -n '1,60p' web/react-gui/src/utils/swt.ts
 sed -n '85,110p' docs/contracts/sync-schema/canonicalization.md
 
-# irrigation_schedules trigger_metric CHECK (confirm P0 issue #92 status)
+# irrigation_schedules trigger_metric CHECK (confirm current schema contract)
 grep -n "trigger_metric" database/seed-blank.sql
 
 # Dendrometer edge (v5) vs cloud (v6) ownership

--- a/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
+++ b/.claude/skills/osi-agronomy-sensors-reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: osi-agronomy-sensors-reference
-description: Use when interpreting soil water tension (SWT) kPa or pF values, Chameleon sensor calibration/wiring, dendrometer TWD/MDS output, rain gauge aggregation (LoRain/S2120), ET0/evapotranspiration questions, deciding which device_data column a sensor writes to, STREGA valve command semantics, or any device-payload/decoder question. Covers KIWI_SENSOR, TEKTELIC_CLOVER, DRAGINO_LSN50, SENSECAP_S2120, AQUASCOPE_LORAIN, STREGA_VALVE.
+description: Use when interpreting soil water tension (SWT) kPa or pF values, Chameleon sensor calibration/wiring, dendrometer TWD/MDS output, rain gauge aggregation (LoRain/S2120), ET0/evapotranspiration questions, deciding which device_data column a sensor writes to, STREGA valve command semantics, UC512 valve telemetry, or any device-payload/decoder question. Covers KIWI_SENSOR, TEKTELIC_CLOVER, DRAGINO_LSN50, SENSECAP_S2120, AQUASCOPE_LORAIN, STREGA_VALVE, MILESIGHT_UC512.
 ---
 
 # OSI Agronomy & Sensors Reference
@@ -44,6 +44,7 @@ Do NOT use this skill for (route instead):
 | `SENSECAP_S2120` | Sensors | Yes — `sensecap_s2120_decoder.js` | `ambient_temperature`, `relative_humidity`, `light_lux`, `barometric_pressure_hpa`, wind speed/direction/gust, `uv_index`, `rain_gauge_cumulative_mm` → `rain_mm_delta`/`rain_mm_today`, `bat_pct` | °C, %RH, hPa, m/s, deg, mm |
 | `AQUASCOPE_LORAIN` | Sensors | Yes — `aquascope_lorain_decoder.js` | `rain_mm_delta` (from raw 0.5 mm steps), `ambient_temperature`, `bat_v` | mm, °C, V |
 | `STREGA_VALVE` | Actuators | Yes — `strega_gen1_decoder.js` | `devices.current_state` (not a `device_data` column), `bat_pct`/`bat_v` | — |
+| `MILESIGHT_UC512` | Sensors | Yes — `milesight_uc512_decoder.js` | `valve_1_state`/`valve_2_state` (text), `valve_1_pulse`/`valve_2_pulse` (integer), `pipe_pressure_kpa` (real) | —, counts, kPa |
 
 File locations for all OSI-authored decoders:
 `conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/{aquascope_lorain_decoder.js, dragino_lsn50_decoder.js, sensecap_s2120_decoder.js, strega_gen1_decoder.js}`.

--- a/.claude/skills/osi-common-pitfalls/SKILL.md
+++ b/.claude/skills/osi-common-pitfalls/SKILL.md
@@ -60,6 +60,11 @@ use this card to catch the repeated mistakes before committing or reporting.
 14. **Do not assert success through a pipe.** `cmd | tail` reports `tail`'s
     status. Check the real command's exit code directly and paste real output.
 
+15. **Use `osiLib.require()`, not bare `require()`.** Function nodes that need
+    a shared helper module must use the `osiLib.require('<seam>')` loader, not
+    Node.js `require()`. Bare `require` bypasses the registry and breaks on the
+    Pi's OpenWrt layout. Enforced by `node scripts/flows-bare-require-scan.js`.
+
 ## Common Mistakes
 
 - Using this card instead of the owning skill for a schema, flow, live-ops, or

--- a/.claude/skills/osi-common-pitfalls/SKILL.md
+++ b/.claude/skills/osi-common-pitfalls/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: osi-common-pitfalls
+description: Use when starting or reviewing OSI OS edge work, writing execution plans, checking generated patches, or preparing execution reports where known cross-cutting repo pitfalls could invalidate a small-looking change.
+---
+
+# OSI Common Pitfalls
+
+## Overview
+
+This is the short cross-cutting hazard card. Use the owning skill for depth;
+use this card to catch the repeated mistakes before committing or reporting.
+
+## Pitfalls
+
+1. **Unfenced FK rebuild wipes children.** Rebuilding parent tables without
+   `PRAGMA foreign_keys=OFF` across the drop/rename swap can cascade-delete
+   `device_data` and `chameleon_readings`. Depth: `osi-schema-change-control`.
+
+2. **Empty catch blocks are ratcheted.** In touched flow nodes, convert
+   `catch (_) {}` / `catch (e) {}` / `catch {}` to visible `node.warn(...)`.
+   Verify with `node scripts/verify-no-new-silent-catch.js`.
+
+3. **bcm2712 mirrors to bcm2709.** Payload files under
+   `conf/...bcm2712/files/` must be byte-identical in the bcm2709 mirror.
+   Verify with `node scripts/verify-profile-parity.js`.
+
+4. **Missing data must look missing.** Do not invent plausible defaults for
+   absent sensor, weather, or agronomy data. Propagate `null` end to end.
+
+5. **`flows.json` is script-edited only.** Parse, mutate, stringify, and guard
+   roundtrip first; update both profiles. Depth: `osi-flows-json-editing`.
+
+6. **Function-node npm modules need `libs`.** `functionExternalModules: true`
+   only enables binding; missing `libs` for `osiDb`, `osiCloudHttp`,
+   `chameleon`, or `dendro` can hang async handlers silently.
+
+7. **`const`/`let` inside `try {}` is block-scoped.** If referenced after the
+   block, it becomes a silent `ReferenceError` path in async function nodes.
+   Declare defaults outside, assign inside.
+
+8. **Never hardcode ChirpStack UUIDs.** MQTT IN topic is always
+   `application/+/device/+/event/up`; discriminate device type downstream.
+
+9. **`device_data` sync trigger is INSERT-only.** Historical repairs through
+   `UPDATE` need explicit `DEVICE_DATA_APPENDED` outbox events or cloud stays
+   stale.
+
+10. **STREGA normal operation is `OPEN_FOR_DURATION`.** A bare `CLOSE` is not
+    the normal close path, even in tests; use cancel for operator cancellation.
+
+11. **`export.csv` 401 can be healthy.** Auth-gated exports should return 401
+    without a token. Treat 404 or 500 as broken route/server behavior.
+
+12. **Guard tests pin contracts.** If the intended contract changes, update
+    the pin in the same commit and state why; do not weaken guards silently.
+
+13. **One source of truth per fact.** Duplicated schema, constants, or protocol
+    maps need a verifier that fails on divergence, or they will drift.
+
+14. **Do not assert success through a pipe.** `cmd | tail` reports `tail`'s
+    status. Check the real command's exit code directly and paste real output.
+
+## Common Mistakes
+
+- Using this card instead of the owning skill for a schema, flow, live-ops, or
+  sensor-semantics change.
+- Reporting "green" from a remembered pass signal instead of the command's
+  current output and exit code.
+- Fixing one profile, one schema copy, or one duplicated constant and trusting
+  CI to discover the sibling drift later.

--- a/.claude/skills/osi-flows-json-editing/SKILL.md
+++ b/.claude/skills/osi-flows-json-editing/SKILL.md
@@ -487,10 +487,10 @@ conf/full_raspberrypi_bcm27xx_bcm2709` and exits non-zero.
 ## MQTT IN topic rule
 
 Every `mqtt in` node in `flows.json` must subscribe to the literal topic
-`application/+/device/+/event/up`. Confirmed by inspecting all 6 `mqtt in`
-nodes in the canonical file on 2026-07-06 (`Local Device Uplinks`, `MQTT IN
-(Field Testing)`, `Local Sensor Uplinks`, `LSN50 IN`, `S2120 IN`, `LoRain IN`)
-— all 6 use exactly that topic string. ChirpStack generates a fresh
+`application/+/device/+/event/up`. Confirmed by inspecting all 7 `mqtt in`
+nodes in the canonical file (`Local Device Uplinks`, `MQTT IN (Field Testing)`,
+`Local Sensor Uplinks`, `LSN50 IN`, `S2120 IN`, `LoRain IN`, `UC512 IN`) —
+all 7 use exactly that topic string. ChirpStack generates a fresh
 per-installation application UUID at bootstrap; a topic hardcoded to one
 gateway's UUID (e.g. `application/<uuid>/device/+/event/up`) will silently
 never match on any other gateway — no error, just zero uplinks. Device-type
@@ -525,6 +525,8 @@ from the repo root.
 | Flow wiring guards | `node scripts/test-flows-wiring.js` | ends `PASS: STREGA wiring + osiDb close + WS2/WS3 wiring guards all passed`, exit 0 |
 | Silent catch ratchet | `node scripts/verify-no-new-silent-catch.js` | exit 0; no new or worsened empty catches in maintained flow nodes |
 | Stray DDL ratchet | `node scripts/verify-no-stray-ddl.js` | exit 0; no unreviewed DDL-marker count increase in flows/deploy surfaces |
+| Flows size ratchet | `node scripts/verify-flows-size-ratchet.js` | exit 0; no node grew, no new node exceeds 4 KB, total embedded JS did not increase |
+| Bare require scan | `node scripts/flows-bare-require-scan.js` | exit 0; no function node uses bare `require()` instead of `osiLib.require()` |
 
 If you intentionally changed a pinned wiring contract, update
 `scripts/test-flows-wiring.js` in the same commit and say why in the commit

--- a/.claude/skills/osi-flows-json-editing/SKILL.md
+++ b/.claude/skills/osi-flows-json-editing/SKILL.md
@@ -9,11 +9,13 @@ description: Use when editing conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/sh
 
 `flows.json` is the Node-RED flow definition that IS the edge backend for OSI OS:
 REST API routes, the scheduler, sync orchestration, and sensor ingest are all
-nodes in this one JSON array. As of 2026-07-06 the canonical copy at
-`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json` is 529 nodes,
-1,245,761 bytes, formatted as `JSON.stringify(flows, null, 2) + '\n'`. It must be
-mirrored byte-for-byte into `conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json`
-(same byte count, confirmed identical on 2026-07-06).
+nodes in this one JSON array. The maintained copies are formatted as
+`JSON.stringify(flows, null, 2) + '\n'`, but node counts and byte counts drift as
+features land. Re-measure them in the current branch before citing them. The
+canonical copy at
+`conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json` must be
+mirrored byte-for-byte into
+`conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json`.
 
 This skill covers the mechanics of making a safe, wiring-correct edit to that
 file — not deploying it, diagnosing a live symptom, schema/migration changes,
@@ -72,17 +74,18 @@ script has a serialization bug (e.g. wrong indent width, missing trailing
 newline, a `Map`/`Set` in the mutation that doesn't round-trip). Do not
 proceed with a real mutation until the no-op case is proven byte-identical.
 
-This was actually run against this repo, not assumed:
+Expected roundtrip-check output shape after you rerun it in the current branch:
 
 ```
 $ node roundtrip-check.js conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
-byte-identical: true   (1,245,761 / 1,245,761 bytes)
+byte-identical: true   (<current bytes> / <current bytes>)
 
 $ node roundtrip-check.js conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
-byte-identical: true   (1,245,761 / 1,245,761 bytes)
+byte-identical: true   (<current bytes> / <current bytes>)
 ```
 
-Verified 2026-07-06 against `origin/main`. Both profile copies pass.
+Do not reuse old byte counts as proof. Fresh output from the branch you are
+editing is the evidence.
 
 ## Complete script skeleton
 
@@ -150,7 +153,7 @@ const exampleFunctionNode = {
     "  const fs = global.get('fs');", // functionGlobalContext local, NOT an npm module — no libs entry needed
     "  value = parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim());",
     "} catch (e) {",
-    "  // sampler must never crash the flow: swallow and report null",
+    "  node.warn('Example Sampler read failed: ' + (e && e.message ? e.message : e));",
     "}",
     "msg.payload = { value };",
     "return msg;",
@@ -286,18 +289,24 @@ automated form of the npm-module rule above.
 
 Wrap every sysfs/file/subprocess read in its own `try/catch` that resolves to
 `null` for that one reading — a sampler failing to read one sysfs path must
-never take down the rest of the function or the flow. Real precedent, node
+never take down the rest of the function or the flow. Adapted from node
 `062a0f9bf66d9789` ("Build Heartbeat", part of the frozen heartbeat cluster —
-read it for the pattern, do not edit it casually):
+read it for isolation shape, but do not copy legacy empty catches):
 
 ```js
 var cpuTemp = null, memPercent = null, load1 = null, load5 = null, load15 = null, fanValue = null;
 
-try { cpuTemp = Math.round(parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim()) / 100) / 10; } catch(e) {}
 try {
-    var tm = os.totalmem(), fm = os.freemem();
-    memPercent = Math.round(((tm - fm) / tm) * 100);
-} catch(e) {}
+  cpuTemp = Math.round(parseInt(fs.readFileSync('/sys/class/thermal/thermal_zone0/temp', 'utf8').trim()) / 100) / 10;
+} catch (e) {
+  node.warn('Build Heartbeat cpu temp read failed: ' + (e && e.message ? e.message : e));
+}
+try {
+  var tm = os.totalmem(), fm = os.freemem();
+  memPercent = Math.round(((tm - fm) / tm) * 100);
+} catch (e) {
+  node.warn('Build Heartbeat memory read failed: ' + (e && e.message ? e.message : e));
+}
 ```
 
 **The let-before-try scoping trap:** a `const` (or `let`) declared *inside* a
@@ -316,7 +325,8 @@ try {
   zoneTimezone = await lookupTimezone(zoneId);   // assignment, not declaration
   phenoMod = await lookupPhenoMod(zoneId);
 } catch (e) {
-  // zoneTimezone/phenoMod keep their safe defaults; nothing downstream breaks
+  node.warn('zone metadata lookup failed: ' + (e && e.message ? e.message : e));
+  // zoneTimezone/phenoMod keep their safe defaults; nothing downstream breaks.
 }
 // zoneTimezone and phenoMod are both safely usable here
 ```
@@ -324,15 +334,59 @@ try {
 Always declare-with-default before the `try`, assign inside it, and never
 `const`/`let` a name inside `try{}` that anything outside the block needs.
 
+### Empty catches are ratcheted
+
+The repo allows legacy empty catches only as an existing baseline. When you
+touch a function node, convert empty `catch(_){}` / `catch(e){}` /
+`catch {}` blocks in that node to a visible warning such as:
+
+```js
+catch (e) {
+  node.warn('node/context: ' + (e && e.message ? e.message : e));
+}
+```
+
+Run `node scripts/verify-no-new-silent-catch.js` before committing. It ratchets
+maintained flow nodes, so a newly-added or worsened silent catch is a real
+failure even when the flow still imports.
+
+### Authenticated HTTP endpoints
+
+For a gated HTTP endpoint, copy the auth block verbatim from the newest shipped
+endpoint with the same auth mode, then diff your block against that precedent.
+Do not retype timing-safe HMAC checks, expiry checks, or token parsing from
+memory.
+
+Every code path must send exactly one HTTP response: success, validation
+failure, auth failure, not-found, and exception paths all terminate in one
+`http response` node or one response send. A route that sometimes returns no
+response is a silent hang; a route that sends twice becomes a Node-RED runtime
+error.
+
+For auth-gated routes, a no-token `401` is healthy proof that the route exists
+and is protected. Treat `404` as broken wiring/path and `500` as a handler bug.
+
+### No ad hoc DDL in flows.json
+
+Schema DDL belongs in ordered migrations and sanctioned deploy/boot repair
+paths, not new flow-node strings. `node scripts/verify-no-stray-ddl.js` is a
+git-anchored count ratchet over the maintained `flows.json` copies and
+`deploy.sh`; adding a new `CREATE TABLE`, `ALTER TABLE`, trigger, index, or
+similar marker in `flows.json` trips that guard against `origin/main`.
+
+If a flow edit appears to need DDL, stop and route through
+`osi-schema-change-control` instead of burying schema changes in a function node.
+
 ### Stable node ids
 
 Never regenerate or reuse an existing node's `id` — every `wires` array in
 every other node references ids directly, so changing one breaks wiring
 silently (Node-RED will not error; the edge from the old id just stops
 being a target). Real ids observed in this file take one of two forms:
-16-lowercase-hex-character Node-RED-generated ids (124 of 529 nodes, e.g.
-`062a0f9bf66d9789`, `c2b43a6c6e7d2c11`) or short descriptive slugs (the
-remaining 405, e.g. `auth-db-query`, `sync-init-fn`, `write-strega-expectation`).
+16-lowercase-hex-character Node-RED-generated ids (e.g. `062a0f9bf66d9789`,
+`c2b43a6c6e7d2c11`) or short descriptive slugs (e.g. `auth-db-query`,
+`sync-init-fn`, `write-strega-expectation`). Re-measure the current distribution
+if you need exact counts for a report.
 For a new node, mint a fresh 16-hex id
 (`node -e "console.log(require('crypto').randomBytes(8).toString('hex'))"`)
 or a new, clearly-unique descriptive slug if you are extending a named
@@ -374,7 +428,7 @@ for (const n of flows) {
 
 Run with plain `node scripts/test-flows-wiring.js` (not `node --test` — the
 file is a plain script with hand-rolled assertions, not a `node:test` suite).
-It pins four kinds of wiring contract, all against the canonical
+It pins these wiring and function-node contracts against the canonical
 (bcm2712) `flows.json` only:
 
 1. **STREGA actuation wiring** (labelled WS1, tags C5/H2/L1/M8) — exact
@@ -384,18 +438,23 @@ It pins four kinds of wiring contract, all against the canonical
    (`STALE_OPEN_OBSERVED`) inside `strega-reconciliation-monitor`'s `func`,
    an absence check (must NOT contain `flow.get('command_types') || {}`), and
    node-existence checks for the today-liters HTTP trio.
-2. **`osiDb.Database` close audit** (WS2/WS3) — described above.
-3. **Function-node `libs` declaration audit** — described above.
-4. **Misc WS2/WS3 wiring invariants** — a handful of `node.id === '...'` checks
+2. **Field request intake + status apply wiring** — required HTTP routes,
+   router `osiDb` binding/close behavior, contact-email persistence, pending
+   command split output count, and status ACK queue wiring.
+3. **Settings module gates** — bulk schedule-disable endpoint existence, bearer
+   auth, scoped schedule update, response shape, and no valve/downlink mutation.
+4. **`osiDb.Database` close audit** (WS2/WS3) — described above.
+5. **Function-node `libs` declaration audit** — described above.
+6. **Misc WS2/WS3 wiring invariants** — a handful of `node.id === '...'` checks
    for specific required substrings in specific nodes (gateway migration
    preflight's parameterized `q`/`run` helpers, `sync-force-build`'s timeout
    guard, `command-ack-build-batch`'s bootstrap gate, `s2120-zones-put-auth-fn`'s
    zone-id validation).
 
 On failure it prints one `FAIL: N flow wiring regression(s):` line followed by
-a bulleted list, then `process.exit(1)`; on success, one `OK` line per check
-plus a final `PASS: STREGA wiring + osiDb close + WS2/WS3 wiring guards all
-passed`.
+a bulleted list, then `process.exit(1)`; on success, it prints `OK` lines for
+the asserted groups plus a final `PASS: STREGA wiring + osiDb close + WS2/WS3
+wiring guards all passed`.
 
 **When you intend a wiring change that this file pins, update the pin in the
 same commit, with a commit message explaining why the wiring changed.** A
@@ -411,7 +470,7 @@ mirror separately, and do not let the two diverge even by a trailing newline.
 
 Enforced by `node scripts/verify-profile-parity.js`, which is chained from
 `node scripts/verify-sync-flow.js` (it runs as the final step, via
-`spawnSync`). Real output shape, run 2026-07-06 against this worktree:
+`spawnSync`). Output shape:
 
 ```
 === conf/full_raspberrypi_bcm27xx_bcm2709 ===
@@ -442,7 +501,7 @@ discrimination happens downstream of the MQTT IN node via
 Enforced by `scripts/check-mqtt-topics.sh`, which checks all three flow
 copies (bcm2712, bcm2709, and a legacy bcm2708 path) for both a UUID-shaped
 regex in any MQTT IN topic and an exact-string match against the expected
-topic. Run 2026-07-06:
+topic. Expected output shape:
 
 ```
 OK: conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json — no UUID patterns in MQTT IN topics
@@ -461,9 +520,11 @@ from the repo root.
 | Roundtrip byte-check ran on both profiles (before AND after your mutation) | your scratchpad roundtrip script | `byte-identical: true` for both `.../bcm2712/.../flows.json` and `.../bcm2709/.../flows.json` |
 | Both profile copies updated | `git status --short` shows both `flows.json` paths changed together | both paths listed, never just one |
 | Profile parity | `node scripts/verify-profile-parity.js` | ends `All parity checks passed.`, exit 0 |
-| Sync flow verification (chains schema/history/parity checks) | `node scripts/verify-sync-flow.js` | prints `Sync flow verification passed` at the end of its own section, then chains profile parity; a healthy full run ends `All parity checks passed.`, exit 0 — verified clean on this worktree 2026-07-06 (no open `duplicate column` failure; that was issue #84, already fixed on `main`) |
+| Sync flow verification (chains schema/history/parity checks) | `node scripts/verify-sync-flow.js` | prints `Sync flow verification passed` at the end of its own section, then chains profile parity; a healthy full run ends `All parity checks passed.`, exit 0 |
 | MQTT topic compliance | `scripts/check-mqtt-topics.sh` | three `OK:` lines, one per flow copy, exit 0 |
 | Flow wiring guards | `node scripts/test-flows-wiring.js` | ends `PASS: STREGA wiring + osiDb close + WS2/WS3 wiring guards all passed`, exit 0 |
+| Silent catch ratchet | `node scripts/verify-no-new-silent-catch.js` | exit 0; no new or worsened empty catches in maintained flow nodes |
+| Stray DDL ratchet | `node scripts/verify-no-stray-ddl.js` | exit 0; no unreviewed DDL-marker count increase in flows/deploy surfaces |
 
 If you intentionally changed a pinned wiring contract, update
 `scripts/test-flows-wiring.js` in the same commit and say why in the commit
@@ -503,6 +564,16 @@ non-author) — §8 defines done, not a green checklist.
   It only enables the *mechanism*; each node still needs its own `libs` entry.
 - Adding schema DDL inside `sync-init-fn` because "it's just one more ADD
   COLUMN" — that node is frozen; see `osi-schema-change-control`.
+- Adding or leaving an empty catch in a touched function node. The
+  `verify-no-new-silent-catch.js` ratchet exists because swallowed errors made
+  flow failures look like missing data or HTTP hangs.
+- Retyping auth boilerplate for a new HTTP endpoint instead of copying and
+  diffing the newest shipped gated endpoint.
+- Treating a no-token `401` on a gated endpoint as a failure. It is the healthy
+  protected-route signal; `404`/`500` are the route/handler failures.
+- Adding DDL-like SQL to `flows.json` and assuming schema verifiers cover it.
+  `verify-no-stray-ddl.js` is the guard that catches ad hoc DDL in flow/deploy
+  surfaces.
 
 ## Provenance and maintenance
 
@@ -515,6 +586,8 @@ Re-verify these before trusting them again, especially after any large flows.jso
 - `functionGlobalContext` keys: `grep -n -A5 "functionGlobalContext" feeds/chirpstack-openwrt-feed/apps/node-red/files/settings.js`.
 - MQTT IN topic compliance: `bash scripts/check-mqtt-topics.sh`.
 - Wiring guard behavior and pass/fail text: `node scripts/test-flows-wiring.js`.
+- Silent-catch ratchet behavior: `node scripts/verify-no-new-silent-catch.js`.
+- Stray-DDL ratchet behavior: `node scripts/verify-no-stray-ddl.js`.
 - Profile parity behavior and pass/fail text: `node scripts/verify-profile-parity.js`.
 - Full chained verifier and current baseline health: `node scripts/verify-sync-flow.js`.
 - Node id format distribution (16-hex vs slug counts): re-run the id-length-distribution one-liner from this skill's authoring session, or `node -e "const f=require('./conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json'); const ids=f.filter(n=>n.id).map(n=>n.id); console.log(ids.filter(i=>/^[0-9a-f]{16}$/.test(i)).length,'/',ids.length)"`.

--- a/.claude/skills/osi-forge-boundaries/SKILL.md
+++ b/.claude/skills/osi-forge-boundaries/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: osi-forge-boundaries
+description: Use when an OSI Forge worker or controller is executing an issue-to-PR task, writing execution reports, deciding whether a requested action is allowed in Stage 1, or preparing branch/PR evidence from a disposable worktree.
+---
+
+# OSI Forge Boundaries
+
+## Overview
+
+Forge Stage 1 agents work in disposable test-VPS worktrees and prove changes
+with local commands. They do not deploy, SSH, read live secrets, inspect
+production, or merge their own work. If correct execution appears to require a
+forbidden action, stop and write the finding into `execution-report.md`.
+Stage 1 is limited to `osi-os` jobs with risk class 0-2; requests that need
+production access, live gateway mutation, or deployment-only proof are
+stop-and-report outcomes.
+
+Verified context: branch naming and draft-PR shape are specified in
+`docs/superpowers/specs/2026-07-08-field-to-pr-design.md` (`agent/req-*`,
+draft PR, evidence body). Production restrictions are in `AGENTS.md`
+("Production cloud access").
+
+## Environment
+
+| Allowed in Stage 1 | Not allowed in Stage 1 |
+|---|---|
+| Disposable worktree on a test VPS | SSH to any gateway or server |
+| Local repo reads and writes within the assigned scope | Docker or host-level service mutation |
+| Local tests, build commands, static verifiers | Reading server `.env` or credential files |
+| Git commits on the assigned branch | Touching a live gateway or `osicloud.ch` |
+| Draft PR creation from `agent/*` branches | Pushing non-`agent/*` branches or merging |
+
+## Absolute Prohibitions
+
+### Mechanical gate targets in the Stage 1 controller
+
+These are the checks the Stage 1 runner must reject before a public draft PR is
+pushed. If the active runner does not expose that gate yet, stop and report the
+gap instead of assuming human review will catch it later.
+
+| Prohibition | Why |
+|---|---|
+| Secret-looking values in diffs | Prevents token, key, AppKey, password, and credential leakage into git history. |
+| Credential paths in diffs | Prevents accidental reads or writes of `.env`, SSH keys, Node-RED credentials, gateway tokens, and similar files. |
+| Oversized diffs beyond the request limit | Keeps worker output reviewable and prevents broad, uncontrolled edits. |
+| Branch names outside the allowed `agent/*` / `agent/req-*` shape | Keeps automation isolated from maintainer and production branches. |
+| Controller content-scan findings when enabled for the current job | Honors task-specific deny lists without pretending every policy item is universally scanned. |
+
+### Policy, caught by review unless a gate also exists
+
+These may not be mechanically enforced by `gates.py` or the current runner.
+They are still forbidden by policy and should be reported when seen.
+
+| Prohibition | Why |
+|---|---|
+| Outbound HTTP calls during implementation or verification | Stage 1 evidence is local-only unless the task explicitly provides an approved wrapper. |
+| Reading arbitrary environment variables | Env can carry secrets and target identity; Forge workers should not learn host credentials. |
+| Raw IP addresses in new code or docs | They can bypass named-environment policy and hide production coupling. |
+| SSH, live gateway access, or `osicloud.ch` access | Live farms and production cloud are outside Forge Stage 1. |
+| Docker or host service mutation | The disposable worktree is the boundary; do not mutate the worker host. |
+
+## Deployment Awareness
+
+| Need | Stage 1 handling |
+|---|---|
+| Prove parser, schema, flow, GUI, codec, or contract behavior locally inside an allowed class 0-2 job | Run the local verifier or test command and paste real output into `execution-report.md`. |
+| Prove a change works only after deployment to a gateway or cloud service | Stop and report. Runtime deployment verification wrappers are Stage 2 - not yet available. |
+| Verify a live Pi, Node-RED runtime, ChirpStack, MQTT, or cloud pending-command path | Stop and report. Stage 1 has no SSH, live gateway, or production access. |
+| Need a deploy/verify wrapper named by a spec | If the wrapper is not present and approved in the current Stage 1 runner, stop and report "Stage 2 - not yet available"; do not emulate it manually. |
+
+## Branch and PR Contract
+
+- Start from an issue or request artifact; do not invent scope outside it.
+- Use `agent/req-<shortid>-<slug>` for Forge worker branches unless the task
+  gives a stricter branch name.
+- Open a draft PR only. The PR body must include issue link, root cause, files
+  changed, commands run, and pasted evidence.
+- Never self-approve, mark ready, merge, squash, retarget, or delete branches
+  unless the maintainer explicitly instructs it in the current turn.
+- Push only `agent/*` worker branches. If the assigned task names a
+  non-`agent/*` branch, commit locally and stop for controller handling.
+
+## Blocked Execution
+
+If the correct next step appears to require a prohibited action:
+
+1. Stop before doing it.
+2. Write the exact missing capability or forbidden requirement in
+   `execution-report.md`.
+3. Include the local evidence already collected.
+4. Mark status `BLOCKED` or `DONE_WITH_CONCERNS`, not `DONE`.
+
+## Common Mistakes
+
+- Treating "test VPS" as permission to read host secrets or mutate services.
+- Calling an unimplemented Stage 2 wrapper by hand through SSH, Docker, or curl.
+- Claiming deployment proof when only local verifier output exists.
+- Assuming an action is allowed because no current gate blocks it. Review policy
+  still applies.
+- Opening a normal PR, marking ready, approving, or merging from the worker.

--- a/.claude/skills/osi-react-gui-patterns/SKILL.md
+++ b/.claude/skills/osi-react-gui-patterns/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: osi-react-gui-patterns
+description: Use when web/react-gui routes, pages, components, service APIs, feature flags, i18n strings, tests, build behavior, or TypeScript types are changed in osi-os.
+---
+
+# OSI React GUI Patterns
+
+## Overview
+
+The edge GUI is a static Vite build served by Node-RED under `/gui`. It must
+work on-device without server-side routing and must preserve missing data as
+missing, especially for agronomy and telemetry.
+
+Verified sources to re-check before edits:
+
+- `AGENTS.md` TypeScript and missing-data rules.
+- Repo-root `architect.yaml` and `RULES.yaml`.
+- `docs/agents/typescript-rule-overlays.md`.
+- `web/react-gui/src/App.tsx`.
+- `web/react-gui/vite.config.js`.
+- `web/react-gui/src/services/api.ts`.
+- `web/react-gui/src/i18n/config.ts`.
+- `web/react-gui/package.json`.
+
+## Serving and Routing
+
+- Node-RED serves the built GUI under `/gui`.
+- Vite uses `base: '/gui/'`; preserve this unless the Node-RED static path
+  changes with it.
+- `App.tsx` uses `HashRouter`. Deep links must be hash routes, not server
+  paths that require BrowserRouter support.
+- Avoid absolute asset paths outside `/gui/`; they break on-device even when
+  they work in local Vite dev.
+
+## Auth and Routes
+
+- Authenticated routes use `PrivateRoute` from
+  `web/react-gui/src/components/PrivateRoute.tsx`.
+- Token storage, login/logout state, and auth-expiry cleanup live in
+  `web/react-gui/src/contexts/AuthContext.tsx` and
+  `web/react-gui/src/services/api.ts`.
+- For new protected pages, copy the newest route block in `App.tsx` and keep
+  auth behavior byte-for-byte where possible.
+
+## i18n
+
+- `web/react-gui/src/i18n/config.ts` wires `i18next`, `react-i18next`,
+  `LanguageDetector`, and `HttpBackend`.
+- Locale files are served from `/gui/locales/{{lng}}/{{ns}}.json`.
+- Farmer-facing strings should use `t()` when adjacent/current pages are
+  already localized.
+- Add new keys to every locale directory under `web/react-gui/public/locales/`.
+  Non-English strings may initially mirror English when the issue scope is key
+  coverage.
+- `LanguageSwitcher` already exists; reuse it instead of creating a separate
+  language control.
+- i18n coverage is incomplete (`AGENTS.md` issue #47). Copy the newest
+  compliant page or test pattern instead of normalizing old hardcoded strings
+  opportunistically.
+
+## Service and Data Boundary
+
+- REST calls go through `web/react-gui/src/services/api.ts`.
+- Keep snake_case/camelCase compatibility and EUI normalization in service
+  helpers, not presentational components.
+- SWR is the existing fetch-hook pattern for dashboard, history, and analysis
+  data.
+- Shared domain types live in `web/react-gui/src/types/farming.ts`.
+- System feature flags come from `/api/system/features`; client defaults stay
+  all-false while loading (`useFeatureFlags`).
+
+## Missing Data Rule
+
+`null` means unavailable. Do not coerce nullish telemetry, weather, rain,
+battery, SWT, dendrometer, or recommendation data into plausible values like
+`0`, `24`, or `-42`. Render an unavailable state and test that zeros remain
+valid when they are measured zeros.
+
+Known helper/test precedent:
+
+- SWT: `web/react-gui/src/utils/swt.ts` and `src/utils/__tests__/swt.test.ts`.
+- Rain no-sample vs measured-dry behavior: `web/react-gui/src/utils/rain.ts`.
+- Battery null handling: `web/react-gui/tests/deviceCardBattery.test.ts`.
+
+## Rule Overlays
+
+Before TypeScript edits:
+
+1. Match the target file against repo-root `architect.yaml`.
+2. Read the corresponding `RULES.yaml` section.
+3. Apply it as an advisory overlay on the existing local pattern and tests.
+
+The overlays do not replace TDD, explicit repo instructions, or verification
+evidence.
+
+## Verification
+
+From `web/react-gui`:
+
+```bash
+npm run test:unit
+npm run build
+```
+
+`npm run test:unit` chains:
+
+- `npm run test:unit:tsx-runner` for `tests/**/*.test.ts`.
+- `npm run test:unit:vitest` for `src/**/__tests__` and selected component
+  test directories.
+
+Also run `git diff --check` from the repo root before committing.
+
+## Common Mistakes
+
+- Replacing `HashRouter` with `BrowserRouter` and breaking on-device deep links.
+- Adding `/assets/...` or `/locales/...` paths that bypass `/gui/`.
+- Creating a route without the `PrivateRoute` wrapper.
+- Putting API compatibility normalization inside a component.
+- Adding English UI text without locale keys on localized pages.
+- Treating feature flags as enabled while `/api/system/features` is still
+  loading.
+- Rendering missing agronomy data as a plausible numeric default.
+- Running only Vitest and forgetting the `tests/**/*.test.ts` tsx runner.

--- a/.claude/skills/osi-schema-change-control/SKILL.md
+++ b/.claude/skills/osi-schema-change-control/SKILL.md
@@ -258,9 +258,9 @@ identical). The rebuild:
 
 1. Reads the live `devices` table's CHECK clause and extracts the current
    `type_id` set with a regex.
-2. Compares it by **set equality** against the six canonical types —
+2. Compares it by **set equality** against the canonical types —
    `KIWI_SENSOR`, `STREGA_VALVE`, `DRAGINO_LSN50`, `TEKTELIC_CLOVER`,
-   `SENSECAP_S2120`, `AQUASCOPE_LORAIN` (named `REQUIRED_TYPES` in the code). If
+   `SENSECAP_S2120`, `AQUASCOPE_LORAIN`, `MILESIGHT_UC512` (named `REQUIRED_TYPES` in the code). If
    the live set is missing a type *or* has an extra/drifted type, `needsRebuild`
    is true — this is stricter than "missing-only," which was a P2 review finding
    fixed before merge (an extra drifted type must also trigger convergence, not
@@ -310,7 +310,7 @@ rows preserved), `would-drop` (a row the new CHECK would reject must never be
 silently dropped, and the abort must be surfaced), `legit-upgrade` (rebuild
 succeeds, CHECK gains `AQUASCOPE_LORAIN`), and `extra-type` (a drifted extra type
 with no offending rows must still trigger a rebuild that converges the CHECK back
-to exactly the six canonical types). `verify-devices-rebuild-fence.js` statically
+to exactly the canonical types). `verify-devices-rebuild-fence.js` statically
 greps both flows files for the fail-closed shape: no `INSERT OR IGNORE INTO
 devices_new`, rebuild inside `_db.transaction(`, guarded by
 `REQUIRED_TYPES`/`needsRebuild`, `finally` before `foreign_keys=ON`, a

--- a/.claude/skills/osi-schema-change-control/SKILL.md
+++ b/.claude/skills/osi-schema-change-control/SKILL.md
@@ -66,6 +66,7 @@ outside the one sanctioned exception.
 | Hand-edit `schema_object_fingerprints` | It is a computed baseline (SHA-256 over live DDL + `PRAGMA table_xinfo`/`foreign_key_list`/`index_list`/`index_xinfo`). A hand edit desyncs the stamp from the real schema and the next `applyPending` either falsely passes or falsely refuses. The only sanctioned re-baselines are `scripts/restamp-fingerprints.js` (recompute fingerprints of a confirmed-good live schema) and `scripts/baseline-existing-db.js` (semantic-gated first baseline of a pre-ledger device — Option B Stage 0, spec 2026-07-07). |
 | Reseed or overwrite `/data/db/farming.db` on a provisioned Pi | `deploy.sh`'s `seed_db_if_missing` only seeds when the file is absent *and* no WAL/SHM/journal sidecars exist; it refuses otherwise. Overwriting destroys irreplaceable farm history. |
 | Add new schema behavior to `sync-init-fn` (the boot node) | It is FROZEN (AGENTS.md "Boot-DDL freeze"). New schema goes through the migration runner's ordered files and deploy-time runner path, not boot-time inline DDL. |
+| Add ad hoc DDL to `flows.json` or `deploy.sh` without routing through schema change control | `scripts/verify-no-stray-ddl.js` is a git-anchored DDL-marker ratchet over the maintained flow copies and `deploy.sh`. A green migration verifier does not prove this guard will pass. |
 | Modify an already-merged `database/migrations/ordered/NNNN__slug.sql` file | Migrations are checksummed (SHA-256 of the raw file bytes, `lib/osi-migrate/migrations-loader.js`). Changing a merged file makes the ledger's stored checksum mismatch the file on next apply, which the runner treats as `repair_required` and refuses to proceed past. |
 | Update `seed-blank.sql` or one bundled DB without the others | `verify-seed-replay.js` and `verify-db-schema-consistency.js` both fail if any of the 7 bundled copies drifts from the seed/migration-replay schema. One home for the fact: keep all copies byte/fingerprint-identical in the same commit. |
 | Rebuild a parent table (drop/rename swap) without the FK fence | Without `PRAGMA foreign_keys=OFF` held across the swap, `ON DELETE CASCADE` on child tables (`device_data`, `chameleon_readings`) silently wipes their rows when the parent is dropped. This caused a documented field history-loss incident (`docs/operations/edge-history-retention.md`). |
@@ -109,9 +110,20 @@ by the ADR but was never committed to the repo — do not go looking for it.)
 
 ### Ordered migrations: format and risk-class declaration
 
-Files live at `database/migrations/ordered/NNNN__slug.sql` — currently
-`0001__baseline.sql` through `0007__analysis_views.sql`. The filename format is
-enforced by a regex in `lib/osi-migrate/migrations-loader.js`:
+Files live at `database/migrations/ordered/NNNN__slug.sql`. Check the current
+inventory before choosing a version:
+
+```bash
+ls database/migrations/ordered/
+```
+
+Use the next contiguous four-digit version after the highest `NNNN` present; do
+not copy an example version from this skill. If `CHECKSUMS.json` is present in
+that directory, keep it in mind when interpreting `verify-migrations.js` output
+and do not edit already-recorded migration bytes casually.
+
+The filename format is enforced by a regex in
+`lib/osi-migrate/migrations-loader.js`:
 `^(\d{4})__([a-z0-9_]+)\.sql$` — four-digit version, double underscore, lowercase
 slug. Versions must be unique and are sorted numerically, not lexically.
 
@@ -280,7 +292,8 @@ fence is what prevents it from recurring.
 
 ### Merge gate for any further touch to this block
 
-Verified present and passing in this worktree on 2026-07-06:
+If you touch the guarded `devices` rebuild block, rerun this gate set in the
+current branch and paste fresh output:
 
 ```
 node scripts/verify-runtime-schema-parity.js     # OK (2 flows: devices CHECK + trigger parity)
@@ -313,14 +326,13 @@ rehearse test); `verify-profile-parity.js` is CI-gated via the
 production-copy rehearsal is additionally expected before rollout to a live
 gateway (see `osi-live-ops-runbook` for the actual on-Pi procedure).
 
-**Additional gate:** `scripts/verify-sync-flow.js` is green on `main` (verified
-in this worktree 2026-07-06, exit 0) and CI-gated by its own workflow,
-`.github/workflows/verify-sync-flow.yml` — separate from `migrations.yml`. It
-chains `verify-db-schema-consistency.js` and `verify-profile-parity.js`: a full
-run prints `Sync flow verification passed` at the end of the sync section and
-terminates with `All parity checks passed.`. (An older plan document described it as RED at baseline; that was the
-stale upgrade-test baseline fixed via the issue #84 pin — treat any RED result
-today as a real regression, not a known baseline.)
+**Additional gate:** `scripts/verify-sync-flow.js` is CI-gated by its own
+workflow, `.github/workflows/verify-sync-flow.yml` — separate from
+`migrations.yml`. It chains `verify-db-schema-consistency.js` and
+`verify-profile-parity.js`: a full run prints `Sync flow verification passed`
+at the end of the sync section and terminates with `All parity checks passed.`.
+Do not rely on historical baseline notes; rerun it in the branch you are
+changing and treat a RED result as a real regression until proven otherwise.
 
 ## Parity surfaces
 
@@ -343,12 +355,12 @@ profiles — it also includes the `base_*` profiles and the legacy `bcm2708`
 directory, plus the two dev-convenience copies under `database/` and
 `web/react-gui/`. All 7 are covered by `verify-db-schema-consistency.js`.)
 
-Four verifiers each check a different slice, all confirmed green in this
-worktree on 2026-07-06:
+Core verifiers each check a different slice. Run them in the current worktree
+and report current output; do not reuse old pass strings:
 
 | Verifier | What it checks | Run output |
 |---|---|---|
-| `scripts/verify-migrations.js` | Every ordered migration file is well-formed; versions contiguous from `0001` | `verify-migrations: OK (2 migrations)` |
+| `scripts/verify-migrations.js` | Every ordered migration file is well-formed; versions contiguous from `0001`; also validates checksum manifest rules when present | exit 0; current script may print a `verify-migrations: OK (...)` summary, but do not require a fixed migration count or exact string |
 | `scripts/verify-seed-replay.js` | Replays `bootstrapFresh` over the ordered migrations into a scratch DB and diffs its computed fingerprints (tables/indexes/triggers, excluding the ledger's own bookkeeping tables) against fingerprints from `seed-blank.sql` applied fresh — keeps the migration set and seed honestly equivalent | `verify-seed-replay: OK` |
 | `scripts/verify-runtime-schema-parity.js` | Compares `sync-init-fn`'s `devices_new` CHECK type-set and each flow file's whole trigger set (both profiles) against the canonical set derived from `seed-blank.sql` — fails if the boot node ever *downgrades* the seed | `verify-runtime-schema-parity: OK (2 flows: devices CHECK + trigger parity)` |
 | `scripts/verify-db-schema-consistency.js` | Hand-maintained column/index/trigger-fragment contract checked against all 7 bundled DB copies (defaults to the 7-path list above; accepts explicit paths as CLI args), plus an `EXPLAIN QUERY PLAN` check that a history query actually uses `idx_device_data_deveui_recorded_at`. Widest and slowest-changing — must be hand-extended whenever the contract changes (see Walkthrough) | all 7 paths `OK`, then `DB schema consistency verification passed` |
@@ -359,10 +371,16 @@ scripts/rehearse-devices-rebuild.test.js` (covered under Boot-DDL freeze above),
 and `scripts/verify-profile-parity.js` (byte-for-byte hash comparison of
 canonical payload files, including `files/usr/share/db` and
 `files/usr/share/flows.json`, between the `bcm2712` source-of-truth profile and
-the `bcm2709` mirror — confirmed green here).
+the `bcm2709` mirror). Rerun both in the branch you are changing.
 
-All of the above ran clean (exit 0) in this worktree on 2026-07-06 with no
-working-tree changes as a side effect.
+`scripts/verify-no-stray-ddl.js` is the provenance ratchet for DDL-like strings
+in `flows.json` and `deploy.sh`. Run it for schema work and for any flow/deploy
+edit that introduces, removes, or moves DDL markers. It is separate from
+`verify-migrations.js`; passing one does not prove the other.
+
+Do not treat a historical green run as current evidence. Re-run the relevant
+commands after changing schema, flow DDL, deploy repair, seed, or bundled DB
+surfaces.
 
 ## `deploy.sh` migration runner
 
@@ -428,6 +446,9 @@ appropriate to reach for at all.
 - **Blaming the boot DDL node for a "duplicate column" verifier failure without
   checking the test baseline first.** Issue #84 shows this exact misattribution
   happened and had to be corrected in writing.
+- **Assuming `verify-migrations.js` covers all DDL provenance.** It validates
+  ordered migration files; `verify-no-stray-ddl.js` is the guard for ad hoc DDL
+  in `flows.json` and `deploy.sh`.
 - **Updating `seed-blank.sql` (or one bundled DB) without the rest.** The
   verifiers above will catch it, but catching it in CI after the fact is more
   expensive than doing the "apply to all 7 copies + mirror" step in one commit.
@@ -451,9 +472,10 @@ change or table rebuild, everything below still applies but you are in
 `destructive`-class territory (writers-stopped gate, FK fence) — do not attempt
 that live without also reading `osi-live-ops-runbook`.
 
-1. **Write the migration.** Create
-   `database/migrations/ordered/0008__your_slug.sql` (next contiguous 4-digit
-   version) with a `-- risk: additive` header as the first line, then your
+1. **Write the migration.** Run `ls database/migrations/ordered/`, choose the
+   next contiguous four-digit version after the highest existing migration, and
+   create `database/migrations/ordered/NNNN__your_slug.sql` with a
+   `-- risk: additive` header as the first line, then your
    `CREATE TABLE`/`ALTER TABLE ... ADD COLUMN`/`CREATE INDEX`/`CREATE TRIGGER`
    statements. Prefer `IF NOT EXISTS` on object-creation statements (tables,
    indexes, triggers) so the file is safely re-runnable, matching the `0002`
@@ -469,6 +491,7 @@ that live without also reading `osi-live-ops-runbook`.
    the `bcm2712` full profile's DB over the `bcm2709` mirror so profile parity
    stays byte-for-byte (this is the exact pattern used for `0002`):
    ```bash
+   MIGRATION=database/migrations/ordered/NNNN__your_slug.sql
    cd "$(git rev-parse --show-toplevel)" && for db in \
      conf/base_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db \
      conf/base_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db \
@@ -476,7 +499,7 @@ that live without also reading `osi-live-ops-runbook`.
      conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db \
      database/farming.db \
      web/react-gui/farming.db
-   do sqlite3 -bail "$db" < database/migrations/ordered/0008__your_slug.sql && echo "OK $db"; done \
+   do sqlite3 -bail "$db" < "$MIGRATION" && echo "OK $db"; done \
      && cp conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db \
            conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db \
      && echo "OK mirror copy"
@@ -498,6 +521,7 @@ that live without also reading `osi-live-ops-runbook`.
    node scripts/verify-seed-replay.js
    node scripts/verify-runtime-schema-parity.js
    node scripts/verify-db-schema-consistency.js
+   node scripts/verify-no-stray-ddl.js
    node scripts/verify-profile-parity.js
    ```
    If your change also touches `sync-init-fn` or the `devices` CHECK, add:
@@ -523,16 +547,17 @@ node scripts/verify-migrations.js                      # migration file well-for
 node scripts/verify-seed-replay.js                      # migrations replay == seed-blank.sql
 node scripts/verify-runtime-schema-parity.js            # boot node devices CHECK + triggers == seed
 node scripts/verify-db-schema-consistency.js            # all 7 bundled DBs match hand-maintained contract
+node scripts/verify-no-stray-ddl.js                     # no ad hoc DDL-marker drift in flows/deploy surfaces
 node scripts/verify-profile-parity.js                   # bcm2712 == bcm2709 byte-for-byte
 node scripts/verify-devices-rebuild-fence.js            # boot-node rebuild is still fail-closed
 node --test scripts/rehearse-devices-rebuild.test.js    # boot-node rebuild behaves correctly against 4 seeded cases
 node --test lib/osi-migrate/__tests__/*.test.js         # runner unit tests (risk classes, atomicity, drift preflight, partial-batch retry)
-find . -name farming.db -not -path '*/node_modules/*'  | sort   # should list exactly 7 paths
-ls database/migrations/ordered/                         # current migration set (0001..0007 as of 2026-07-10)
+find . -name farming.db -not -path '*/node_modules/*'  | sort   # current bundled DB surface; investigate unexpected additions/removals
+ls database/migrations/ordered/                         # current migration set; choose next contiguous NNNN dynamically
 ls .github/workflows/ && cat .github/workflows/migrations.yml .github/workflows/verify-sync-flow.yml   # what CI actually gates (both workflows)
 grep -rn "osi-migrate\|applyPending\|bootstrapFresh\|verifyHead" scripts/ lib/ deploy.sh conf/ feeds/chirpstack-openwrt-feed/apps/node-red/files/ --exclude-dir=node_modules   # re-confirm no on-device caller (covers flows.json + init files, not just *.js/*.sh)
 ```
 
-All commands above were run against this worktree on 2026-07-06 and returned the
-outputs quoted in this document, with a clean `git status --short` afterward
-(read-only verification, no tracked-file side effects).
+The command list above is a maintenance recipe, not current proof. Re-run it
+against the branch you are changing and paste fresh output in the PR or
+execution report; old authoring-session outputs are not completion evidence.

--- a/.claude/skills/osi-server-backend-patterns/SKILL.md
+++ b/.claude/skills/osi-server-backend-patterns/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: osi-server-backend-patterns
+description: Use when osi-server backend, frontend, API, sync, Flyway migration, Spring service/controller, Gradle build, Terra, or prediction-service changes are involved.
+---
+
+# OSI Server Backend Patterns
+
+## Overview
+
+This skill is available from the `osi-os` skill tree for paired-repo awareness.
+Stage 1 Forge indexes `osi-os` only, so this server skill is ready for Stage 2
+but should not be added to the Stage 1 forge index.
+
+Verified sources to re-check before server work:
+
+- `/home/phil/Repos/osi-server/AGENTS.md`.
+- `/home/phil/Repos/osi-server/backend/build.gradle.kts`.
+- `/home/phil/Repos/osi-server/backend/src/main/resources/application.yml`.
+- `/home/phil/Repos/osi-server/architect.yaml` and `RULES.yaml`.
+- `/home/phil/Repos/osi-server/docs/agents/typescript-rule-overlays.md`.
+
+## Stack Facts
+
+- Java source/target compatibility is 17; local/runtime prerequisite is JRE 21.
+- Lombok is used throughout; prefer constructor injection with
+  `@RequiredArgsConstructor`.
+- Gradle builds the React frontend and Terra frontend into the Spring JAR
+  through `processResources`.
+- `docker/frontend/Dockerfile` and `docker/frontend/nginx.conf` are legacy and
+  unused for current serving; the Spring JAR serves `classpath:/static/`.
+
+## Flyway Discipline
+
+- Hibernate `ddl-auto` is `validate`; never switch it to `create` or `update`.
+- Migrations live in `backend/src/main/resources/db/migration/`.
+- Existing migrations include legacy numeric `V<N>__...` files and newer
+  date-versioned `V2026_MM_DD_*` files. Never renumber or edit an applied
+  migration.
+- New date-versioned migrations must sort after the highest applied production
+  version. Re-check with:
+
+```sql
+SELECT version FROM flyway_schema_history ORDER BY installed_rank DESC LIMIT 5;
+```
+
+Postgres pitfalls already hit in this repo:
+
+- Newly added enum values cannot be referenced by later DDL in the same Flyway
+  transaction. Split enum adds from the DDL that uses them.
+- Partial index predicates cannot use non-IMMUTABLE expressions such as enum
+  casts to text. Use direct enum comparison where applicable.
+- Provenance: see
+  `V2026_05_16_011__device_commands_lease_columns.sql` and
+  `V2026_05_16_012__device_commands_lease_columns_apply.sql`.
+
+## Test Conventions
+
+- Backend unit tests normally use JUnit 5, `@ExtendWith(MockitoExtension.class)`,
+  Mockito, and AssertJ.
+- For current work-request-style units, repositories are mocked; do not add a
+  database dependency unless the task explicitly needs integration coverage.
+- Backend test command:
+
+```bash
+cd /home/phil/Repos/osi-server/backend && ./gradlew test
+```
+
+Other surfaces:
+
+```bash
+cd /home/phil/Repos/osi-server/frontend && npm run test:unit
+cd /home/phil/Repos/osi-server/terra-intelligence && npm test
+cd /home/phil/Repos/osi-server/prediction-service && pytest
+```
+
+## Build Commands
+
+Full build:
+
+```bash
+cd /home/phil/Repos/osi-server/backend && ./gradlew build
+```
+
+Backend-only JAR without tests or frontend rebuilds:
+
+```bash
+cd /home/phil/Repos/osi-server/backend && ./gradlew bootJar --no-daemon -x test -x buildFrontend -x buildTerraIntelligenceFrontend
+```
+
+If Terra changed, do not skip `buildTerraIntelligenceFrontend` unless the task
+is explicitly backend-only and the skipped surface is irrelevant.
+
+## API Shape Bridge
+
+`frontend/src/services/api.ts` owns the cloud frontend compatibility bridge.
+`normaliseDevice()` and `normaliseZone()` map camelCase Spring JSON to
+snake_case legacy/edge-compatible fields. New endpoints must choose where the
+bridge lives and keep normalization in services, not presentational components.
+
+Synced resource mutations remain edge-first: cloud edits for gateway-backed
+farms are pending until the edge applies them through sync commands.
+
+## Misc Traps
+
+- `DeviceType` is a string-constant class at
+  `backend/src/main/java/org/osi/server/device/DeviceType.java`, not a Java enum.
+- `SecurityConfig` wires `new RateLimitFilter()`; Bucket4j limits live in
+  `backend/src/main/java/org/osi/server/security/RateLimitFilter.java`.
+- `DataInitializer` requires an enabled super-admin or complete
+  `SUPERADMIN_*`/`ADMIN_*` bootstrap env; otherwise startup fails.
+- No ESLint/Prettier is configured for the frontend.
+- TypeScript overlays apply in both `frontend/` and `terra-intelligence/`.
+- MQTT is edge-to-cloud only for telemetry/status/ACK. Do not revive
+  deprecated `MqttPublisherService` for cloud-to-edge commands.
+
+## Common Mistakes
+
+- Editing an applied Flyway migration instead of adding a new one.
+- Adding a date-versioned migration that sorts before already-applied versions.
+- Using a Postgres enum value in the same migration that added it.
+- Moving camelCase/snake_case compatibility into React components.
+- Treating cloud state as canonical for edge-backed synced resources.
+- Adding DB-backed tests to simple Mockito unit work without a clear need.
+- Skipping frontend or Terra tests after changing their service/type contracts.
+
+## Re-Verification
+
+Use the touched surface to choose gates, then report real output:
+
+- Backend Java/API/Flyway: `cd backend && ./gradlew test`.
+- Full packaged behavior: `cd backend && ./gradlew build`.
+- Cloud frontend: `cd frontend && npm run test:unit && npm run build`.
+- Terra: `cd terra-intelligence && npm test && npm run build`.
+- Prediction service: `cd prediction-service && pytest`.
+- Sync contract mirror changes: run the relevant `osi-os` sync contract
+  verifiers as well as server tests.

--- a/.claude/skills/osi-sync-contract-awareness/SKILL.md
+++ b/.claude/skills/osi-sync-contract-awareness/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: osi-sync-contract-awareness
+description: Use when sync, outbox/inbox/cursor, contract schemas, paired edge/cloud mirrors, pending commands, command/event payloads, resource canonicalization, or osi-os/osi-server sync changes are involved.
+---
+
+# OSI Sync Contract Awareness
+
+## Overview
+
+Treat sync as an edge-authoritative contract, not a local implementation detail.
+The edge writes canonical state first and emits outbox events; the cloud mirrors
+and queues commands until the edge applies them.
+
+Verified sources to re-check before changing behavior:
+
+- `AGENTS.md` sync model, REST endpoint table, MQTT topic table, and production rules.
+- `docs/contracts/sync-schema/README.md`.
+- `docs/contracts/sync-schema/events.schema.json`.
+- `docs/contracts/sync-schema/commands.schema.json`.
+- `docs/contracts/sync-schema/resources.schema.json`.
+- `docs/contracts/sync-schema/effect-keys.md`.
+- `docs/contracts/sync-schema/canonicalization.md`.
+- `scripts/verify-sync-contract.js`.
+- `scripts/test-contract-schemas.js`.
+- `scripts/verify-sync-op-parity.js`.
+- `scripts/verify-sync-flow.js`.
+
+## Contract Home
+
+`docs/contracts/sync-schema/` in `osi-os` is the contract source of truth.
+Mirror copies in `osi-server`, when present, must match byte-for-byte. From an
+`osi-os/.worktrees/*` checkout, do not assume `../osi-server`; locate the real
+sister repo first.
+
+Contract files:
+
+- `events.schema.json` - edge outbox event envelope and operation enum.
+- `commands.schema.json` - cloud-to-edge pending command payloads.
+- `resources.schema.json` - canonical resource shapes.
+- `effect-keys.md` - physical-effect idempotency keys and authority.
+- `canonicalization.md` - payload-hash canonicalization and golden vectors.
+
+Versioning rule: a breaking semantic change gets a new file, such as
+`canonicalization-v2.md`, and a deprecation period on both edge and cloud. Do
+not edit v1 semantics in place and hope both runtimes update atomically.
+
+## Transport Invariants
+
+- REST is the only cloud-to-edge command path.
+- The edge polls `/api/v1/sync/gateways/{eui}/pending-commands` every 30s.
+- MQTT is edge-to-cloud telemetry, heartbeat/status, and command ACK only.
+- The edge is not subscribed to the cloud broker.
+- Cloud `MqttPublisherService` is deprecated; do not use it to "fix"
+  cloud-to-edge commands.
+
+## Authority Rules
+
+- Edge writes local SQLite state first, then emits `sync_outbox` events.
+- Cloud-originated edits are pending until the edge applies them.
+- Cloud features must not directly mutate synced resource state as if the edge
+  already accepted it; queue a pending command and represent pending/applied
+  state honestly.
+- `user_uuid`, `zone_uuid`, `gateway_device_eui`, and `sync_version` are
+  contract identifiers. Tombstones use `deleted_at`, not hard deletes across
+  the sync boundary.
+
+## Idempotency Patterns
+
+- `sync_outbox` is edge-to-cloud delivery state.
+- `sync_inbox` deduplicates inbound command/event application.
+- `sync_cursor` tracks progress for history/resource streams.
+- `effect_key` deduplicates repeated physical effects across command replays.
+- Result semantics must stay stable: `applied`, `already-applied`, `rejected`
+  with a stable reason, and retryable failure metadata. Do not collapse
+  protocol rejection into delivered success.
+- Use UUID command/event keys plus `sync_version` to make retries harmless.
+
+## Trigger Gotcha
+
+The live `device_data -> sync_outbox` trigger fires on `INSERT`, not `UPDATE`.
+Historical repairs that update old rows must explicitly enqueue corrected
+`DEVICE_DATA_APPENDED` events or the cloud mirror remains stale.
+
+## Canonicalization
+
+Cross-runtime formulas and hashes live in `canonicalization.md`; do not invent
+parallel formulas in JS, TS, or Java.
+
+Examples to re-check:
+
+- SWT pF: `pF = log10(kPa * 10)`; `NULL`, non-finite, and `<= 0` kPa derive
+  `null`.
+- Edge/GUI TS reference: `web/react-gui/src/utils/swt.ts`.
+- Server Java reference: `osi-server/backend/src/main/java/org/osi/server/sync/SyncPayloadCanonicalizer.java`.
+- Server vector tests: `osi-server/backend/src/test/java/org/osi/server/sync/SyncPayloadCanonicalizerTest.java`.
+
+## Verification
+
+Run the narrowest relevant set, then report real output and exit status:
+
+```bash
+node scripts/verify-sync-contract.js
+node scripts/test-contract-schemas.js
+node scripts/verify-sync-op-parity.js
+node scripts/verify-sync-flow.js
+```
+
+When an `osi-server` mirror or Java/cloud behavior changes too:
+
+```bash
+cd /home/phil/Repos/osi-server/backend && ./gradlew test
+```
+
+For mirror-byte checks, locate the server repo and compare the actual files
+with `cmp` or `sha256sum`; do not rely on matching filenames in a stale branch.
+
+## Cross-Repo PR Rule
+
+Use paired branches/PRs for paired edge/cloud changes. Never cross-commit from
+one repo into the other. Each PR must state:
+
+- Contract files changed.
+- Whether a mirror update is required.
+- Where the paired PR/branch lands.
+- Which edge and server verification commands were run.
+
+## Common Mistakes
+
+- Treating a server-side update as canonical before the edge applies it.
+- Adding a cloud-to-edge MQTT path because it looks simpler than pending
+  commands.
+- Editing v1 contract semantics in place for a breaking change.
+- Updating `device_data` history without explicit outbox backfill events.
+- Changing pF, timestamp, UUID, EUI, or number canonicalization in one runtime
+  only.
+- Reporting `verify-sync-flow.js | tail` instead of the verifier's own exit
+  status and relevant output.

--- a/.claude/skills/osi-verification-commands/SKILL.md
+++ b/.claude/skills/osi-verification-commands/SKILL.md
@@ -49,6 +49,17 @@ repo (`scripts/`, `.github/workflows/`) plus `AGENTS.md`.
 | Codec robustness | `node scripts/verify-codec-robustness.js` | Exit 0. |
 | Communication contract | `node scripts/verify-communication-contract.js` | Exit 0. |
 | Gateway health persistence | `node --test scripts/test-gateway-health-persistence.js` | Node test exit 0. |
+| Flows size ratchet | `node scripts/verify-flows-size-ratchet.js` | Exit 0. Fails if any existing node grew, a new node exceeds 4 KB, or total embedded JS increased. |
+| Helper registration | `node scripts/verify-helper-registration.js` | Exit 0. Verifies osi-lib NAME_TO_PATH registry, loader test, and deploy.sh coverage match. |
+| Bare require scan | `node scripts/flows-bare-require-scan.js` | Exit 0. Fails if any function node uses bare `require()` instead of `osiLib.require()`. |
+| Channel manifest parity | `node scripts/verify-channel-manifest-parity.js` | Exit 0. GUI and edge manifest byte-identical. |
+| Command safety | `node scripts/verify-command-safety.js` | Exit 0. Actuator duration-bound + registry parity assertions. |
+| Heartbeat health | `node scripts/verify-heartbeat-health.js` | Exit 0. |
+| Dendro contract mirror | `node scripts/verify-dendro-contract-mirror.js` | Exit 0. |
+| Contract schemas | `node scripts/test-contract-schemas.js` | Exit 0. |
+| Device integration round-trip | `node scripts/verify-device-integration.js` | Exit 0. Full codec→normalize→write round trip for all registered devices. |
+| LSN50/Chameleon codec | `node scripts/verify-lsn50-chameleon-codec.js` | Exit 0. |
+| GUI typecheck | `cd web/react-gui && npm run typecheck` | npm exits 0. CI-gated; `vite build` does not typecheck. |
 | GUI unit tests | `cd web/react-gui && npm run test:unit` | npm exits 0. |
 | GUI build | `cd web/react-gui && npm run build` | npm exits 0. |
 | Whitespace/diff sanity | `git diff --check` | No output, exit 0. |
@@ -57,7 +68,7 @@ repo (`scripts/`, `.github/workflows/`) plus `AGENTS.md`.
 
 | Changed surface | Minimum local evidence |
 |---|---|
-| `flows.json` function, route, inject, MQTT, or wiring | Roundtrip guard, `verify-no-new-silent-catch.js`, `test-flows-wiring.js`, `check-mqtt-topics.sh` if MQTT touched, `verify-no-stray-ddl.js` if DDL-like text changed, `verify-sync-flow.js`. |
+| `flows.json` function, route, inject, MQTT, or wiring | Roundtrip guard, `verify-no-new-silent-catch.js`, `test-flows-wiring.js`, `verify-flows-size-ratchet.js`, `flows-bare-require-scan.js`, `check-mqtt-topics.sh` if MQTT touched, `verify-no-stray-ddl.js` if DDL-like text changed, `verify-sync-flow.js`. |
 | Edge schema, seed, bundled DBs, migrations, or `deploy.sh` schema repair | `verify-migrations.js`, `verify-seed-replay.js`, `verify-runtime-schema-parity.js`, `verify-db-schema-consistency.js`, `verify-no-stray-ddl.js`, `verify-profile-parity.js`. |
 | `sync-init-fn` devices-CHECK/rebuild logic | Edge schema set plus `verify-devices-rebuild-fence.js` and `node --test scripts/rehearse-devices-rebuild.test.js`. |
 | Device decoder or payload semantics | The device-specific decoder verifier plus `verify-codec-robustness.js`; add `verify-sync-flow.js` if ingest flow or DB writes changed. |

--- a/.claude/skills/osi-verification-commands/SKILL.md
+++ b/.claude/skills/osi-verification-commands/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: osi-verification-commands
+description: Use when selecting OSI OS verification commands, writing execution-report.md evidence, checking pass signals, or deciding whether a red local/base gate should stop Forge or agent execution.
+---
+
+# OSI Verification Commands
+
+## Overview
+
+Paste real command output and exit status into `execution-report.md`. Do not
+claim a gate passed from memory, from a piped command's last process, or from a
+truncated `tail` output.
+
+Verified commands and pass signals come from scripts and workflow files in this
+repo (`scripts/`, `.github/workflows/`) plus `AGENTS.md`.
+
+## Rules
+
+- Run commands from the repo root unless the row says otherwise.
+- Check the command's own exit code directly. Never prove success with
+  `command | tail`, `grep OK`, or another pipe unless `set -o pipefail` and the
+  original status are explicitly captured.
+- Paste enough output into `execution-report.md` to show the pass signal and
+  any relevant warning context.
+- If a required verifier is red on the branch base, stop and report
+  `red-on-base`; do not bury the baseline failure inside your patch.
+- If a verifier is not relevant to the changed surface, say why instead of
+  running broad, expensive gates as decoration.
+
+## Command Table
+
+| Surface | Command | Pass signal |
+|---|---|---|
+| Full sync/flow contract | `node scripts/verify-sync-flow.js` | Prints `Sync flow verification passed` in its own section and exits 0; it also chains profile parity, so a healthy full run ends with `All parity checks passed.` |
+| Profile payload parity | `node scripts/verify-profile-parity.js` | Ends `All parity checks passed.`, exit 0. |
+| MQTT IN topic compliance | `scripts/check-mqtt-topics.sh` | `OK:` lines for checked flow copies, exit 0. |
+| Flow wiring guards | `node scripts/test-flows-wiring.js` | Ends `PASS: STREGA wiring + osiDb close + WS2/WS3 wiring guards all passed`, exit 0. |
+| Silent catch ratchet | `node scripts/verify-no-new-silent-catch.js` | Exit 0. Any new or worsened empty catch in maintained flow nodes is a stop. |
+| Stray DDL ratchet | `node scripts/verify-no-stray-ddl.js` | Exit 0. A new DDL marker in `flows.json` or `deploy.sh` must be intentional and reviewed. |
+| Migration file structure | `node scripts/verify-migrations.js` | Exit 0. Do not require a specific success string; current versions may print an OK line with migration/checksum details. |
+| Seed replay parity | `node scripts/verify-seed-replay.js` | `verify-seed-replay: OK`, exit 0. |
+| Runtime schema parity | `node scripts/verify-runtime-schema-parity.js` | Exit 0; current healthy output includes an OK summary for flow devices CHECK and trigger parity. |
+| Bundled DB schema consistency | `node scripts/verify-db-schema-consistency.js` | Ends `DB schema consistency verification passed`, exit 0. |
+| Devices CHECK rebuild fence | `node scripts/verify-devices-rebuild-fence.js` | `verify-devices-rebuild-fence: OK (<n> flows)`, exit 0. Required when touching `sync-init-fn` devices-CHECK logic. |
+| Devices CHECK rebuild rehearsal | `node --test scripts/rehearse-devices-rebuild.test.js` | Node test exit 0. Required with `verify-devices-rebuild-fence.js` for `sync-init-fn` devices-CHECK touches. |
+| STREGA Gen1 decoder | `node scripts/verify-strega-gen1.js` | Exit 0. |
+| Aqua-Scope LoRain decoder | `node scripts/verify-lorain-codec.js` | Exit 0. |
+| SENSECAP S2120 decoder | `node scripts/verify-s2120-codec.js` | Exit 0. |
+| Codec robustness | `node scripts/verify-codec-robustness.js` | Exit 0. |
+| Communication contract | `node scripts/verify-communication-contract.js` | Exit 0. |
+| Gateway health persistence | `node --test scripts/test-gateway-health-persistence.js` | Node test exit 0. |
+| GUI unit tests | `cd web/react-gui && npm run test:unit` | npm exits 0. |
+| GUI build | `cd web/react-gui && npm run build` | npm exits 0. |
+| Whitespace/diff sanity | `git diff --check` | No output, exit 0. |
+
+## Surface Selection
+
+| Changed surface | Minimum local evidence |
+|---|---|
+| `flows.json` function, route, inject, MQTT, or wiring | Roundtrip guard, `verify-no-new-silent-catch.js`, `test-flows-wiring.js`, `check-mqtt-topics.sh` if MQTT touched, `verify-no-stray-ddl.js` if DDL-like text changed, `verify-sync-flow.js`. |
+| Edge schema, seed, bundled DBs, migrations, or `deploy.sh` schema repair | `verify-migrations.js`, `verify-seed-replay.js`, `verify-runtime-schema-parity.js`, `verify-db-schema-consistency.js`, `verify-no-stray-ddl.js`, `verify-profile-parity.js`. |
+| `sync-init-fn` devices-CHECK/rebuild logic | Edge schema set plus `verify-devices-rebuild-fence.js` and `node --test scripts/rehearse-devices-rebuild.test.js`. |
+| Device decoder or payload semantics | The device-specific decoder verifier plus `verify-codec-robustness.js`; add `verify-sync-flow.js` if ingest flow or DB writes changed. |
+| React GUI | `npm run test:unit` and `npm run build` from `web/react-gui`; add contract/edge verifiers if GUI semantics depend on changed edge fields. |
+| Sync contract docs or payload schemas | `verify-communication-contract.js` plus the edge/server tests named by the contract change. |
+| Server/backend companion work | Use the sister `osi-server` repo gates for backend changes. OSI OS edge verifiers do not prove cloud Java/Postgres behavior. |
+
+## Common Mistakes
+
+- Requiring `verify-migrations.js` to print an exact OK string; use exit 0
+  because the script's summary can include current migration and checksum
+  details.
+- Treating `verify-sync-flow.js | tail -1` as proof. The pipe can hide the real
+  exit code and the final line can come from chained profile parity.
+- Ignoring a red verifier because it was "red before." Red-on-base is a
+  stop-and-report condition unless the task explicitly scopes baseline repair.
+- Omitting `verify-s2120-codec.js` or `verify-codec-robustness.js` for decoder
+  work because `verify-sync-flow.js` happened to pass.


### PR DESCRIPTION
## Summary
- Adds Forge Stage 1 always-inject skills: osi-forge-boundaries, osi-common-pitfalls, osi-verification-commands.
- Adds Claude-selectable skills: osi-sync-contract-awareness, osi-react-gui-patterns, osi-server-backend-patterns.
- Updates existing OSI skills for silent-catch, schema inventory, stray-DDL, and stale agronomy guidance.

## Test plan
- [x] Skills have YAML frontmatter and readable first four lines
- [x] Broken internal `See \`osi-...` reference grep returned no hits
- [x] `git diff --check`

Verification run:
```bash
git diff --check
for skill in .claude/skills/*/SKILL.md; do head -4 "$skill" >/dev/null || exit 1; done
grep -r 'See `osi-' .claude/skills/ | grep -v SKILL.md || true
```

## Forge checklist
- [x] Skills have correct YAML frontmatter and verified claims
- [ ] ForgeService.claim() uses pessimistic lock (server PR)
- [ ] ISSUE_OPEN -> AWAITING_AGENT dispatch works (server PR)
- [ ] Controller credential separation verified (server PR)
- [ ] Post-gate scans diff + execution-report.md + PR body (server PR)
- [ ] Controller re-runs tests independently (server PR)
- [ ] Ephemeral git auth (server PR)