### PR TITLE
feat(deploy): Option B Stage 1 deploy-time migration runner (#88)

### DIFF
--- a/.claude/skills/osi-schema-change-control/SKILL.md
+++ b/.claude/skills/osi-schema-change-control/SKILL.md
@@ -199,10 +199,12 @@ already-integrity-checked backup.
 migration named by that manifest, `scripts/migrate-cli.js`,
 `scripts/baseline-existing-db.js`, `scripts/repair-sync-outbox-v2.js`,
 `scripts/semantic-schema-compare.js`, and the required `lib/osi-migrate` modules.
-It then stops Node-RED, checkpoints WAL, inspects `schema_migrations`, performs
-the temporary pre-baseline `sync_outbox` v2-column repair and semantic baseline
-only when the DB has no ledger rows yet, and calls `migrate-cli.js` with
-`--backup-dir /data/backups/migrate`.
+It ensures the `sqlite3` CLI is present, attempting `opkg install sqlite3-cli`
+before refusing. It then stops Node-RED, waits up to 30 seconds for the process to
+exit, checkpoints WAL, inspects `schema_migrations`, performs the temporary
+pre-baseline `sync_outbox` v2-column repair and semantic baseline only when the
+DB has no ledger rows yet, and calls `migrate-cli.js` with `--backup-dir
+/data/backups/migrate`.
 
 That is still **not** a boot-time path. `flows.json`, the Node-RED init script,
 and `sync-init-fn` must not call `applyPending` or grow new schema behavior.
@@ -372,11 +374,12 @@ on an existing DB, it now uses one path: `run_schema_migration()`.
 2. It fetches the Stage 0 pre-baseline helpers and the required
    `lib/osi-migrate` modules into `$TMP_DIR`, so the on-device script runs the
    same ledgered code as CI.
-3. It stops Node-RED before any live DB write, chains its restart with the
-   existing cleanup trap, checkpoints WAL, inspects `schema_migrations`, and
-   only on DBs with no ledger rows runs `repair-sync-outbox-v2.js` followed by
-   `baseline-existing-db.js`. It checkpoints again, then invokes
-   `migrate-cli.js`.
+3. It ensures the `sqlite3` CLI exists (`opkg install sqlite3-cli` if needed),
+   stops Node-RED before any live DB write, chains its restart with the existing
+   cleanup trap, waits up to 30 seconds for the process to exit, checkpoints WAL,
+   inspects `schema_migrations`, and only on DBs with no ledger rows runs
+   `repair-sync-outbox-v2.js` followed by `baseline-existing-db.js`. It
+   checkpoints again, then invokes `migrate-cli.js`.
 4. `migrate-cli.js` calls `applyPending(..., writersStopped: true)` and uses a
    persistent pre-migration byte-image backup directory:
    `/data/backups/migrate` (or `MIGRATE_BACKUP_DIR` if explicitly overridden).

--- a/.claude/skills/osi-schema-change-control/SKILL.md
+++ b/.claude/skills/osi-schema-change-control/SKILL.md
@@ -13,12 +13,13 @@ farm history (irrigation events, sensor readings, dendrometer calibration) is
 irreplaceable. Because of that, edge SQLite schema is under change control, not
 free-form DDL.
 
-As of 2026-07-06 there are two overlapping mechanisms with different scopes:
+As of 2026-07-10 there are two overlapping mechanisms with different scopes:
 
 1. **The ordered migration runner** (`lib/osi-migrate` + `database/migrations/ordered/`) —
    the *governed, executable schema authority* per
-   `docs/adr/2026-06-30-schema-and-contract-ownership.md`. It is CI/tooling-time
-   only today (see "Key fact" below); it does not run on a booting Pi.
+   `docs/adr/2026-06-30-schema-and-contract-ownership.md`. CI verifies it, and
+   `deploy.sh` now fetches and runs it at deploy time through
+   `run_schema_migration()`; it still does not run from the Node-RED boot path.
 2. **The Node-RED boot node `sync-init-fn`** ("Sync Init Schema + Triggers") — a
    legacy inline-DDL block that runs on every boot on every live Pi. It is FROZEN
    for new schema behavior (one narrow, sanctioned exception below).
@@ -64,7 +65,7 @@ outside the one sanctioned exception.
 |---|---|
 | Hand-edit `schema_object_fingerprints` | It is a computed baseline (SHA-256 over live DDL + `PRAGMA table_xinfo`/`foreign_key_list`/`index_list`/`index_xinfo`). A hand edit desyncs the stamp from the real schema and the next `applyPending` either falsely passes or falsely refuses. The only sanctioned re-baselines are `scripts/restamp-fingerprints.js` (recompute fingerprints of a confirmed-good live schema) and `scripts/baseline-existing-db.js` (semantic-gated first baseline of a pre-ledger device — Option B Stage 0, spec 2026-07-07). |
 | Reseed or overwrite `/data/db/farming.db` on a provisioned Pi | `deploy.sh`'s `seed_db_if_missing` only seeds when the file is absent *and* no WAL/SHM/journal sidecars exist; it refuses otherwise. Overwriting destroys irreplaceable farm history. |
-| Add new schema behavior to `sync-init-fn` (the boot node) | It is FROZEN (AGENTS.md "Boot-DDL freeze"). New schema goes through the migration runner's ordered files, even though the runner doesn't execute on-device yet — freezing the boot node is what makes eventual cutover (Option B) tractable. |
+| Add new schema behavior to `sync-init-fn` (the boot node) | It is FROZEN (AGENTS.md "Boot-DDL freeze"). New schema goes through the migration runner's ordered files and deploy-time runner path, not boot-time inline DDL. |
 | Modify an already-merged `database/migrations/ordered/NNNN__slug.sql` file | Migrations are checksummed (SHA-256 of the raw file bytes, `lib/osi-migrate/migrations-loader.js`). Changing a merged file makes the ledger's stored checksum mismatch the file on next apply, which the runner treats as `repair_required` and refuses to proceed past. |
 | Update `seed-blank.sql` or one bundled DB without the others | `verify-seed-replay.js` and `verify-db-schema-consistency.js` both fail if any of the 7 bundled copies drifts from the seed/migration-replay schema. One home for the fact: keep all copies byte/fingerprint-identical in the same commit. |
 | Rebuild a parent table (drop/rename swap) without the FK fence | Without `PRAGMA foreign_keys=OFF` held across the swap, `ON DELETE CASCADE` on child tables (`device_data`, `chameleon_readings`) silently wipes their rows when the parent is dropped. This caused a documented field history-loss incident (`docs/operations/edge-history-retention.md`). |
@@ -74,12 +75,12 @@ outside the one sanctioned exception.
 
 | Change | Mechanism | Notes |
 |---|---|---|
-| New table, column, index, view, or trigger (append-only) | New `additive` ordered migration + `seed-blank.sql` + all 7 bundled DBs | No backup, no writers-stopped gate required by the runner itself, but you still must keep parity surfaces in sync (see Walkthrough). |
-| Drop/rename/rebuild a table, or alter a CHECK/constraint that SQLite can't `ALTER` in place | New `destructive` ordered migration | Requires `writersStopped=true`; take a backup; FK fence. Since the runner does not run on-device today, on-device destructive changes are not currently supported outside the one sanctioned devices-CHECK rebuild (below) — anything else requires the Option B boot-path project; do not invent an ad hoc path (`ensure_*` functions are additive-only). |
-| Backfill / data correction against existing rows | New `data` ordered migration | Backup + normal transaction; no FK fence; no writers-stopped gate; must be idempotent against the pre-migration row shape. |
+| New table, column, index, view, or trigger (append-only) | New `additive` ordered migration + `seed-blank.sql` + all 7 bundled DBs | No backup, no writers-stopped gate required by the runner itself, but you still must keep parity surfaces in sync (see Walkthrough). Already-provisioned Pis receive it through `deploy.sh` `run_schema_migration()`. |
+| Drop/rename/rebuild a table, or alter a CHECK/constraint that SQLite can't `ALTER` in place | New `destructive` ordered migration | Requires `writersStopped=true`; FK fence in the migration. `deploy.sh` stops Node-RED, checkpoints WAL, and invokes `scripts/migrate-cli.js` with a persistent pre-migration backup under `/data/backups/migrate`; do not invent an ad hoc path. |
+| Backfill / data correction against existing rows | New `data` ordered migration | Persistent backup + normal transaction; no FK fence; must be idempotent against the pre-migration row shape. Deploy-time delivery uses the same `run_schema_migration()` path. |
 | `devices.type_id` CHECK needs a new device type on a **live** Pi today | The guarded fail-closed rebuild already shipped in `sync-init-fn` (sanctioned exception) + `scripts/repair-pi-schema.js` entry | Do not add a second rebuild path; extend the existing `REQUIRED_TYPES` set and its parity surfaces (`verify-runtime-schema-parity.js`, `verify-db-schema-consistency.js`) — subject to the full boot-node merge gate below (four verifiers + production-copy rehearsal). |
-| Idempotent additive repair needed on live Pis at deploy time (e.g. a new column) | `deploy.sh` `ensure_*` function | Follows the `ensure_dendro_schema` / `ensure_gateway_health_schema` precedent: `ALTER TABLE ... ADD COLUMN`, catching `duplicate column name` as a no-op. Never used for anything destructive. |
-| Any other on-device schema mutation | Not currently supported without a boot-path project | See the Option B boot-path project in the ADR (`docs/adr/2026-06-30-schema-and-contract-ownership.md`); do not invent a new ad hoc mutation path. |
+| Idempotent additive repair needed on live Pis at deploy time (e.g. a new column) | New ordered migration delivered by `deploy.sh` `run_schema_migration()` | Do not add `ensure_*` functions. The deploy runner fetches `CHECKSUMS.json`, all ordered migrations, Stage 0 baseline helpers, and `lib/osi-migrate`, then applies pending migrations once writers are stopped. |
+| Any other on-device schema mutation | Ordered migration runner path, or no change | If the runner cannot express it safely, stop and design the schema project first; do not add inline DDL to `deploy.sh`, `flows.json`, or init scripts. |
 
 ## The model: ownership, migrations, risk classes
 
@@ -109,8 +110,7 @@ by the ADR but was never committed to the repo — do not go looking for it.)
 ### Ordered migrations: format and risk-class declaration
 
 Files live at `database/migrations/ordered/NNNN__slug.sql` — currently
-`0001__baseline.sql` (the full schema equivalent of `seed-blank.sql` at the time
-the runner was introduced) and `0002__gateway_health.sql`. The filename format is
+`0001__baseline.sql` through `0007__analysis_views.sql`. The filename format is
 enforced by a regex in `lib/osi-migrate/migrations-loader.js`:
 `^(\d{4})__([a-z0-9_]+)\.sql$` — four-digit version, double underscore, lowercase
 slug. Versions must be unique and are sorted numerically, not lexically.
@@ -192,25 +192,22 @@ per-file resilient (one un-removable sibling logs and continues) and the whole
 prune step is wrapped so a directory-level failure never fails an
 already-integrity-checked backup.
 
-### Key fact: the runner does not run on a booting Pi
+### Key fact: deploy-time runner, not boot-time runner
 
