### PR TITLE
feat(deploy): staged atomic payload swap + auto-rollback (5.3 DD10)

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Fetch migration base ref
         run: git fetch --no-tags origin main:refs/remotes/origin/main
       - run: node --test lib/osi-migrate/__tests__/*.test.js
-      - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js scripts/verify-migrations.test.js scripts/verify-no-stray-ddl.test.js scripts/verify-no-new-silent-catch.test.js scripts/test-error-recording-flow.js scripts/flows-bare-require-scan.test.js scripts/verify-helper-registration.test.js scripts/semantic-schema-compare.test.js scripts/repair-sync-outbox-v2.test.js scripts/baseline-existing-db.test.js scripts/migrate-cli.test.js scripts/test-deploy-migration-wiring.js
+      - run: node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js scripts/verify-migrations.test.js scripts/verify-no-stray-ddl.test.js scripts/verify-no-new-silent-catch.test.js scripts/test-error-recording-flow.js scripts/flows-bare-require-scan.test.js scripts/verify-helper-registration.test.js scripts/semantic-schema-compare.test.js scripts/repair-sync-outbox-v2.test.js scripts/baseline-existing-db.test.js scripts/migrate-cli.test.js scripts/test-deploy-migration-wiring.js scripts/deploy-payload-swap.test.js scripts/test-deploy-atomic-payload-wiring.js
       - run: node scripts/test-history-helper.js
       - run: node --test scripts/test-health-helper.js
       - run: node scripts/verify-migrations.js

--- a/deploy.sh
+++ b/deploy.sh
@@ -41,13 +41,17 @@ detect_seed_db_rel() {
 }
 SEED_DB_REL="$(detect_seed_db_rel)"
 TMP_DIR="/tmp/osi-os-deploy.$$"
+PAYLOADS_ROOT="/srv/node-red/payloads"
+DEPLOY_STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+PAYLOAD_KEEP_N="${PAYLOAD_KEEP_N:-5}"
+SWAP_JS="$TMP_DIR/deploy-payload-swap.js"
 
 cleanup() {
     rm -rf "$TMP_DIR"
 }
 trap cleanup EXIT INT TERM
 
-mkdir -p "$TMP_DIR" /srv/node-red "$DB_DIR"
+mkdir -p "$TMP_DIR" /srv/node-red "$PAYLOADS_ROOT" "$DB_DIR"
 
 fetch() {
     src="$1"
@@ -63,6 +67,27 @@ fetch_required() {
     echo "--- $label ---"
     fetch "$src" "$dest"
     echo "OK"
+}
+
+same_fs_or_die() {
+    dev_a="$(stat -c %d /srv/node-red 2>/dev/null || echo A)"
+    dev_b="$(stat -c %d "$PAYLOADS_ROOT" 2>/dev/null || echo B)"
+    if [ "$dev_a" != "$dev_b" ]; then
+        echo "ERROR: $PAYLOADS_ROOT is on a different filesystem than /srv/node-red; symlink flip would not be atomic." >&2
+        exit 1
+    fi
+}
+
+swap_call() {
+    node -e '
+      const m = require(process.argv[1]);
+      const fn = process.argv[2];
+      const args = process.argv.slice(3);
+      const out = m[fn]("/srv/node-red", ...args);
+      if (out === null || out === undefined) process.exit(0);
+      if (typeof out === "object") process.stdout.write(JSON.stringify(out));
+      else process.stdout.write(String(out));
+    ' "$SWAP_JS" "$@"
 }
 
 run_communication_preflight() {
@@ -330,9 +355,17 @@ fi
 rm -f /etc/init.d/osi-gateway-gps /usr/bin/osi-gateway-gps.js
 echo "OK"
 
-fetch_required "flows.json" \
-    "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json" \
-    "/srv/node-red/flows.json"
+echo "--- Deploy payload swap helper ---"
+fetch "scripts/deploy-payload-swap.js" "$SWAP_JS"
+same_fs_or_die
+echo "OK"
+
+echo "--- flows.json (staged payload; flip deferred to post-migration) ---"
+STAGED_FLOWS="$TMP_DIR/flows.json"
+fetch "conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json" "$STAGED_FLOWS"
+swap_call stagePayload "$DEPLOY_STAMP" "$STAGED_FLOWS" >/dev/null
+PREV_STAMP="$(swap_call currentStamp || true)"
+echo "OK: staged payloads/$DEPLOY_STAMP (current: ${PREV_STAMP:-none}; flip deferred)"
 
 seed_db_if_missing
 
@@ -488,6 +521,42 @@ fix_mosquitto_ownership() {
 
 fix_mosquitto_ownership
 
+echo "--- Flip payload + local health self-check + auto-rollback (5.3 / DD10) ---"
+swap_call flipTo "$DEPLOY_STAMP" >/dev/null
+echo "OK: flipped /srv/node-red/flows.json -> payloads/$DEPLOY_STAMP"
+
+/etc/init.d/node-red restart || true
+
+PROBE_OK=1
+if pgrep -f 'node-red' >/dev/null 2>&1; then
+    sleep 5
+    if wget -q -O /dev/null --spider "http://127.0.0.1:1880/gui" 2>/dev/null; then
+        echo "OK: local health self-check PASSED (Node-RED alive, /gui reachable)"
+        PROBE_OK=0
+    else
+        echo "WARN: Node-RED process alive but /gui not reachable after 5s" >&2
+    fi
+else
+    echo "ALERT: Node-RED process not found after restart" >&2
+fi
+
+if [ "$PROBE_OK" = "0" ]; then
+    echo "OK: committing payload $DEPLOY_STAMP"
+    swap_call prunePayloads "$PAYLOAD_KEEP_N" >/dev/null
+else
+    echo "ALERT: local health self-check FAILED - AUTO-ROLLING-BACK the flows payload" >&2
+    if [ -n "${PREV_STAMP:-}" ]; then
+        swap_call flipTo "$PREV_STAMP" >/dev/null
+        /etc/init.d/node-red restart || true
+        echo "ROLLED BACK: flows.json -> payloads/$PREV_STAMP; Node-RED restarted on last-known-good payload" >&2
+        echo "NOTE: any committed DB migration is NOT auto-undone (DD10); restore is an operator call via 1.B1 backup." >&2
+        echo "NOTE: run deploy-canary-gate.js from your operator machine for the full cloud verdict." >&2
+        exit 1
+    fi
+    echo "ERROR: no previous payload to roll back to. Payload $DEPLOY_STAMP left live; investigate." >&2
+    exit 1
+fi
+
 echo "--- React GUI ---"
 fetch "react_gui.tar.gz" "$TMP_DIR/react_gui.tar.gz"
 mkdir -p /usr/lib/node-red/gui
@@ -499,9 +568,10 @@ tar xzf "$TMP_DIR/react_gui.tar.gz" -C /usr/lib/node-red/gui/
 echo "OK"
 
 echo ""
-echo "=== Deploy complete. Next steps: ==="
-echo "  1. Restart Node-RED:  /etc/init.d/node-red restart"
-echo "  2. Open the UI:       http://<device-ip>:1880/gui"
+echo "=== Deploy complete. ==="
+echo "  Payload:  /srv/node-red/payloads/$DEPLOY_STAMP (flipped + local health self-checked)"
+echo "  UI:       http://<device-ip>:1880/gui"
+echo "  Rollback: automatic for payload failure; committed DB migration restore is the 1.B1 operator path, not auto."
 echo ""
 echo "  NOTE: ChirpStack provisioning runs automatically on first boot via"
 echo "        osi-bootstrap (START=99).  No manual bootstrap step needed on"

--- a/scripts/deploy-payload-swap.js
+++ b/scripts/deploy-payload-swap.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function payloadsRoot(root) {
+  return path.join(root, 'payloads');
+}
+
+function payloadDir(root, stamp) {
+  return path.join(payloadsRoot(root), stamp);
+}
+
+function flowsLink(root) {
+  return path.join(root, 'flows.json');
+}
+
+function stagePayload(root, stamp, srcFlowsPath) {
+  const dir = payloadDir(root, stamp);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.copyFileSync(srcFlowsPath, path.join(dir, 'flows.json'));
+  return dir;
+}
+
+function flipTo(root, stamp) {
+  const target = path.join(payloadDir(root, stamp), 'flows.json');
+  if (!fs.existsSync(target)) {
+    throw new Error(`flipTo: staged payload missing: ${target}`);
+  }
+  const link = flowsLink(root);
+  const relativeTarget = path.relative(root, target);
+  const tmp = path.join(root, `.flows.json.flip-${process.pid}-${Date.now()}`);
+  try {
+    fs.rmSync(tmp, { force: true });
+  } catch (_) {}
+  fs.symlinkSync(relativeTarget, tmp);
+  fs.renameSync(tmp, link);
+  return { flowsLink: link, target };
+}
+
+function currentStamp(root) {
+  const link = flowsLink(root);
+  let stat;
+  try {
+    stat = fs.lstatSync(link);
+  } catch (_) {
+    return null;
+  }
+  if (!stat.isSymbolicLink()) {
+    return null;
+  }
+  let resolved;
+  let resolvedPayloadsRoot;
+  try {
+    resolved = fs.realpathSync(link);
+    resolvedPayloadsRoot = fs.realpathSync(payloadsRoot(root));
+  } catch (_) {
+    return null;
+  }
+  const dir = path.dirname(resolved);
+  if (path.dirname(dir) !== resolvedPayloadsRoot) {
+    return null;
+  }
+  return path.basename(dir);
+}
+
+function listStamps(root) {
+  try {
+    return fs.readdirSync(payloadsRoot(root))
+      .filter((entry) => fs.statSync(payloadDir(root, entry)).isDirectory())
+      .sort();
+  } catch (_) {
+    return [];
+  }
+}
+
+function previousStamp(root) {
+  const current = currentStamp(root);
+  const candidates = listStamps(root).filter((stamp) => stamp !== current);
+  return candidates.length ? candidates[candidates.length - 1] : null;
+}
+
+function rollback(root) {
+  const previous = previousStamp(root);
+  if (!previous) {
+    throw new Error('rollback: no previous payload retained to fall back to');
+  }
+  flipTo(root, previous);
+  return { flippedTo: previous };
+}
+
+function prunePayloads(root, keepN) {
+  const current = currentStamp(root);
+  const stamps = listStamps(root);
+  const keep = new Set(stamps.slice(Math.max(0, stamps.length - keepN)));
+  if (current) {
+    keep.add(current);
+  }
+  const removed = [];
+  for (const stamp of stamps) {
+    if (keep.has(stamp)) {
+      continue;
+    }
+    fs.rmSync(payloadDir(root, stamp), { recursive: true, force: true });
+    removed.push(stamp);
+  }
+  return { removed };
+}
+
+module.exports = {
+  stagePayload,
+  flipTo,
+  currentStamp,
+  previousStamp,
+  rollback,
+  prunePayloads,
+};

--- a/scripts/deploy-payload-swap.test.js
+++ b/scripts/deploy-payload-swap.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  stagePayload,
+  flipTo,
+  currentStamp,
+  previousStamp,
+  rollback,
+  prunePayloads,
+} = require('./deploy-payload-swap');
+
+function fakeRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'srv-node-red-'));
+}
+
+function fakeFlowsSrc(dir, marker) {
+  const src = path.join(dir, 'flows-src.json');
+  fs.writeFileSync(src, JSON.stringify([{ id: 'x', marker }]));
+  return src;
+}
+
+test('stagePayload writes payloads/<stamp>/flows.json without touching the live symlink', () => {
+  const root = fakeRoot();
+  const src = fakeFlowsSrc(root, 'v1');
+  const dir = stagePayload(root, '20260508T100000Z', src);
+
+  assert.equal(dir, path.join(root, 'payloads', '20260508T100000Z'));
+  assert.ok(fs.existsSync(path.join(dir, 'flows.json')));
+  assert.equal(currentStamp(root), null, 'no flip yet - nothing live');
+});
+
+test('flipTo atomically points flows.json at the staged payload; currentStamp reads it back', () => {
+  const root = fakeRoot();
+  const src = fakeFlowsSrc(root, 'v1');
+  stagePayload(root, 'stampA', src);
+
+  const { target } = flipTo(root, 'stampA');
+  const link = path.join(root, 'flows.json');
+  assert.ok(fs.lstatSync(link).isSymbolicLink());
+  assert.equal(fs.realpathSync(link), fs.realpathSync(target));
+  assert.equal(currentStamp(root), 'stampA');
+  assert.match(fs.readFileSync(link, 'utf8'), /v1/);
+});
+
+test('flipTo over an existing symlink is atomic replacement', () => {
+  const root = fakeRoot();
+  stagePayload(root, 'stampA', fakeFlowsSrc(root, 'v1'));
+  stagePayload(root, 'stampB', fakeFlowsSrc(root, 'v2'));
+
+  flipTo(root, 'stampA');
+  flipTo(root, 'stampB');
+
+  assert.equal(currentStamp(root), 'stampB');
+  assert.match(fs.readFileSync(path.join(root, 'flows.json'), 'utf8'), /v2/);
+});
+
+test('flipTo migrates an in-place regular flows.json file to the symlink layout', () => {
+  const root = fakeRoot();
+  fs.writeFileSync(path.join(root, 'flows.json'), JSON.stringify([{ id: 'legacy' }]));
+  stagePayload(root, 'stampA', fakeFlowsSrc(root, 'v1'));
+
+  flipTo(root, 'stampA');
+
+  assert.ok(fs.lstatSync(path.join(root, 'flows.json')).isSymbolicLink(), 'regular file replaced by symlink');
+  assert.equal(currentStamp(root), 'stampA');
+});
+
+test('previousStamp returns the newest retained non-current stamp', () => {
+  const root = fakeRoot();
+  stagePayload(root, '20260501T000000Z', fakeFlowsSrc(root, 'old'));
+  stagePayload(root, '20260502T000000Z', fakeFlowsSrc(root, 'new'));
+  flipTo(root, '20260501T000000Z');
+  flipTo(root, '20260502T000000Z');
+
+  assert.equal(previousStamp(root), '20260501T000000Z');
+});
+
+test('rollback flips back to the previous payload', () => {
+  const root = fakeRoot();
+  stagePayload(root, 'good', fakeFlowsSrc(root, 'GOOD'));
+  stagePayload(root, 'bad', fakeFlowsSrc(root, 'BAD'));
+  flipTo(root, 'good');
+  flipTo(root, 'bad');
+
+  const { flippedTo } = rollback(root);
+
+  assert.equal(flippedTo, 'good');
+  assert.equal(currentStamp(root), 'good');
+  assert.match(fs.readFileSync(path.join(root, 'flows.json'), 'utf8'), /GOOD/);
+});
+
+test('rollback throws when there is no previous payload to fall back to', () => {
+  const root = fakeRoot();
+  stagePayload(root, 'only', fakeFlowsSrc(root, 'ONLY'));
+  flipTo(root, 'only');
+
+  assert.throws(() => rollback(root), /no previous payload/i);
+});
+
+test('prunePayloads keeps the newest N and never removes the current target', () => {
+  const root = fakeRoot();
+  for (const stamp of ['20260501', '20260502', '20260503', '20260504']) {
+    stagePayload(root, stamp, fakeFlowsSrc(root, stamp));
+  }
+  flipTo(root, '20260501');
+
+  const { removed } = prunePayloads(root, 2);
+  const remaining = fs.readdirSync(path.join(root, 'payloads')).sort();
+
+  assert.ok(remaining.includes('20260501'), 'current target is never pruned');
+  assert.ok(remaining.includes('20260504'), 'newest is retained');
+  assert.ok(remaining.length <= 3, `keepN=2 plus protected current: got ${remaining.join(',')}`);
+  assert.ok(removed.length >= 1);
+});

--- a/scripts/test-deploy-atomic-payload-wiring.js
+++ b/scripts/test-deploy-atomic-payload-wiring.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const deploy = fs.readFileSync(path.resolve(__dirname, '..', 'deploy.sh'), 'utf8');
+
+function indexOf(needle) {
+  const idx = deploy.indexOf(needle);
+  assert.notEqual(idx, -1, `missing deploy.sh snippet: ${needle}`);
+  return idx;
+}
+
+test('deploy.sh fetches the tested payload-swap module and verifies same-filesystem atomicity', () => {
+  assert.match(deploy, /PAYLOADS_ROOT="\/srv\/node-red\/payloads"/);
+  assert.match(deploy, /SWAP_JS="\$TMP_DIR\/deploy-payload-swap\.js"/);
+  assert.match(deploy, /fetch "scripts\/deploy-payload-swap\.js" "\$SWAP_JS"/);
+  assert.match(deploy, /same_fs_or_die\(\)/);
+  assert.match(deploy, /stat -c %d \/srv\/node-red/);
+  assert.match(deploy, /stat -c %d "\$PAYLOADS_ROOT"/);
+});
+
+test('deploy.sh stages flows before migration and flips only after migration succeeds', () => {
+  const stageIdx = indexOf('swap_call stagePayload "$DEPLOY_STAMP" "$STAGED_FLOWS"');
+  const migrationIdx = indexOf('run_schema_migration || exit 1');
+  const flipIdx = indexOf('swap_call flipTo "$DEPLOY_STAMP"');
+
+  assert.ok(stageIdx < migrationIdx, 'flows payload must be staged before schema migration');
+  assert.ok(migrationIdx < flipIdx, 'flows symlink must flip only after schema migration succeeds');
+  assert.doesNotMatch(
+    deploy,
+    /fetch_required "flows\.json"[\s\S]*"\/srv\/node-red\/flows\.json"/,
+    'deploy must not write flows.json in place'
+  );
+});
+
+test('deploy.sh captures the previous payload before flip and rolls back to it on failed local self-check', () => {
+  const prevIdx = indexOf('PREV_STAMP="$(swap_call currentStamp || true)"');
+  const flipIdx = indexOf('swap_call flipTo "$DEPLOY_STAMP"');
+  const rollbackIdx = indexOf('swap_call flipTo "$PREV_STAMP"');
+  const restartIdx = deploy.indexOf('/etc/init.d/node-red restart || true', rollbackIdx);
+
+  assert.ok(prevIdx < flipIdx, 'previous payload must be captured before the new flip');
+  assert.ok(flipIdx < rollbackIdx, 'rollback must happen only after the new payload was tried');
+  assert.notEqual(restartIdx, -1, 'rollback must restart Node-RED after flipping back');
+  assert.match(deploy, /AUTO-ROLLING-BACK the flows payload/);
+  assert.match(deploy, /committed DB migration is NOT auto-undone/);
+});
+
+test('deploy.sh uses a local self-check on the Pi and leaves cloud canary gate to the operator', () => {
+  assert.match(deploy, /pgrep -f 'node-red'/);
+  assert.match(deploy, /http:\/\/127\.0\.0\.1:1880\/gui/);
+  assert.match(deploy, /local health self-check PASSED/);
+  assert.match(deploy, /deploy-canary-gate\.js from your operator machine/);
+  assert.doesNotMatch(deploy, /OSI_ADMIN_TOKEN/, 'gateway deploy must not require cloud admin credentials');
+});
+
+test('deploy.sh prunes retained payloads only after the flipped payload passes the local self-check', () => {
+  const passIdx = indexOf('if [ "$PROBE_OK" = "0" ]; then');
+  const pruneIdx = indexOf('swap_call prunePayloads "$PAYLOAD_KEEP_N"');
+  const rollbackIdx = indexOf('swap_call flipTo "$PREV_STAMP"');
+
+  assert.ok(passIdx < pruneIdx, 'prune must be inside the passing post-check branch');
+  assert.ok(pruneIdx < rollbackIdx, 'rollback branch must still have the retained previous payload');
+});


### PR DESCRIPTION
Stacked on #123 / `feat/88-stage1-deploy-runner`. Refactor-program item 5.3, DD10.

## Scope

Adds staged atomic payload delivery for `deploy.sh`:

- New tested module `scripts/deploy-payload-swap.js` stages `flows.json` under `/srv/node-red/payloads/<stamp>/`, flips `/srv/node-red/flows.json` via atomic symlink replacement, reads current/previous stamps, rolls back, and prunes retained payloads.
- `deploy.sh` no longer writes `flows.json` in place. It stages the new payload first, runs Stage 1 `run_schema_migration || exit 1`, then flips only after migration succeeds.
- After flip, deploy restarts Node-RED and runs a local self-check: Node-RED process alive plus `/gui` reachable on localhost. On failure it flips back to the retained previous payload and restarts Node-RED.
- CI now runs both the pure swap-module test and the deploy-ordering/rollback wiring guard.

No boot-node change, no live gateway, no fleet orchestration.

## Rollback asymmetry

Payload rollback is automatic: symlink flip back to the retained previous payload plus Node-RED restart.

DB migration rollback is not automatic. If a migration has already committed, restore remains the 1.B1 operator path using the pre-migration backup. A flows failure after a successful migration leaves the migrated DB with the old payload, and the deploy output says so.

## Consumed contracts

- 1.B1: `run_schema_migration` remains the migration/backup/restore mechanism. 5.3 stages before it and flips only after it succeeds.
- 0.2: the full cloud canary gate remains operator-side. This PR deliberately does not put admin credentials or cloud verdict logic on the gateway. The on-Pi check is local smoke only; deploy output tells the operator to run `deploy-canary-gate.js` from their workstation.

## Verification

```text
$ node --test scripts/check-sync-parity.test.js scripts/restamp-fingerprints.test.js scripts/verify-migrations.test.js scripts/verify-no-stray-ddl.test.js scripts/verify-no-new-silent-catch.test.js scripts/test-error-recording-flow.js scripts/flows-bare-require-scan.test.js scripts/verify-helper-registration.test.js scripts/semantic-schema-compare.test.js scripts/repair-sync-outbox-v2.test.js scripts/baseline-existing-db.test.js scripts/migrate-cli.test.js scripts/test-deploy-migration-wiring.js scripts/deploy-payload-swap.test.js scripts/test-deploy-atomic-payload-wiring.js
# tests 96
# pass 96
# fail 0

$ node scripts/verify-sync-flow.js
Sync flow verification passed
All parity checks passed.

$ node scripts/verify-no-stray-ddl.js
verify-no-stray-ddl: OK (HEAD total 702 <= origin/main total 732; committed baseline matches HEAD total 702)

$ sh -n deploy.sh
 deploy.sh parses under POSIX sh

$ node scripts/test-history-helper.js
OK deploy script delivers analysis_views through the migration runner
OK runRollupJob populates hourly and daily rollups for a zone

$ git diff --check
# no output
```

## Follow-up

The live bad-flows -> local check fails -> auto-rollback -> old payload healthy cycle still needs a 5.2/operator rehearsal against a throwaway Node-RED instance before rollout.