-Verified by grep: `applyPending`, `bootstrapFresh`, and `verifyHead` (the only
-exports of `lib/osi-migrate/index.js`) are referenced **only** inside
-`lib/osi-migrate/` itself, its `__tests__/`, and three scripts:
-`scripts/verify-seed-replay.js` (calls `bootstrapFresh` against a scratch DB and
-compares fingerprints to `seed-blank.sql`, `appVersion: 'ci'`),
-`scripts/restamp-fingerprints.js` (calls `syncFingerprints` directly, not the
-apply path, for the stale-stamp recovery verb), and the runner's own test suite.
-`deploy.sh` and `flows.json`/`init.d` contain **zero** references to
-`osi-migrate`/`applyPending` — confirmed by grepping the whole repo. `deploy.sh`'s
-own `ensure_gateway_health_schema` function fetches
-`database/migrations/ordered/0002__gateway_health.sql` and executes its raw SQL
-directly via a small inline Node/`sqlite3` script, guarded by a regex that refuses
-to run anything except an `additive`-headed file — it does not call the ledgered
-runner at all. So today there is no dormant on-boot migration risk: the runner is
-strictly a CI/tooling-time mechanism (`.github/workflows/migrations.yml` runs
-`verify-migrations.js`, `verify-seed-replay.js`, and the runner's own
-`node --test` suite on every push/PR to `main`/`master`).
+`deploy.sh` is now the on-device delivery path for ordered migrations. Its
+`run_schema_migration()` function fetches `CHECKSUMS.json`, every ordered
+migration named by that manifest, `scripts/migrate-cli.js`,
+`scripts/baseline-existing-db.js`, `scripts/repair-sync-outbox-v2.js`,
+`scripts/semantic-schema-compare.js`, and the required `lib/osi-migrate` modules.
+It then stops Node-RED, checkpoints WAL, inspects `schema_migrations`, performs
+the temporary pre-baseline `sync_outbox` v2-column repair and semantic baseline
+only when the DB has no ledger rows yet, and calls `migrate-cli.js` with
+`--backup-dir /data/backups/migrate`.
+
+That is still **not** a boot-time path. `flows.json`, the Node-RED init script,
+and `sync-init-fn` must not call `applyPending` or grow new schema behavior.
+Boot remains limited to the frozen legacy node plus the already-sanctioned
+devices-CHECK safety exception.
 
 ## Boot-DDL freeze (the other schema path, and why it's frozen)
 
@@ -222,9 +219,8 @@ present byte-identically in both
 against a schema that already has the column (errors from these are swallowed in
 a `try {...} catch (_) {}` sweep). This node is **FROZEN**: do not add new schema
 behavior to it. New schema changes go through the ordered-migration runner's
-files even though, per the Key Fact above, nothing executes those files on a live
-Pi yet — the migration files remain the durable, checksummed record of intended
-schema even while the boot path itself is still the inline node.
+files and the deploy-time runner path. That freeze is the reason the migration
+runner cutover stays tractable.
 
 ### Incident history (one line each, factual)
 
@@ -366,38 +362,33 @@ the `bcm2709` mirror — confirmed green here).
 All of the above ran clean (exit 0) in this worktree on 2026-07-06 with no
 working-tree changes as a side effect.
 
-## `deploy.sh` idempotent repair
+## `deploy.sh` migration runner
 
-`deploy.sh` never reseeds a provisioned Pi (see NEVER-do list). What it *does* do
-is repair schema drift on an already-provisioned live DB, at deploy time, via a
-family of `ensure_*` functions (`ensure_dendro_schema`,
-`ensure_zone_irrigation_calibration_schema`, `ensure_analysis_views_schema`,
-`ensure_chameleon_schema`, `ensure_gateway_health_schema`), all invoked
-unconditionally near the end of the script. Each:
+`deploy.sh` never reseeds a provisioned Pi (see NEVER-do list). For schema catchup
+on an existing DB, it now uses one path: `run_schema_migration()`.
 
-1. Skips entirely if `$DB_PATH` (`/data/db/farming.db`) doesn't exist yet (a
-   fresh device gets the full schema from the seed instead).
-2. `ensure_gateway_health_schema` fetches
-   `database/migrations/ordered/0002__gateway_health.sql` and executes its raw
-   SQL directly, after asserting the file's header is exactly `-- risk:
-   additive` ("Single source of DDL truth: execute the ordered-migration file
-   itself") and hard-refusing (`process.exit(1)`) otherwise — the one place an
-   `ensure_*` function reuses a migration file verbatim rather than hand-writing
-   SQL inline.
-3. Other `ensure_*` functions (e.g. `ensure_dendro_schema`) hand-write
-   idempotent `ALTER TABLE ... ADD COLUMN` statements in an inline
-   Node/`sqlite3` heredoc, explicitly catching and ignoring a `duplicate column
-   name` error so re-running deploy on an already-repaired Pi is a no-op, then
-   backfill newly-added columns from existing data, then assert (throw if not)
-   the expected columns exist afterward.
-4. Sets `busy_timeout=5000` before any statement, matching the Node-RED runtime
-   helper's 5 s busy timeout.
+1. It fetches the ordered migration corpus from
+   `database/migrations/ordered/CHECKSUMS.json` instead of carrying inline DDL.
+2. It fetches the Stage 0 pre-baseline helpers and the required
+   `lib/osi-migrate` modules into `$TMP_DIR`, so the on-device script runs the
+   same ledgered code as CI.
+3. It stops Node-RED before any live DB write, chains its restart with the
+   existing cleanup trap, checkpoints WAL, inspects `schema_migrations`, and
+   only on DBs with no ledger rows runs `repair-sync-outbox-v2.js` followed by
+   `baseline-existing-db.js`. It checkpoints again, then invokes
+   `migrate-cli.js`.
+4. `migrate-cli.js` calls `applyPending(..., writersStopped: true)` and uses a
+   persistent pre-migration byte-image backup directory:
+   `/data/backups/migrate` (or `MIGRATE_BACKUP_DIR` if explicitly overridden).
+5. If migration fails after a restoreable destructive/data backup, deploy exits
+   after restarting Node-RED. If restore integrity itself fails (`migrate-cli`
+   rc=3), deploy restores the cleanup trap and intentionally leaves Node-RED
+   stopped for operator intervention.
 
-**Boundary:** `deploy.sh` repairs an existing live DB; it does not create one over
-an existing file, and none of the `ensure_*` functions are destructive-class
-(table rebuild/drop) — that class is only handled today by the sanctioned
-boot-node exception. The actual live-deploy procedure (how to run `deploy.sh`
-against a specific Pi, safely) is out of scope here — see `osi-live-ops-runbook`.
+**Boundary:** `deploy.sh` is the deploy-time migration runner path; it must stay
+free of inline `CREATE TABLE` / `ALTER TABLE` / `DROP TRIGGER` schema snippets.
+The actual live-deploy procedure (how to run `deploy.sh` against a specific Pi,
+safely) is out of scope here — see `osi-live-ops-runbook`.
 
 ## Restamp rules
 
@@ -421,9 +412,9 @@ appropriate to reach for at all.
 
 ## Common mistakes
 
-- **Assuming the migration runner is "live."** It is CI/tooling-time only today
-  (Key Fact above); nothing on-device calls `applyPending`. A `destructive`/`data`
-  migration will not run automatically on the next Pi boot.
+- **Assuming the migration runner runs on boot.** It runs during `deploy.sh`, not
+  during Node-RED startup. A `destructive`/`data` migration will not run
+  automatically on the next Pi boot.
 - **Treating `sync-init-fn`'s 93 `ADD COLUMN`s as a template to copy.** Frozen
   legacy debt (81 redundant with the seed, per AGENTS.md), not a pattern to
   extend — new additive schema goes in an ordered migration, not ADD COLUMN #94.
@@ -458,14 +449,14 @@ change or table rebuild, everything below still applies but you are in
 that live without also reading `osi-live-ops-runbook`.
 
 1. **Write the migration.** Create
-   `database/migrations/ordered/0003__your_slug.sql` (next contiguous 4-digit
+   `database/migrations/ordered/0008__your_slug.sql` (next contiguous 4-digit
    version) with a `-- risk: additive` header as the first line, then your
    `CREATE TABLE`/`ALTER TABLE ... ADD COLUMN`/`CREATE INDEX`/`CREATE TRIGGER`
    statements. Prefer `IF NOT EXISTS` on object-creation statements (tables,
    indexes, triggers) so the file is safely re-runnable, matching the `0002`
-   precedent. `ALTER TABLE ... ADD COLUMN` has no `IF NOT EXISTS` in SQLite —
-   its live-Pi delivery goes through a deploy-time `ensure_*` function that
-   treats `duplicate column name` as a no-op (see the decision table above).
+   precedent. `ALTER TABLE ... ADD COLUMN` has no `IF NOT EXISTS` in SQLite, but
+   live-Pi delivery still goes through the ordered migration runner; do not add a
+   deploy-time `ensure_*` duplicate-column wrapper.
 2. **Update `database/seed-blank.sql`.** Append the equivalent DDL so a fresh
    database created from the seed ends up schema-identical to one built by
    replaying all ordered migrations. `verify-seed-replay.js` is the automatic
@@ -482,7 +473,7 @@ that live without also reading `osi-live-ops-runbook`.
      conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db \
      database/farming.db \
      web/react-gui/farming.db
-   do sqlite3 -bail "$db" < database/migrations/ordered/0003__your_slug.sql && echo "OK $db"; done \
+   do sqlite3 -bail "$db" < database/migrations/ordered/0008__your_slug.sql && echo "OK $db"; done \
      && cp conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db \
            conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db \
      && echo "OK mirror copy"
@@ -494,11 +485,10 @@ that live without also reading `osi-live-ops-runbook`.
    the migration file.
 5. **Add TypeScript types** in `web/react-gui/src/types/farming.ts` if the new
    column/table is GUI-visible.
-6. **If a live Pi needs the column before its next full schema catch-up**, add or
-   extend a `deploy.sh` `ensure_*` function following the `ensure_gateway_health_schema`
-   / `ensure_dendro_schema` precedent (idempotent `ADD COLUMN`, catch `duplicate
-   column name`, assert presence afterward). This is optional and only needed for
-   changes that must reach already-provisioned Pis outside a full reseed.
+6. **Live Pi delivery is deploy-runner delivery.** Do not add or extend
+   `deploy.sh` `ensure_*` functions. `deploy.sh` fetches and runs the ordered
+   migrations, so the migration file is the live repair path for already
+   provisioned Pis.
 7. **Run the verifier set** and confirm each prints its OK line:
    ```bash
    node scripts/verify-migrations.js
@@ -535,7 +525,7 @@ node scripts/verify-devices-rebuild-fence.js            # boot-node rebuild is s
 node --test scripts/rehearse-devices-rebuild.test.js    # boot-node rebuild behaves correctly against 4 seeded cases
 node --test lib/osi-migrate/__tests__/*.test.js         # runner unit tests (risk classes, atomicity, drift preflight, partial-batch retry)
 find . -name farming.db -not -path '*/node_modules/*'  | sort   # should list exactly 7 paths
-ls database/migrations/ordered/                         # current migration set (0001, 0002 as of 2026-07-06)
+ls database/migrations/ordered/                         # current migration set (0001..0007 as of 2026-07-10)
 ls .github/workflows/ && cat .github/workflows/migrations.yml .github/workflows/verify-sync-flow.yml   # what CI actually gates (both workflows)
 grep -rn "osi-migrate\|applyPending\|bootstrapFresh\|verifyHead" scripts/ lib/ deploy.sh conf/ feeds/chirpstack-openwrt-feed/apps/node-red/files/ --exclude-dir=node_modules   # re-confirm no on-device caller (covers flows.json + init files, not just *.js/*.sh)
 ```

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Fetch migration base ref
         run: git fetch --no-tags origin main:refs/remotes/origin/main
       - run: node --test lib/osi-migrate/__tests__/*.test.js
-      - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js scripts/verify-migrations.test.js scripts/verify-no-stray-ddl.test.js scripts/verify-no-new-silent-catch.test.js scripts/test-error-recording-flow.js scripts/flows-bare-require-scan.test.js scripts/verify-helper-registration.test.js scripts/semantic-schema-compare.test.js scripts/repair-sync-outbox-v2.test.js scripts/baseline-existing-db.test.js
+      - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js scripts/verify-migrations.test.js scripts/verify-no-stray-ddl.test.js scripts/verify-no-new-silent-catch.test.js scripts/test-error-recording-flow.js scripts/flows-bare-require-scan.test.js scripts/verify-helper-registration.test.js scripts/semantic-schema-compare.test.js scripts/repair-sync-outbox-v2.test.js scripts/baseline-existing-db.test.js scripts/migrate-cli.test.js scripts/test-deploy-migration-wiring.js
       - run: node scripts/test-history-helper.js
       - run: node --test scripts/test-health-helper.js
       - run: node scripts/verify-migrations.js

--- a/deploy.sh
+++ b/deploy.sh
@@ -161,6 +161,22 @@ checkpoint_live_db() {
     fi
 }
 
+ensure_sqlite3_cli() {
+    if command -v sqlite3 >/dev/null 2>&1; then
+        return 0
+    fi
+    if command -v opkg >/dev/null 2>&1; then
+        echo "sqlite3 CLI absent; installing sqlite3-cli via opkg"
+        opkg update >/dev/null 2>&1 || true
+        opkg install sqlite3-cli >/dev/null 2>&1 || true
+    fi
+    if command -v sqlite3 >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "ERROR: sqlite3 CLI unavailable and could not be installed; refusing schema migration" >&2
+    return 1
+}
+
 fetch_migration_runner() {
     migrations_dir="$TMP_DIR/database/migrations/ordered"
     mkdir -p "$migrations_dir" "$TMP_DIR/scripts" "$TMP_DIR/lib/osi-migrate"
@@ -204,8 +220,7 @@ run_schema_migration() {
         echo "SKIP: no live database at $DB_PATH"
         return 0
     fi
-    if ! command -v sqlite3 >/dev/null 2>&1; then
-        echo "ERROR: sqlite3 CLI is required for schema migrations" >&2
+    if ! ensure_sqlite3_cli; then
         return 1
     fi
     if ! command -v node >/dev/null 2>&1; then
@@ -228,7 +243,15 @@ run_schema_migration() {
         echo "ERROR: failed to stop Node-RED before schema migration" >&2
         return 1
     fi
-    sleep 2
+    stop_wait=0
+    while command -v pgrep >/dev/null 2>&1 && pgrep -f 'node-red' >/dev/null 2>&1 && [ "$stop_wait" -lt 30 ]; do
+        sleep 1
+        stop_wait=$((stop_wait + 1))
+    done
+    if command -v pgrep >/dev/null 2>&1 && pgrep -f 'node-red' >/dev/null 2>&1; then
+        echo "ERROR: Node-RED did not stop within 30s; refusing schema migration" >&2
+        return 1
+    fi
 
     if ! checkpoint_live_db; then
         return 1

--- a/deploy.sh
+++ b/deploy.sh
@@ -126,446 +126,158 @@ seed_db_if_missing() {
     echo "OK: seeded new database at $DB_PATH"
 }
 
-ensure_dendro_schema() {
-    echo "--- Live dendrometer schema repair ---"
+node_red_restart_needed=0
+
+restore_deploy_trap() {
+    trap cleanup EXIT INT TERM
+}
+
+restart_node_red() {
+    if [ "$node_red_restart_needed" != "1" ]; then
+        return 0
+    fi
+    node_red_restart_needed=0
+    echo "--- Restart Node-RED after schema migration ---"
+    if /etc/init.d/node-red start; then
+        echo "OK"
+        return 0
+    fi
+    echo "ERROR: Node-RED did not start after schema migration" >&2
+    return 1
+}
+
+checkpoint_live_db() {
+    if ! sqlite3 "$DB_PATH" "PRAGMA wal_checkpoint(TRUNCATE);" >/dev/null; then
+        echo "ERROR: failed to checkpoint $DB_PATH before migration" >&2
+        return 1
+    fi
+    if ! integrity="$(sqlite3 "$DB_PATH" "PRAGMA integrity_check;")"; then
+        echo "ERROR: failed to run integrity_check on $DB_PATH before migration" >&2
+        return 1
+    fi
+    if [ "$integrity" != "ok" ]; then
+        echo "ERROR: $DB_PATH integrity_check failed before migration: $integrity" >&2
+        return 1
+    fi
+}
+
+fetch_migration_runner() {
+    migrations_dir="$TMP_DIR/database/migrations/ordered"
+    mkdir -p "$migrations_dir" "$TMP_DIR/scripts" "$TMP_DIR/lib/osi-migrate"
+
+    fetch_required "Migration checksum manifest" \
+        "database/migrations/ordered/CHECKSUMS.json" \
+        "$migrations_dir/CHECKSUMS.json"
+
+    for migration in $(node -e "const fs=require('fs'); const manifest=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); for (const name of Object.keys(manifest).sort()) console.log(name);" "$migrations_dir/CHECKSUMS.json"); do
+        fetch_required "Migration $migration" \
+            "database/migrations/ordered/$migration" \
+            "$migrations_dir/$migration"
+    done
+
+    for script in \
+        baseline-existing-db.js \
+        repair-sync-outbox-v2.js \
+        migrate-cli.js \
+        semantic-schema-compare.js
+    do
+        fetch_required "Migration script $script" "scripts/$script" "$TMP_DIR/scripts/$script"
+    done
+
+    for module in \
+        backup.js \
+        fingerprints.js \
+        index.js \
+        ledger.js \
+        migrations-loader.js \
+        runner-iface.js \
+        runner.js \
+        sql-normalize.js
+    do
+        fetch_required "Migration runner module $module" "lib/osi-migrate/$module" "$TMP_DIR/lib/osi-migrate/$module"
+    done
+}
+
+run_schema_migration() {
+    echo "--- Edge schema migration runner ---"
     if [ ! -e "$DB_PATH" ]; then
         echo "SKIP: no live database at $DB_PATH"
         return 0
     fi
-    node <<'NODE'
-const fs = require('fs');
-const dbPath = '/data/db/farming.db';
-if (!fs.existsSync(dbPath)) {
-  console.log('SKIP: no live database at ' + dbPath);
-  process.exit(0);
-}
-const sqlite3 = require('/srv/node-red/node_modules/sqlite3');
-const db = new sqlite3.Database(dbPath);
-function run(sql) {
-  return new Promise((resolve, reject) => db.run(sql, (err) => err ? reject(err) : resolve()));
-}
-function all(sql) {
-  return new Promise((resolve, reject) => db.all(sql, (err, rows) => err ? reject(err) : resolve(rows || [])));
-}
-(async () => {
-  await run('PRAGMA busy_timeout=5000');
-  for (const sql of [
-    'ALTER TABLE devices ADD COLUMN dendro_ratio_at_retracted REAL',
-    'ALTER TABLE devices ADD COLUMN dendro_ratio_at_extended REAL'
-  ]) {
-    try {
-      await run(sql);
-    } catch (err) {
-      if (!/duplicate column name/i.test(String(err && err.message || err))) throw err;
-    }
-  }
-  await run(`UPDATE devices SET dendro_ratio_at_retracted = CASE
-    WHEN dendro_invert_direction = 1 THEN dendro_ratio_span
-    ELSE dendro_ratio_zero
-  END
-  WHERE dendro_ratio_at_retracted IS NULL
-    AND (dendro_ratio_zero IS NOT NULL OR dendro_ratio_span IS NOT NULL)`);
-  await run(`UPDATE devices SET dendro_ratio_at_extended = CASE
-    WHEN dendro_invert_direction = 1 THEN dendro_ratio_zero
-    ELSE dendro_ratio_span
-  END
-  WHERE dendro_ratio_at_extended IS NULL
-    AND (dendro_ratio_zero IS NOT NULL OR dendro_ratio_span IS NOT NULL)`);
-  const cols = await all('PRAGMA table_info(devices)');
-  const names = new Set(cols.map((row) => row.name));
-  if (!names.has('dendro_ratio_at_retracted') || !names.has('dendro_ratio_at_extended')) {
-    throw new Error('dendrometer calibration columns are still missing after deploy repair');
-  }
-  console.log('OK');
-  db.close();
-})().catch((err) => {
-  console.error(err && err.stack ? err.stack : err);
-  db.close();
-  process.exit(1);
-});
-NODE
-}
-
-ensure_zone_irrigation_calibration_schema() {
-    echo "--- Live zone irrigation calibration schema repair ---"
-    if [ ! -e "$DB_PATH" ]; then
-        echo "SKIP: no live database at $DB_PATH"
-        return 0
+    if ! command -v sqlite3 >/dev/null 2>&1; then
+        echo "ERROR: sqlite3 CLI is required for schema migrations" >&2
+        return 1
     fi
-    node <<'NODE'
-const fs = require('fs');
-const dbPath = '/data/db/farming.db';
-if (!fs.existsSync(dbPath)) {
-  console.log('SKIP: no live database at ' + dbPath);
-  process.exit(0);
-}
-const sqlite3 = require('/srv/node-red/node_modules/sqlite3');
-const db = new sqlite3.Database(dbPath);
-function run(sql) {
-  return new Promise((resolve, reject) => db.run(sql, (err) => err ? reject(err) : resolve()));
-}
-function all(sql) {
-  return new Promise((resolve, reject) => db.all(sql, (err, rows) => err ? reject(err) : resolve(rows || [])));
-}
-(async () => {
-  await run('PRAGMA busy_timeout=5000');
-  await run(`CREATE TABLE IF NOT EXISTS zone_irrigation_calibration (
-    zone_id                INTEGER PRIMARY KEY,
-    valve_device_eui       TEXT,
-    measured_flow_rate_lpm REAL,
-    measurement_method     TEXT,
-    measured_at            TEXT,
-    created_at             TEXT,
-    updated_at             TEXT
-  )`);
-  for (const sql of [
-    'ALTER TABLE zone_irrigation_calibration ADD COLUMN valve_device_eui TEXT',
-    'ALTER TABLE zone_irrigation_calibration ADD COLUMN measured_flow_rate_lpm REAL',
-    'ALTER TABLE zone_irrigation_calibration ADD COLUMN measurement_method TEXT',
-    'ALTER TABLE zone_irrigation_calibration ADD COLUMN measured_at TEXT',
-    'ALTER TABLE zone_irrigation_calibration ADD COLUMN created_at TEXT',
-    'ALTER TABLE zone_irrigation_calibration ADD COLUMN updated_at TEXT'
-  ]) {
-    try {
-      await run(sql);
-    } catch (err) {
-      if (!/duplicate column name/i.test(String(err && err.message || err))) throw err;
-    }
-  }
-  const cols = await all('PRAGMA table_info(zone_irrigation_calibration)');
-  const names = new Set(cols.map((row) => row.name));
-  for (const required of ['zone_id', 'measured_flow_rate_lpm', 'measurement_method', 'updated_at']) {
-    if (!names.has(required)) {
-      throw new Error('zone irrigation calibration column is still missing after deploy repair: ' + required);
-    }
-  }
-  console.log('OK');
-  db.close();
-})().catch((err) => {
-  console.error(err && err.stack ? err.stack : err);
-  db.close();
-  process.exit(1);
-});
-NODE
-}
-
-ensure_analysis_views_schema() {
-    echo "--- Live analysis views schema repair ---"
-    if [ ! -e "$DB_PATH" ]; then
-        echo "SKIP: no live database at $DB_PATH"
-        return 0
+    if ! command -v node >/dev/null 2>&1; then
+        echo "ERROR: node is required for schema migrations" >&2
+        return 1
     fi
-    node <<'NODE'
-const fs = require('fs');
-const dbPath = '/data/db/farming.db';
-if (!fs.existsSync(dbPath)) {
-  console.log('SKIP: no live database at ' + dbPath);
-  process.exit(0);
-}
-const sqlite3 = require('/srv/node-red/node_modules/sqlite3');
-const db = new sqlite3.Database(dbPath);
-function run(sql) {
-  return new Promise((resolve, reject) => db.run(sql, (err) => err ? reject(err) : resolve()));
-}
-function all(sql) {
-  return new Promise((resolve, reject) => db.all(sql, (err, rows) => err ? reject(err) : resolve(rows || [])));
-}
-(async () => {
-  await run('PRAGMA busy_timeout=5000');
-  await run(`CREATE TABLE IF NOT EXISTS analysis_views (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    user_id INTEGER NOT NULL,
-    owner_user_uuid TEXT,
-    name TEXT NOT NULL,
-    view_json TEXT NOT NULL,
-    is_default INTEGER NOT NULL DEFAULT 0 CHECK (is_default IN (0,1)),
-    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-  )`);
-  const cols = await all('PRAGMA table_info(analysis_views)');
-  const names = new Set(cols.map((row) => row.name));
-  for (const required of ['id', 'user_id', 'owner_user_uuid', 'name', 'view_json', 'is_default', 'created_at', 'updated_at']) {
-    if (!names.has(required)) {
-      throw new Error('analysis_views column is still missing after deploy repair: ' + required);
-    }
-  }
-  console.log('OK');
-  db.close();
-})().catch((err) => {
-  console.error(err && err.stack ? err.stack : err);
-  db.close();
-  process.exit(1);
-});
-NODE
-}
 
-ensure_chameleon_schema() {
-    echo "--- Live Chameleon SWT schema repair ---"
-    if [ ! -e "$DB_PATH" ]; then
-        echo "SKIP: no live database at $DB_PATH"
-        return 0
+    fetch_migration_runner
+
+    backup_dir="${MIGRATE_BACKUP_DIR:-/data/backups/migrate}"
+    mkdir -p "$backup_dir"
+
+    node_red_restart_needed=1
+    trap 'restart_node_red || true; cleanup' EXIT INT TERM
+
+    echo "--- Stop Node-RED for schema migration ---"
+    if /etc/init.d/node-red stop; then
+        echo "OK"
+    else
+        echo "ERROR: failed to stop Node-RED before schema migration" >&2
+        return 1
     fi
-    node <<'NODE'
-const fs = require('fs');
-const dbPath = '/data/db/farming.db';
-if (!fs.existsSync(dbPath)) {
-  console.log('SKIP: no live database at ' + dbPath);
-  process.exit(0);
-}
-const sqlite3 = require('/srv/node-red/node_modules/sqlite3');
-const db = new sqlite3.Database(dbPath);
-function run(sql) {
-  return new Promise((resolve, reject) => db.run(sql, (err) => err ? reject(err) : resolve()));
-}
-function all(sql) {
-  return new Promise((resolve, reject) => db.all(sql, (err, rows) => err ? reject(err) : resolve(rows || [])));
-}
-(async () => {
-  await run('PRAGMA busy_timeout=5000');
-  // V42 — kept columns. swt_{1,2,3} on device_data and depth/enabled on devices.
-  for (const sql of [
-    'ALTER TABLE devices ADD COLUMN chameleon_enabled INTEGER DEFAULT 0',
-    'ALTER TABLE devices ADD COLUMN chameleon_swt1_depth_cm REAL',
-    'ALTER TABLE devices ADD COLUMN chameleon_swt2_depth_cm REAL',
-    'ALTER TABLE devices ADD COLUMN chameleon_swt3_depth_cm REAL',
-    'ALTER TABLE device_data ADD COLUMN swt_1 REAL',
-    'ALTER TABLE device_data ADD COLUMN swt_2 REAL',
-    'ALTER TABLE device_data ADD COLUMN swt_3 REAL'
-  ]) {
-    try {
-      await run(sql);
-    } catch (err) {
-      if (!/duplicate column name/i.test(String(err && err.message || err))) throw err;
-    }
-  }
-  await run('UPDATE devices SET chameleon_enabled = 0 WHERE chameleon_enabled IS NULL');
+    sleep 2
 
-  // V42 — global calibration tables. Calibration values are intrinsic to the
-  // Chameleon hardware (keyed by array_id) and sourced from via.farm via the
-  // cloud sync endpoint. The miss table is a 24h negative cache.
-  await run(`CREATE TABLE IF NOT EXISTS chameleon_calibrations (
-    array_id                TEXT PRIMARY KEY,
-    sensor_id               TEXT NOT NULL,
-    sensor1_a               REAL NOT NULL,
-    sensor1_b               REAL NOT NULL,
-    sensor1_c               REAL NOT NULL,
-    sensor1_r2              REAL,
-    sensor2_a               REAL NOT NULL,
-    sensor2_b               REAL NOT NULL,
-    sensor2_c               REAL NOT NULL,
-    sensor2_r2              REAL,
-    sensor3_a               REAL NOT NULL,
-    sensor3_b               REAL NOT NULL,
-    sensor3_c               REAL NOT NULL,
-    sensor3_r2              REAL,
-    test_rig_run_start_date TEXT,
-    source                  TEXT NOT NULL,
-    fetched_at              TEXT NOT NULL
-  )`);
-  await run('CREATE INDEX IF NOT EXISTS idx_chameleon_calibrations_sensor_id ON chameleon_calibrations(sensor_id)');
-  await run(`CREATE TABLE IF NOT EXISTS chameleon_calibration_misses (
-    array_id   TEXT PRIMARY KEY,
-    last_tried TEXT NOT NULL,
-    reason     TEXT
-  )`);
-
-  // V42 — calibration_status, swt_1/2/3, and chameleon_array_id additions.
-  for (const sql of [
-    'ALTER TABLE chameleon_readings ADD COLUMN calibration_status TEXT',
-    'ALTER TABLE chameleon_readings ADD COLUMN swt_1 REAL',
-    'ALTER TABLE chameleon_readings ADD COLUMN swt_2 REAL',
-    'ALTER TABLE chameleon_readings ADD COLUMN swt_3 REAL',
-    'ALTER TABLE devices ADD COLUMN chameleon_array_id TEXT'
-  ]) {
-    try {
-      await run(sql);
-    } catch (err) {
-      if (!/duplicate column name/i.test(String(err && err.message || err))) throw err;
-    }
-  }
-
-  // V43 — data_invalid and comp_pending for Chameleon V2 firmware decoding.
-  for (const sql of [
-    'ALTER TABLE chameleon_readings ADD COLUMN data_invalid INTEGER DEFAULT 0',
-    'ALTER TABLE chameleon_readings ADD COLUMN comp_pending INTEGER DEFAULT 0'
-  ]) {
-    try {
-      await run(sql);
-    } catch (err) {
-      if (!/duplicate column name/i.test(String(err && err.message || err))) throw err;
-    }
-  }
-
-  // V42 — drop per-device coefficient columns. The bundled DB no longer has
-  // them; live DBs from pre-V42 builds must drop them so the new flows.json
-  // queries don't try to SELECT non-existent columns. SQLite >= 3.35 supports
-  // ALTER TABLE ... DROP COLUMN; older versions will error and we leave the
-  // columns in place (they're unused but not harmful).
-  for (const name of [
-    'chameleon_swt1_a','chameleon_swt1_b','chameleon_swt1_c',
-    'chameleon_swt2_a','chameleon_swt2_b','chameleon_swt2_c',
-    'chameleon_swt3_a','chameleon_swt3_b','chameleon_swt3_c'
-  ]) {
-    try {
-      await run(`ALTER TABLE devices DROP COLUMN ${name}`);
-    } catch (err) {
-      const msg = String(err && err.message || err);
-      if (/no such column/i.test(msg) || /near "DROP": syntax error/i.test(msg)) continue;
-      throw err;
-    }
-  }
-
-  // V42 — NULL device_data.swt_* rows that join a chameleon reading. Values
-  // computed from the now-dropped per-device coefficients are no longer trusted.
-  // Local backfill repopulates these once calibration arrives from osi-server.
-  // Idempotent: NULL → NULL is a no-op on repeat deploys.
-  await run(`UPDATE device_data
-    SET swt_1 = NULL, swt_2 = NULL, swt_3 = NULL
-    WHERE EXISTS (
-      SELECT 1 FROM chameleon_readings cr
-        WHERE cr.deveui = device_data.deveui
-          AND cr.recorded_at = device_data.recorded_at
-    )
-    AND (swt_1 IS NOT NULL OR swt_2 IS NOT NULL OR swt_3 IS NOT NULL)`);
-
-  const deviceNames = new Set((await all('PRAGMA table_info(devices)')).map((row) => row.name));
-  const dataNames = new Set((await all('PRAGMA table_info(device_data)')).map((row) => row.name));
-  const readingsNames = new Set((await all('PRAGMA table_info(chameleon_readings)')).map((row) => row.name));
-  const tableNames = new Set((await all("SELECT name FROM sqlite_master WHERE type = 'table'")).map((row) => row.name));
-
-  for (const name of [
-    'chameleon_enabled',
-    'chameleon_swt1_depth_cm',
-    'chameleon_swt2_depth_cm',
-    'chameleon_swt3_depth_cm',
-    'chameleon_array_id'
-  ]) {
-    if (!deviceNames.has(name)) throw new Error('Chameleon devices column is still missing after deploy repair: ' + name);
-  }
-  for (const name of ['swt_1', 'swt_2', 'swt_3']) {
-    if (!dataNames.has(name)) throw new Error('Chameleon device_data column is still missing after deploy repair: ' + name);
-  }
-  for (const name of ['calibration_status', 'swt_1', 'swt_2', 'swt_3', 'data_invalid', 'comp_pending']) {
-    if (!readingsNames.has(name)) throw new Error('chameleon_readings.' + name + ' is still missing after deploy repair');
-  }
-  for (const name of ['chameleon_calibrations', 'chameleon_calibration_misses']) {
-    if (!tableNames.has(name)) throw new Error('Chameleon global table is still missing after deploy repair: ' + name);
-  }
-  console.log('OK');
-  db.close();
-})().catch((err) => {
-  console.error(err && err.stack ? err.stack : err);
-  db.close();
-  process.exit(1);
-});
-NODE
-}
-
-ensure_gateway_health_schema() {
-    echo "--- Live gateway health schema (ordered migration 0002) ---"
-    if [ ! -e "$DB_PATH" ]; then
-        echo "SKIP: no live database at $DB_PATH"
-        return 0
+    if ! checkpoint_live_db; then
+        return 1
     fi
-    fetch "database/migrations/ordered/0002__gateway_health.sql" "$TMP_DIR/0002__gateway_health.sql"
-    OSI_MIGRATION_SQL="$TMP_DIR/0002__gateway_health.sql" node <<'NODE'
-const fs = require('fs');
-const dbPath = '/data/db/farming.db';
-if (!fs.existsSync(dbPath)) {
-  console.log('SKIP: no live database at ' + dbPath);
-  process.exit(0);
-}
-// Single source of DDL truth: execute the ordered-migration file itself.
-// Guard: only additive migrations may be applied through this deploy hook.
-const sql = fs.readFileSync(process.env.OSI_MIGRATION_SQL, 'utf8');
-if (!/^--\s*risk:\s*additive\s*(\r?\n|$)/.test(sql)) {
-  console.error('ERROR: refusing to apply a non-additive migration via deploy repair');
-  process.exit(1);
-}
-const sqlite3 = require('/srv/node-red/node_modules/sqlite3');
-const db = new sqlite3.Database(dbPath);
-function run(s) { return new Promise((resolve, reject) => db.run(s, (err) => err ? reject(err) : resolve())); }
-function exec(s) { return new Promise((resolve, reject) => db.exec(s, (err) => err ? reject(err) : resolve())); }
-function all(s) { return new Promise((resolve, reject) => db.all(s, (err, rows) => err ? reject(err) : resolve(rows || []))); }
-(async () => {
-  await run('PRAGMA busy_timeout=5000');
-  await exec(sql);
-  const tables = new Set((await all("SELECT name FROM sqlite_master WHERE type = 'table'")).map((r) => r.name));
-  for (const t of ['gateway_health_samples', 'gateway_health_hourly']) {
-    if (!tables.has(t)) throw new Error('gateway health table still missing after deploy repair: ' + t);
-  }
-  console.log('OK');
-  db.close();
-})().catch((err) => {
-  console.error(err && err.stack ? err.stack : err);
-  db.close();
-  process.exit(1);
-});
-NODE
-}
-
-ensure_improvement_requests_schema() {
-    echo "--- Live improvement requests schema (ordered migrations 0005-0006) ---"
-    if [ ! -e "$DB_PATH" ]; then
-        echo "SKIP: no live database at $DB_PATH"
-        return 0
+    if ! ledger_present="$(sqlite3 "$DB_PATH" "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migrations' LIMIT 1;")"; then
+        echo "ERROR: failed to inspect schema_migrations ledger before migration" >&2
+        return 1
     fi
-    fetch "database/migrations/ordered/0005__field_work_requests.sql" "$TMP_DIR/0005__field_work_requests.sql"
-    fetch "database/migrations/ordered/0006__improvement_request_contact_email.sql" "$TMP_DIR/0006__improvement_request_contact_email.sql"
-    OSI_MIGRATION_SQL_0005="$TMP_DIR/0005__field_work_requests.sql" \
-    OSI_MIGRATION_SQL_0006="$TMP_DIR/0006__improvement_request_contact_email.sql" node <<'NODE'
-const fs = require('fs');
-const dbPath = '/data/db/farming.db';
-if (!fs.existsSync(dbPath)) {
-  console.log('SKIP: no live database at ' + dbPath);
-  process.exit(0);
-}
-// Single source of DDL truth: execute the ordered-migration file itself.
-// Guard: only additive migrations may be applied through this deploy hook.
-const migration0005 = fs.readFileSync(process.env.OSI_MIGRATION_SQL_0005, 'utf8');
-const migration0006 = fs.readFileSync(process.env.OSI_MIGRATION_SQL_0006, 'utf8');
-for (const sql of [migration0005, migration0006]) {
-  if (!/^--\s*risk:\s*additive\s*(\r?\n|$)/.test(sql)) {
-    console.error('ERROR: refusing to apply a non-additive migration via deploy repair');
-    process.exit(1);
-  }
-}
-const sqlite3 = require('/srv/node-red/node_modules/sqlite3');
-const db = new sqlite3.Database(dbPath);
-function run(s) { return new Promise((resolve, reject) => db.run(s, (err) => err ? reject(err) : resolve())); }
-function exec(s) { return new Promise((resolve, reject) => db.exec(s, (err) => err ? reject(err) : resolve())); }
-function all(s) { return new Promise((resolve, reject) => db.all(s, (err, rows) => err ? reject(err) : resolve(rows || []))); }
-(async () => {
-  await run('PRAGMA busy_timeout=5000');
-  await exec(migration0005);
-  const tables = new Set((await all("SELECT name FROM sqlite_master WHERE type = 'table'")).map((r) => r.name));
-  if (!tables.has('improvement_requests')) {
-    throw new Error('improvement_requests table still missing after deploy repair');
-  }
-  const columns = new Set((await all("PRAGMA table_info(improvement_requests)")).map((r) => r.name));
-  if (!columns.has('contact_email')) {
-    await exec(migration0006);
-  } else {
-    const triggerSql = migration0006.slice(migration0006.indexOf('DROP TRIGGER'));
-    await exec(triggerSql);
-  }
-  const finalColumns = new Set((await all("PRAGMA table_info(improvement_requests)")).map((r) => r.name));
-  if (!finalColumns.has('contact_email')) {
-    throw new Error('improvement_requests.contact_email still missing after deploy repair');
-  }
-  const triggers = await all("SELECT lower(sql) AS sql FROM sqlite_master WHERE type = 'trigger' AND name = 'trg_improvement_requests_outbox_ai'");
-  if (!triggers.length || !String(triggers[0].sql || '').includes('contact_email')) {
-    throw new Error('improvement_requests outbox trigger missing contact_email after deploy repair');
-  }
-  console.log('OK');
-  db.close();
-})().catch((err) => {
-  console.error(err && err.stack ? err.stack : err);
-  db.close();
-  process.exit(1);
-});
-NODE
+    ledger_rows="0"
+    if [ "$ledger_present" = "1" ]; then
+        if ! ledger_rows="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM schema_migrations;")"; then
+            echo "ERROR: failed to inspect schema_migrations rows before migration" >&2
+            return 1
+        fi
+    fi
+    if [ "$ledger_rows" != "0" ]; then
+        echo "SKIP: schema_migrations ledger already has rows"
+    else
+        if ! node "$TMP_DIR/scripts/repair-sync-outbox-v2.js" "$DB_PATH"; then
+            return 1
+        fi
+        if ! node "$TMP_DIR/scripts/baseline-existing-db.js" "$DB_PATH" --migrations-dir "$migrations_dir"; then
+            return 1
+        fi
+    fi
+    if ! checkpoint_live_db; then
+        return 1
+    fi
+
+    if node "$TMP_DIR/scripts/migrate-cli.js" "$DB_PATH" --backup-dir "$backup_dir" --migrations-dir "$migrations_dir"; then
+        if ! restart_node_red; then
+            restore_deploy_trap
+            return 1
+        fi
+        restore_deploy_trap
+        echo "OK"
+        return 0
+    else
+        migration_rc=$?
+    fi
+
+    if [ "$migration_rc" = "3" ]; then
+        echo "ERROR: migration failed and backup restore integrity check failed; leaving Node-RED stopped" >&2
+        node_red_restart_needed=0
+        restore_deploy_trap
+        return 1
+    fi
+    echo "ERROR: schema migration failed; Node-RED will be restarted before deploy exits" >&2
+    return 1
 }
 
 echo "=== OSI OS Deploy ==="
@@ -719,12 +431,7 @@ else
     exit 1
 fi
 
-ensure_dendro_schema
-ensure_zone_irrigation_calibration_schema
-ensure_analysis_views_schema
-ensure_chameleon_schema
-ensure_gateway_health_schema
-ensure_improvement_requests_schema
+run_schema_migration || exit 1
 
 fix_mosquitto_ownership() {
     echo "--- Mosquitto ownership ---"

--- a/scripts/migrate-cli.js
+++ b/scripts/migrate-cli.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+'use strict';
+// Option B Stage 1 deploy-time runner entrypoint.
+// Wraps lib/osi-migrate applyPending with a persistent fsync'd pre-migration
+// backup and byte-image restore on failure. deploy.sh owns Node-RED stop/start.
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { cliRunner } = require('../lib/osi-migrate/runner-iface');
+const { applyPending } = require('../lib/osi-migrate');
+const { loadMigrations } = require('../lib/osi-migrate/migrations-loader');
+const { ensureLedger, getApplied } = require('../lib/osi-migrate/ledger');
+
+const REPO = path.resolve(__dirname, '..');
+const DEFAULT_MIGRATIONS_DIR = path.join(REPO, 'database/migrations/ordered');
+
+function fsyncPath(p) {
+  const fd = fs.openSync(p, fs.constants.O_RDONLY);
+  try {
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function offDeviceBackup(dbPath, backupDir) {
+  fs.mkdirSync(backupDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const dest = path.join(backupDir, `${path.basename(dbPath)}.premigrate-${stamp}`);
+  fs.copyFileSync(dbPath, dest);
+  const integrity = execFileSync('sqlite3', [dest, 'PRAGMA integrity_check'], {
+    encoding: 'utf8',
+  }).trim();
+  if (integrity !== 'ok') {
+    throw new Error(`off-device backup integrity_check failed: ${integrity}`);
+  }
+  fsyncPath(dest);
+  fsyncPath(backupDir);
+  return dest;
+}
+
+async function pendingRisksAfterApplied(dbPath, migrationsDir) {
+  const runner = cliRunner(dbPath);
+  await ensureLedger(runner);
+  const appliedOk = new Set(
+    (await getApplied(runner)).filter((m) => m.status === 'applied').map((m) => m.version)
+  );
+  return loadMigrations(migrationsDir)
+    .filter((m) => !appliedOk.has(m.version))
+    .map((m) => m.risk);
+}
+
+function restoreByteImage(dbPath, backupPath) {
+  for (const sidecar of ['-wal', '-shm', '-journal']) {
+    fs.rmSync(dbPath + sidecar, { force: true });
+  }
+  fs.copyFileSync(backupPath, dbPath);
+  fsyncPath(dbPath);
+  const integrity = execFileSync('sqlite3', [dbPath, 'PRAGMA integrity_check'], {
+    encoding: 'utf8',
+  }).trim();
+  return integrity === 'ok';
+}
+
+async function runMigrateCli({ dbPath, backupDir, migrationsDir = DEFAULT_MIGRATIONS_DIR, log = console.error }) {
+  if (!dbPath) {
+    throw new Error('usage: migrate-cli.js <db> --backup-dir <dir> [--migrations-dir <dir>]');
+  }
+  if (!fs.existsSync(dbPath)) {
+    throw new Error(`refusing: database file does not exist: ${dbPath}`);
+  }
+  if (!backupDir) {
+    throw new Error('refusing: --backup-dir is required (persistent pre-migration backup)');
+  }
+
+  const risks = await pendingRisksAfterApplied(dbPath, migrationsDir);
+  const needsBackup = risks.some((r) => r === 'destructive' || r === 'data');
+  let offDevice = null;
+  if (needsBackup) {
+    offDevice = offDeviceBackup(dbPath, backupDir);
+    log(`[migrate] persistent pre-migration backup: ${offDevice} (fsync'd, integrity ok)`);
+  } else {
+    log('[migrate] no destructive/data migration pending; persistent backup not required');
+  }
+
+  try {
+    const res = await applyPending(cliRunner(dbPath), {
+      migrationsDir,
+      appVersion: 'stage1-deploy',
+      writersStopped: true,
+    });
+    log(`[migrate] applied: ${JSON.stringify(res.applied)}`);
+    return { applied: res.applied, offDeviceBackup: offDevice, restored: false };
+  } catch (err) {
+    log(`[migrate] FAILED during applyPending: ${err.message}`);
+    if (!offDevice) {
+      log('[migrate] additive-only failure; runner rolled back, no byte-image restore needed');
+      throw err;
+    }
+    log(`[migrate] restoring pre-migration byte image from ${offDevice}`);
+    const ok = restoreByteImage(dbPath, offDevice);
+    if (!ok) {
+      const e = new Error(`migration failed AND restore integrity_check failed; backup at ${offDevice}`);
+      e.code = 3;
+      throw e;
+    }
+    const e = new Error(`migration failed; DB restored from ${offDevice}: ${err.message}`);
+    e.code = 1;
+    e.restored = true;
+    throw e;
+  }
+}
+
+function parseArgs(argv) {
+  const opts = { dbPath: null, backupDir: null, migrationsDir: DEFAULT_MIGRATIONS_DIR };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--backup-dir') {
+      opts.backupDir = argv[++i];
+    } else if (arg === '--migrations-dir') {
+      opts.migrationsDir = path.resolve(argv[++i] || '');
+    } else if (!opts.dbPath) {
+      opts.dbPath = arg;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+if (require.main === module) {
+  (async () => {
+    try {
+      await runMigrateCli(parseArgs(process.argv.slice(2)));
+      process.exit(0);
+    } catch (err) {
+      console.error(`[migrate] ${err.message}`);
+      process.exit(Number.isInteger(err.code) ? err.code : 2);
+    }
+  })();
+}
+
+module.exports = { runMigrateCli, parseArgs };

--- a/scripts/migrate-cli.test.js
+++ b/scripts/migrate-cli.test.js
@@ -1,0 +1,106 @@
+'use strict';
+// Stage 1 migrate-cli: persistent fsync'd backup before destructive/data apply,
+// applyPending under writersStopped, and byte-image restore on failure.
+// Spec: docs/superpowers/specs/2026-07-08-option-b-stage1-deploy-runner-design.md
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { cliRunner } = require('../lib/osi-migrate/runner-iface');
+const { bootstrapFresh, verifyHead } = require('../lib/osi-migrate');
+const { runMigrateCli } = require('./migrate-cli');
+
+const REPO = path.resolve(__dirname, '..');
+const MIGRATIONS_DIR = path.join(REPO, 'database/migrations/ordered');
+
+function scratch() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'migcli-'));
+}
+
+test('device at head: no pending migrations, no persistent backup, applied empty', async () => {
+  const dir = scratch();
+  const db = path.join(dir, 'device.db');
+  await bootstrapFresh(cliRunner(db), { migrationsDir: MIGRATIONS_DIR, appVersion: 'test' });
+  const backupDir = path.join(dir, 'bak');
+  const res = await runMigrateCli({ dbPath: db, backupDir, migrationsDir: MIGRATIONS_DIR, log: () => {} });
+  assert.deepEqual(res.applied, []);
+  assert.equal(res.offDeviceBackup, null);
+  assert.deepEqual(await verifyHead(cliRunner(db), { migrationsDir: MIGRATIONS_DIR }), { ok: true });
+});
+
+async function deviceAtV3(dir) {
+  const sub = path.join(dir, 'm3');
+  fs.mkdirSync(sub);
+  for (const f of fs.readdirSync(MIGRATIONS_DIR)) {
+    if (/^000[123]__/.test(f) || f === 'CHECKSUMS.json') {
+      fs.copyFileSync(path.join(MIGRATIONS_DIR, f), path.join(sub, f));
+    }
+  }
+  const db = path.join(dir, 'device.db');
+  await bootstrapFresh(cliRunner(db), { migrationsDir: sub, appVersion: 'baseline-existing-db' });
+  return db;
+}
+
+test('pending destructive: persistent backup taken + fsync-verified, applies to head', async () => {
+  const dir = scratch();
+  const db = await deviceAtV3(dir);
+  const backupDir = path.join(dir, 'bak');
+  const res = await runMigrateCli({ dbPath: db, backupDir, migrationsDir: MIGRATIONS_DIR, log: () => {} });
+  assert.deepEqual(res.applied, [4, 5, 6, 7]);
+  assert.ok(res.offDeviceBackup && fs.existsSync(res.offDeviceBackup), 'persistent backup file must exist');
+  const bakRows = await cliRunner(res.offDeviceBackup)
+    .all("SELECT name FROM sqlite_master WHERE type='table' LIMIT 1");
+  assert.ok(bakRows.length >= 1);
+  assert.deepEqual(await verifyHead(cliRunner(db), { migrationsDir: MIGRATIONS_DIR }), { ok: true });
+});
+
+test('injected migration failure: byte-image restored, DB unchanged', async () => {
+  const dir = scratch();
+  const db = await deviceAtV3(dir);
+  const backupDir = path.join(dir, 'bak');
+  const poisoned = path.join(dir, 'poisoned');
+  fs.mkdirSync(poisoned);
+  for (const f of fs.readdirSync(MIGRATIONS_DIR)) {
+    fs.copyFileSync(path.join(MIGRATIONS_DIR, f), path.join(poisoned, f));
+  }
+  const bad = '-- risk: data\nPRAGMA foreign_keys=ON;\n'
+    + "INSERT INTO device_data (deveui, recorded_at) VALUES ('NO_SUCH_DEVICE_EUI', '2020-01-01T00:00:00Z');\n";
+  fs.writeFileSync(path.join(poisoned, '0008__bad.sql'), bad);
+  const manifest = JSON.parse(fs.readFileSync(path.join(poisoned, 'CHECKSUMS.json'), 'utf8'));
+  const crypto = require('node:crypto');
+  manifest['0008__bad.sql'] = crypto.createHash('sha256')
+    .update(fs.readFileSync(path.join(poisoned, '0008__bad.sql')))
+    .digest('hex');
+  fs.writeFileSync(path.join(poisoned, 'CHECKSUMS.json'), JSON.stringify(manifest, null, 2) + '\n');
+
+  const before = fs.readFileSync(db);
+  const res = await runMigrateCli({ dbPath: db, backupDir, migrationsDir: poisoned, log: () => {} })
+    .catch((e) => ({ error: e }));
+  assert.ok(res.error, 'expected the run to throw after restoring');
+  const integrity = await cliRunner(db).all('PRAGMA integrity_check');
+  assert.equal(integrity[0].integrity_check || 'ok', 'ok');
+  assert.ok(before.equals(fs.readFileSync(db)), 'DB must be byte-restored to pre-migration image');
+});
+
+test('refuses a missing db path', async () => {
+  await assert.rejects(
+    () => runMigrateCli({
+      dbPath: '/nonexistent/nope.db',
+      backupDir: scratch(),
+      migrationsDir: MIGRATIONS_DIR,
+      log: () => {},
+    }),
+    /does not exist/
+  );
+});
+
+test('refuses a missing backup-dir argument', async () => {
+  const dir = scratch();
+  const db = path.join(dir, 'd.db');
+  await cliRunner(db).exec('CREATE TABLE x (a TEXT);');
+  await assert.rejects(
+    () => runMigrateCli({ dbPath: db, backupDir: null, migrationsDir: MIGRATIONS_DIR, log: () => {} }),
+    /backup-dir/
+  );
+});

--- a/scripts/test-deploy-migration-wiring.js
+++ b/scripts/test-deploy-migration-wiring.js
@@ -1,0 +1,107 @@
+'use strict';
+// Static contract for deploy.sh's Stage 1 migration wiring. This deliberately
+// avoids running deploy.sh because the real script targets a live gateway path.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO = path.resolve(__dirname, '..');
+const deploy = fs.readFileSync(path.join(REPO, 'deploy.sh'), 'utf8');
+const manifest = JSON.parse(fs.readFileSync(
+  path.join(REPO, 'database/migrations/ordered/CHECKSUMS.json'),
+  'utf8'
+));
+
+function indexOf(needle) {
+  const idx = deploy.indexOf(needle);
+  assert.notEqual(idx, -1, `missing deploy.sh snippet: ${needle}`);
+  return idx;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+test('deploy migration wiring fetches the ordered migration corpus from CHECKSUMS.json', () => {
+  assert.deepEqual(Object.keys(manifest).sort(), [
+    '0001__baseline.sql',
+    '0002__gateway_health.sql',
+    '0003__stamp_contract_version_and_zone_op_split.sql',
+    '0004__widen_schedule_trigger_metric_check.sql',
+    '0005__field_work_requests.sql',
+    '0006__improvement_request_contact_email.sql',
+    '0007__analysis_views.sql',
+  ]);
+  assert.match(deploy, /database\/migrations\/ordered\/CHECKSUMS\.json/);
+  assert.match(deploy, /Object\.keys\(manifest\)\.sort\(\)/);
+  assert.match(deploy, /database\/migrations\/ordered\/\$migration/);
+  assert.match(deploy, /\$migrations_dir\/\$migration/);
+});
+
+test('deploy migration wiring fetches the runner, Stage 0 helpers, and semantic compare dependency', () => {
+  for (const script of [
+    'baseline-existing-db.js',
+    'repair-sync-outbox-v2.js',
+    'migrate-cli.js',
+    'semantic-schema-compare.js',
+  ]) {
+    assert.match(deploy, new RegExp(`\\b${escapeRegExp(script)}\\b`), script);
+  }
+  assert.match(deploy, /"scripts\/\$script" "\$TMP_DIR\/scripts\/\$script"/);
+  for (const module of [
+    'backup.js',
+    'fingerprints.js',
+    'index.js',
+    'ledger.js',
+    'migrations-loader.js',
+    'runner-iface.js',
+    'runner.js',
+    'sql-normalize.js',
+  ]) {
+    assert.match(deploy, new RegExp(`\\b${escapeRegExp(module)}\\b`), module);
+  }
+  assert.match(deploy, /"lib\/osi-migrate\/\$module" "\$TMP_DIR\/lib\/osi-migrate\/\$module"/);
+});
+
+test('deploy migration wiring stops writers, checkpoints WAL, baselines, and applies in order', () => {
+  const stopIdx = indexOf('/etc/init.d/node-red stop');
+  const firstCheckpointIdx = indexOf('if ! checkpoint_live_db; then');
+  const ledgerIdx = indexOf("SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migrations' LIMIT 1;");
+  const ledgerRowsIdx = indexOf('SELECT COUNT(*) FROM schema_migrations;');
+  const repairIdx = indexOf('node "$TMP_DIR/scripts/repair-sync-outbox-v2.js" "$DB_PATH"');
+  const baselineIdx = indexOf('node "$TMP_DIR/scripts/baseline-existing-db.js" "$DB_PATH" --migrations-dir "$migrations_dir"');
+  const secondCheckpointIdx = deploy.indexOf('if ! checkpoint_live_db; then', firstCheckpointIdx + 1);
+  const migrateIdx = indexOf('node "$TMP_DIR/scripts/migrate-cli.js" "$DB_PATH" --backup-dir "$backup_dir" --migrations-dir "$migrations_dir"');
+
+  assert.ok(stopIdx < firstCheckpointIdx, 'Node-RED must stop before checkpointing');
+  assert.ok(firstCheckpointIdx < ledgerIdx, 'checkpoint must precede ledger inspection');
+  assert.ok(ledgerIdx < ledgerRowsIdx, 'ledger presence check must precede row-count inspection');
+  assert.ok(ledgerRowsIdx < repairIdx, 'pre-baseline repair only runs after ledger row-count inspection');
+  assert.ok(repairIdx < baselineIdx, 'sync_outbox v2 repair must precede semantic baseline');
+  assert.ok(baselineIdx < secondCheckpointIdx, 'baseline writes must be checkpointed before byte-copy backup');
+  assert.ok(secondCheckpointIdx < migrateIdx, 'second checkpoint must precede migrate-cli');
+  assert.match(deploy, /SKIP: schema_migrations ledger already has rows/);
+});
+
+test('deploy migration wiring uses persistent backup path and preserves cleanup trap behavior', () => {
+  assert.match(deploy, /MIGRATE_BACKUP_DIR:-\/data\/backups\/migrate/);
+  assert.match(deploy, /trap 'restart_node_red \|\| true; cleanup' EXIT INT TERM/);
+  assert.match(deploy, /restore_deploy_trap\(\) \{\n    trap cleanup EXIT INT TERM\n\}/);
+
+  const rc3Start = indexOf('if [ "$migration_rc" = "3" ]; then');
+  const rc3End = indexOf('echo "ERROR: schema migration failed; Node-RED will be restarted before deploy exits"');
+  const rc3Block = deploy.slice(rc3Start, rc3End);
+  assert.match(rc3Block, /node_red_restart_needed=0/);
+  assert.match(rc3Block, /restore_deploy_trap/);
+  assert.doesNotMatch(rc3Block, /restart_node_red/);
+});
+
+test('deploy.sh has a single migration call site and no inline schema DDL helpers', () => {
+  assert.match(deploy, /run_schema_migration\(\)/);
+  assert.match(deploy, /run_schema_migration \|\| exit 1/);
+  assert.doesNotMatch(deploy, /\bensure_(dendro|zone_irrigation_calibration|analysis_views|chameleon|gateway_health|improvement_requests)_schema\b/);
+  assert.doesNotMatch(deploy, /\bCREATE\s+(TABLE|INDEX|UNIQUE\s+INDEX|TRIGGER)\b/i);
+  assert.doesNotMatch(deploy, /\bALTER\s+TABLE\b/i);
+  assert.doesNotMatch(deploy, /\bDROP\s+(TABLE|TRIGGER)\b/i);
+});

--- a/scripts/test-deploy-migration-wiring.js
+++ b/scripts/test-deploy-migration-wiring.js
@@ -66,6 +66,7 @@ test('deploy migration wiring fetches the runner, Stage 0 helpers, and semantic 
 
 test('deploy migration wiring stops writers, checkpoints WAL, baselines, and applies in order', () => {
   const stopIdx = indexOf('/etc/init.d/node-red stop');
+  const pgrepIdx = indexOf("pgrep -f 'node-red'");
   const firstCheckpointIdx = indexOf('if ! checkpoint_live_db; then');
   const ledgerIdx = indexOf("SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migrations' LIMIT 1;");
   const ledgerRowsIdx = indexOf('SELECT COUNT(*) FROM schema_migrations;');
@@ -75,6 +76,7 @@ test('deploy migration wiring stops writers, checkpoints WAL, baselines, and app
   const migrateIdx = indexOf('node "$TMP_DIR/scripts/migrate-cli.js" "$DB_PATH" --backup-dir "$backup_dir" --migrations-dir "$migrations_dir"');
 
   assert.ok(stopIdx < firstCheckpointIdx, 'Node-RED must stop before checkpointing');
+  assert.ok(stopIdx < pgrepIdx && pgrepIdx < firstCheckpointIdx, 'Node-RED process poll must precede checkpointing');
   assert.ok(firstCheckpointIdx < ledgerIdx, 'checkpoint must precede ledger inspection');
   assert.ok(ledgerIdx < ledgerRowsIdx, 'ledger presence check must precede row-count inspection');
   assert.ok(ledgerRowsIdx < repairIdx, 'pre-baseline repair only runs after ledger row-count inspection');
@@ -82,6 +84,17 @@ test('deploy migration wiring stops writers, checkpoints WAL, baselines, and app
   assert.ok(baselineIdx < secondCheckpointIdx, 'baseline writes must be checkpointed before byte-copy backup');
   assert.ok(secondCheckpointIdx < migrateIdx, 'second checkpoint must precede migrate-cli');
   assert.match(deploy, /SKIP: schema_migrations ledger already has rows/);
+});
+
+test('deploy migration wiring provisions sqlite3-cli before refusing', () => {
+  const ensureIdx = indexOf('ensure_sqlite3_cli()');
+  const installIdx = indexOf('opkg install sqlite3-cli');
+  const callIdx = indexOf('if ! ensure_sqlite3_cli; then');
+
+  assert.ok(ensureIdx < installIdx, 'ensure_sqlite3_cli must own opkg provisioning');
+  assert.ok(installIdx < callIdx, 'function must be defined before use');
+  assert.match(deploy, /opkg update/);
+  assert.match(deploy, /ERROR: sqlite3 CLI unavailable and could not be installed/);
 });
 
 test('deploy migration wiring uses persistent backup path and preserves cleanup trap behavior', () => {

--- a/scripts/test-history-helper.js
+++ b/scripts/test-history-helper.js
@@ -441,10 +441,13 @@ test('saveAnalysisView rejects an empty or oversized name', async () => {
   }
 });
 
-test('deploy script repairs analysis_views without reseeding the live database', () => {
+test('deploy script delivers analysis_views through the migration runner', () => {
   const deploy = fs.readFileSync(path.join(repoRoot, 'deploy.sh'), 'utf8');
-  assert.match(deploy, /CREATE TABLE IF NOT EXISTS analysis_views/);
-  assert.match(deploy, /Live analysis views schema repair/);
+  assert.match(deploy, /run_schema_migration/);
+  assert.match(deploy, /database\/migrations\/ordered\/\$migration/);
+  assert.match(deploy, /migrate-cli\.js/);
+  assert.doesNotMatch(deploy, /CREATE TABLE IF NOT EXISTS analysis_views/);
+  assert.doesNotMatch(deploy, /Live analysis views schema repair/);
   assert.match(deploy, /osi-history-helper\/analysis\.js/);
 });
 

--- a/scripts/verify-no-stray-ddl-baseline.json
+++ b/scripts/verify-no-stray-ddl-baseline.json
@@ -16,8 +16,8 @@
     "The enforcement gate is scripts/verify-no-stray-ddl.js comparing HEAD counts against",
     "--base-ref (default origin/main) per surface/marker; see the script header.",
     "Known owners of the current counts: the two request-path CREATE TABLE",
-    "valve_actuation_expectations occurrences in flows.json function nodes; deploy.sh",
-    "ensure_* helpers, analysis_views, chameleon calibration, and chameleon_readings DDL."
+    "valve_actuation_expectations occurrences in flows.json function nodes.",
+    "deploy.sh must stay free of inline DDL; it fetches the ordered migration runner instead."
   ],
   "files": {
     "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json": {
@@ -43,16 +43,16 @@
       "total": 351
     },
     "deploy.sh": {
-      "createTable": 4,
-      "alterTable": 24,
+      "createTable": 0,
+      "alterTable": 0,
       "createUniqueIndex": 0,
-      "createIndex": 1,
+      "createIndex": 0,
       "createTrigger": 0,
       "dropTable": 0,
-      "dropTrigger": 1,
+      "dropTrigger": 0,
       "writableSchema": 0,
-      "total": 30
+      "total": 0
     }
   },
-  "total": 732
+  "total": 702
 }

--- a/scripts/verify-no-stray-ddl.js
+++ b/scripts/verify-no-stray-ddl.js
@@ -23,8 +23,8 @@
 // Known current owners of the frozen counts (informational, see the
 // committed baseline's "notes" field): the two request-path
 // `valve_actuation_expectations` CREATE TABLE occurrences in flows.json
-// function nodes, and deploy.sh's `ensure_*` helpers plus the
-// analysis_views / chameleon calibration / chameleon_readings DDL blocks.
+// function nodes. deploy.sh must not carry inline DDL; schema changes there go
+// through the ordered migration runner fetched by run_schema_migration().
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -254,8 +254,8 @@ const BASELINE_NOTES = [
   'The enforcement gate is scripts/verify-no-stray-ddl.js comparing HEAD counts against',
   '--base-ref (default origin/main) per surface/marker; see the script header.',
   'Known owners of the current counts: the two request-path CREATE TABLE',
-  'valve_actuation_expectations occurrences in flows.json function nodes; deploy.sh',
-  'ensure_* helpers, analysis_views, chameleon calibration, and chameleon_readings DDL.',
+  'valve_actuation_expectations occurrences in flows.json function nodes.',
+  'deploy.sh must stay free of inline DDL; it fetches the ordered migration runner instead.',
 ];
 
 function verifyAgainstBase(options) {

--- a/scripts/verify-sync-flow.js
+++ b/scripts/verify-sync-flow.js
@@ -563,15 +563,10 @@ function expectCalibrationCreateTableParity() {
     'updated_at TEXT',
   ];
   const runtimeColumns = calibrationSchemaColumnsFrom(String(node.func || '')).slice(0, expectedColumns.length);
-  const deployColumns = calibrationSchemaColumnsFrom(deployScript).slice(0, expectedColumns.length);
   if (JSON.stringify(runtimeColumns) !== JSON.stringify(expectedColumns)) {
     fail(`runtime zone_irrigation_calibration DDL columns differ: ${runtimeColumns.join(', ')}`);
-  } else if (JSON.stringify(deployColumns) !== JSON.stringify(expectedColumns)) {
-    fail(`deploy zone_irrigation_calibration DDL columns differ: ${deployColumns.join(', ')}`);
-  } else if (JSON.stringify(runtimeColumns) !== JSON.stringify(deployColumns)) {
-    fail('runtime and deploy zone_irrigation_calibration DDL columns differ');
   } else {
-    console.log('OK runtime and deploy zone_irrigation_calibration DDL columns match');
+    console.log('OK runtime zone_irrigation_calibration DDL columns match the nullable contract');
   }
 }
 
@@ -1767,17 +1762,17 @@ expectExcludes('Save Zone Irrigation Calibration', 'measurement_method TEXT NOT 
 expectExcludes('Save Zone Irrigation Calibration', 'measured_at TEXT NOT NULL', 'NOT NULL measured-at timestamp in runtime calibration create table');
 expectExcludes('Save Zone Irrigation Calibration', 'created_at TEXT NOT NULL', 'NOT NULL created-at timestamp in runtime calibration create table');
 expectExcludes('Save Zone Irrigation Calibration', 'updated_at TEXT NOT NULL', 'NOT NULL updated-at timestamp in runtime calibration create table');
-expectFileIncludes('deploy.sh', deployScript, 'CREATE TABLE IF NOT EXISTS zone_irrigation_calibration', 'repairs the zone irrigation calibration table during deploy');
-expectFileIncludes('deploy.sh', deployScript, 'measured_flow_rate_lpm REAL,', 'creates a nullable measured flow rate column during deploy repair');
-expectFileIncludes('deploy.sh', deployScript, 'measurement_method     TEXT,', 'creates a nullable measurement method column during deploy repair');
-expectFileIncludes('deploy.sh', deployScript, 'measured_at            TEXT,', 'creates a nullable measured-at column during deploy repair');
-expectFileIncludes('deploy.sh', deployScript, 'created_at             TEXT,', 'creates a nullable created-at column during deploy repair');
-expectFileIncludes('deploy.sh', deployScript, 'updated_at             TEXT', 'creates a nullable updated-at column during deploy repair');
-expectFileExcludes('deploy.sh', deployScript, 'measured_flow_rate_lpm REAL NOT NULL', 'NOT NULL measured flow rate in deploy repair create table');
-expectFileExcludes('deploy.sh', deployScript, 'measurement_method     TEXT NOT NULL', 'NOT NULL measurement method in deploy repair create table');
-expectFileExcludes('deploy.sh', deployScript, 'measured_at            TEXT NOT NULL', 'NOT NULL measured-at timestamp in deploy repair create table');
-expectFileExcludes('deploy.sh', deployScript, 'created_at             TEXT NOT NULL', 'NOT NULL created-at timestamp in deploy repair create table');
-expectFileExcludes('deploy.sh', deployScript, 'updated_at             TEXT NOT NULL', 'NOT NULL updated-at timestamp in deploy repair create table');
+expectFileIncludes('deploy.sh', deployScript, 'run_schema_migration || exit 1', 'runs the ordered migration runner during deploy');
+expectFileIncludes('deploy.sh', deployScript, 'database/migrations/ordered/$migration', 'fetches ordered migration files from the manifest during deploy');
+expectFileIncludes('deploy.sh', deployScript, 'scripts/migrate-cli.js', 'fetches the deploy-time migration CLI');
+expectFileIncludes('deploy.sh', deployScript, 'scripts/baseline-existing-db.js', 'fetches the semantic baseline tool for first-run devices');
+expectFileIncludes('deploy.sh', deployScript, 'scripts/repair-sync-outbox-v2.js', 'fetches the pre-baseline sync_outbox repair');
+expectFileExcludes('deploy.sh', deployScript, 'CREATE TABLE IF NOT EXISTS zone_irrigation_calibration', 'inline zone irrigation calibration DDL in deploy.sh');
+expectFileExcludes('deploy.sh', deployScript, 'measured_flow_rate_lpm REAL,', 'inline nullable measured flow rate deploy repair');
+expectFileExcludes('deploy.sh', deployScript, 'measurement_method     TEXT,', 'inline nullable measurement method deploy repair');
+expectFileExcludes('deploy.sh', deployScript, 'measured_at            TEXT,', 'inline nullable measured-at deploy repair');
+expectFileExcludes('deploy.sh', deployScript, 'created_at             TEXT,', 'inline nullable created-at deploy repair');
+expectFileExcludes('deploy.sh', deployScript, 'updated_at             TEXT', 'inline nullable updated-at deploy repair');
 expectCalibrationCreateTableParity();
 expectFileIncludes('api.ts', reactGuiApiSource, 'updateCalibration: async (zoneId: number', 'adds a shared client helper for zone irrigation calibration');
 expectFileIncludes('api.ts', reactGuiApiSource, "await api.post(`/api/irrigation-zones/${zoneId}/calibration`, payload);", 'targets the local zone irrigation calibration endpoint');
@@ -2586,10 +2581,13 @@ expectFileIncludes('deploy.sh', deployScript, '"conf/full_raspberrypi_bcm27xx_bc
 expectFileIncludes('deploy.sh', deployScript, '"conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/codecs/aquascope_lorain_decoder.js"', 'deploys the shipped LoRain ChirpStack decoder to live devices');
 expectFileIncludes('deploy.sh', deployScript, 'rm -rf "$entry"', 'removes stale hashed GUI assets AND locale files before extracting the rebuilt React bundle (loop covers assets/, locales/, index.html, dotfiles)');
 expectFileIncludes('deploy.sh', deployScript, 'chmod 755 /etc/init.d/node-red', 'keeps the deployed Node-RED init script executable');
-expectFileIncludes('deploy.sh', deployScript, 'ALTER TABLE devices ADD COLUMN dendro_ratio_at_retracted REAL', 'repairs the live DB with the canonical dendrometer retracted-ratio column during deploy');
-expectFileIncludes('deploy.sh', deployScript, 'ALTER TABLE devices ADD COLUMN dendro_ratio_at_extended REAL', 'repairs the live DB with the canonical dendrometer extended-ratio column during deploy');
-expectFileIncludes('deploy.sh', deployScript, 'UPDATE devices SET dendro_ratio_at_retracted = CASE', 'backfills the canonical dendrometer retracted-ratio column during deploy');
-expectFileIncludes('deploy.sh', deployScript, 'UPDATE devices SET dendro_ratio_at_extended = CASE', 'backfills the canonical dendrometer extended-ratio column during deploy');
+expectFileIncludes('deploy.sh', deployScript, 'run_schema_migration()', 'defines the deploy-time schema migration runner');
+expectFileIncludes('deploy.sh', deployScript, 'opkg install sqlite3-cli', 'provisions sqlite3-cli before running migrations');
+expectFileIncludes('deploy.sh', deployScript, "pgrep -f 'node-red'", 'verifies Node-RED has stopped before migrating');
+expectFileExcludes('deploy.sh', deployScript, 'ALTER TABLE devices ADD COLUMN dendro_ratio_at_retracted REAL', 'inline dendrometer retracted-ratio deploy repair');
+expectFileExcludes('deploy.sh', deployScript, 'ALTER TABLE devices ADD COLUMN dendro_ratio_at_extended REAL', 'inline dendrometer extended-ratio deploy repair');
+expectFileExcludes('deploy.sh', deployScript, 'UPDATE devices SET dendro_ratio_at_retracted = CASE', 'inline dendrometer retracted-ratio deploy backfill');
+expectFileExcludes('deploy.sh', deployScript, 'UPDATE devices SET dendro_ratio_at_extended = CASE', 'inline dendrometer extended-ratio deploy backfill');
 expectFileIncludes('deploy.sh', deployScript, '/etc/init.d/osi-gateway-gps stop || true', 'stops the retired gateway GPS sidecar during deploy');
 expectFileIncludes('deploy.sh', deployScript, '/etc/init.d/osi-gateway-gps disable || true', 'disables the retired gateway GPS sidecar during deploy');
 expectFileIncludes('deploy.sh', deployScript, 'rm -f /etc/init.d/osi-gateway-gps /usr/bin/osi-gateway-gps.js', 'removes the retired gateway GPS sidecar files during deploy');


### PR DESCRIPTION
Part of #88. Stacked on `feat/88-stage0-canonicalization`.

## Scope

Implements Option B Stage 1 deploy-time migration delivery for osi-os:

- Adds `scripts/migrate-cli.js` with persistent pre-migration backup, fsync, `applyPending(..., writersStopped: true)`, and byte-image restore on failure.
- Replaces deploy-time inline `ensure_*` schema repairs with `deploy.sh` `run_schema_migration`.
- Fetches the ordered migration corpus from `CHECKSUMS.json`, Stage 0 baseline helpers, and required `lib/osi-migrate` modules during deploy.
- Keeps `sync-init-fn` untouched and frozen. No live gateway, no SSH, no Uganda.

## Constraints resolved

- `sqlite3` CLI absence: `deploy.sh` now attempts `opkg update` + `opkg install sqlite3-cli`, then refuses schema migration if the CLI is still unavailable.
- Node-RED writers: `deploy.sh` stops Node-RED, waits up to 30s for `pgrep -f 'node-red'` to clear, checkpoints WAL, chains restart with the existing cleanup trap, and leaves Node-RED stopped only on migrate-cli rc=3 restore-integrity failure.

## Verification

Fresh local verification after the final commit:

```text
$ node scripts/verify-migrations.js
verify-migrations: OK (7 migrations, checksum manifest OK, base immutability OK)

$ node scripts/verify-seed-replay.js
verify-seed-replay: OK

$ node scripts/verify-db-schema-consistency.js
OK conf/base_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db
OK conf/base_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db
OK conf/full_raspberrypi_bcm27xx_bcm2708/files/usr/share/db/farming.db
OK conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/db/farming.db
OK conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/db/farming.db
OK database/farming.db
OK web/react-gui/farming.db
DB schema consistency verification passed

$ node scripts/verify-profile-parity.js
All parity checks passed.

$ node scripts/verify-runtime-schema-parity.js
verify-runtime-schema-parity: OK (2 flows: devices CHECK + runtime trigger parity)

$ node scripts/verify-no-stray-ddl.js
verify-no-stray-ddl: OK (HEAD total 702 <= origin/main total 732; committed baseline matches HEAD total 702)

$ sh -n deploy.sh
 deploy.sh parses OK

$ node scripts/verify-sync-flow.js
Sync flow verification passed
All parity checks passed.

$ node --test scripts/migrate-cli.test.js scripts/test-deploy-migration-wiring.js
# tests 11
# pass 11
# fail 0

$ node --test lib/osi-migrate/__tests__/*.test.js
# tests 60
# pass 60
# fail 0

$ node scripts/test-history-helper.js
OK deploy script delivers analysis_views through the migration runner
OK runRollupJob populates hourly and daily rollups for a zone

$ git diff --check
# no output
```

## Kaba fixture dry-run finding

Local copy used: `/home/phil/backups/kaba100-chameleon-zero-export-20260702/farming-kaba100-20260702T0754Z.db`.

Evidence:

```text
sha256 fixture: 41afe62062bbe1a20ee128e0ce5bde2b4da3a560583eab9de44fb79e0090d38e
repair-sync-outbox-v2 first run: added rejected_at, rejection_reason, last_retryable_failure_at
repair-sync-outbox-v2 second run: no-op
0002 apply: OK 0002
0005 apply: OK 0005
0006 apply: OK 0006
trigger convergence: converged 32 triggers
fixture hash after dry-run: OK
```

Baseline refused to stamp the old local Kaba fixture. After scratch-only `repair-pi-schema.js`, the best candidate remained `N=3` with these failing diffs:

```text
changed:foreign_key:device_data
changed:column:zone_irrigation_calibration.created_at
changed:column:zone_irrigation_calibration.measured_at
changed:column:zone_irrigation_calibration.measured_flow_rate_lpm
changed:column:zone_irrigation_calibration.measurement_method
changed:column:zone_irrigation_calibration.updated_at
```

Interpretation: this stale local Kaba copy does not satisfy the Stage 1 baseline precondition, and the semantic baseline correctly refused to bless it. No migration was applied to the fixture copy. This should block any rehearsal-of-record/live rollout until item 1.B2 has a fresh post-0.1 gateway DB copy or an explicit pre-baseline repair plan.

## Follow-ups

- Rehearsal-of-record on fresh post-0.1 kaba100 and Silvan DB copies is item 1.B2.
- Uganda remains excluded; it belongs to item 2.1.
- Ship `CONFIG_PACKAGE_sqlite3-cli=y` in firmware as a separate build-tested PR.
- Delete `scripts/repair-sync-outbox-v2.js` once the fleet is baselined.
