### PR TITLE
fix(history-api): rollup hardening — invariant guard, coverage clamp, multi-device tests (1.A6 T1-T3)

### DIFF
--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-history-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-history-helper/index.js
@@ -962,6 +962,7 @@ function aggregateRows(rows, options = {}) {
   if (startMs === null || endMs === null || endMs <= startMs) throw new Error('aggregateRows requires a valid start/end range for bucketed aggregation');
 
   const buckets = aggregationBuckets(startMs, endMs, aggregation, bucketSeconds, options.timezone);
+  const nowMs = toFiniteNumber(options.nowMs) ?? Date.now();
 
   for (const bucket of buckets) {
     const bucketRows = sortedRows.filter((entry) => entry.recordedAtMs >= bucket.bucketStartMs && entry.recordedAtMs < bucket.bucketEndMs);
@@ -978,7 +979,12 @@ function aggregateRows(rows, options = {}) {
       };
       bucket.sampleCount += bucket.series[channel.id].sampleCount;
     }
-    const coverage = coverageForBucket(bucketRows, channels, sourceCadences, (bucket.bucketEndMs - bucket.bucketStartMs) / 1000);
+    // Coverage denominator counts only elapsed time: a bucket (or window)
+    // that extends past `now` cannot be "missing" samples it could not
+    // yet have received. Fully-future buckets get a zero denominator,
+    // which coverageForBucket maps to coveragePct null.
+    const elapsedBucketSeconds = Math.max(0, (Math.min(bucket.bucketEndMs, nowMs) - bucket.bucketStartMs) / 1000);
+    const coverage = coverageForBucket(bucketRows, channels, sourceCadences, elapsedBucketSeconds);
     bucket.coveragePct = coverage.coveragePct;
     bucket.coverageConfidence = coverage.coverageConfidence;
     delete bucket.bucketStartMs;
@@ -986,7 +992,7 @@ function aggregateRows(rows, options = {}) {
   }
 
   const totalSamples = buckets.reduce((sum, bucket) => sum + bucket.sampleCount, 0);
-  const totalSeconds = (endMs - startMs) / 1000;
+  const totalSeconds = Math.max(0, (Math.min(endMs, nowMs) - startMs) / 1000);
   const totalCoverage = coverageForBucket(sortedRows, channels, sourceCadences, totalSeconds);
   return {
     aggregation,
@@ -2173,26 +2179,17 @@ function buildLocalInterpretations(input = {}) {
 
   const generatedMs = parseTime(generatedAt);
   const rangeFromMs = parseTime(input.rangeFrom);
-  const rangeToMs = parseTime(input.rangeTo);
-  const windowKnown = rangeFromMs !== null && rangeToMs !== null && generatedMs !== null && rangeToMs > rangeFromMs;
-  const fullyFutureWindow = windowKnown && rangeFromMs >= generatedMs;
-  let effectiveCoveragePct = coveragePct;
-  if (coveragePct !== null && windowKnown && rangeToMs > generatedMs) {
-    const totalMs = rangeToMs - rangeFromMs;
-    const elapsedMs = generatedMs - rangeFromMs;
-    effectiveCoveragePct = elapsedMs <= 0 ? null : Math.min(100, coveragePct * (totalMs / elapsedMs));
-  }
-  const coverageGapFires = effectiveCoveragePct !== null
-    ? effectiveCoveragePct < 80
-    : (coverageConfidence === 'unknown' && !fullyFutureWindow);
-  if (coverageGapFires) {
+  // Fully-future windows have nothing to be missing yet; coverage is null
+  // there and must not trigger the unknown-confidence info banner either.
+  const fullyFutureWindow = rangeFromMs !== null && generatedMs !== null && rangeFromMs >= generatedMs;
+  if (!fullyFutureWindow && (coverageConfidence === 'unknown' || (coveragePct !== null && coveragePct < 80))) {
     items.push({
       ruleId: 'data-coverage-gap',
       severity: coverageConfidence === 'unknown' ? 'info' : 'warning',
       titleKey: 'history.interpretation.dataCoverageGap.title',
       bodyKey: 'history.interpretation.dataCoverageGap.body',
-      params: { coveragePct: effectiveCoveragePct ?? coveragePct, coverageConfidence },
-      evidence: [{ type: 'coverage', coveragePct: effectiveCoveragePct ?? coveragePct, coverageConfidence }],
+      params: { coveragePct, coverageConfidence },
+      evidence: [{ type: 'coverage', coveragePct, coverageConfidence }],
       source: 'local-rule',
     });
   }

--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-history-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/node-red/osi-history-helper/index.js
@@ -1048,6 +1048,7 @@ function normalizeQueryChannels(channels) {
   return normalized;
 }
 
+/** Aggregates the UNION of scope.deveuis into one combined row per bucket/channel under scope.logicalSourceKey. */
 async function computeRollupBuckets(db, scope = {}, level, windowMs, nowMs) {
   const aggregation = String(level || '').trim();
   if (!['hourly', 'daily', 'weekly'].includes(aggregation)) throw new Error(`unsupported rollup level: ${level}`);
@@ -1132,7 +1133,28 @@ async function upsertRollups(db, rows) {
   return count;
 }
 
+/**
+ * Builds an aggregate result from history_channel_rollups rows.
+ *
+ * CONTRACT (verified live on kaba100, 2026-07-11):
+ * - Input rows MUST all belong to ONE logical_source_key. Merged cards
+ *   (soil='root-zone', environment='microclimate') store ONE combined-
+ *   aggregate row per bucket/channel — computeRollupBuckets aggregates the
+ *   UNION of the card's devices before upserting. Per-source detail exists
+ *   only in raw device_data and the CSV export path.
+ * - bucket.series is keyed by channel_id only; multi-key input would
+ *   silently drop data, hence the guard below. A future per-source rollup
+ *   scheme must extend this keying (see refactor-program open decisions).
+ * - bucket.sampleCount sums sample_count ACROSS CHANNELS (same semantics
+ *   as the live aggregateRows path).
+ */
 function rollupRowsToResult(rows, query, channels) {
+  const sourceKeys = new Set((rows || [])
+    .map((row) => row.logical_source_key)
+    .filter((value) => value !== undefined && value !== null));
+  if (sourceKeys.size > 1) {
+    throw new Error(`rollupRowsToResult requires rows from a single logical_source_key, got: ${Array.from(sourceKeys).sort().join(', ')}`);
+  }
   const channelMap = new Map(channels.map((channel) => [channel.id, channel]));
   const byBucket = new Map();
   for (const row of rows || []) {
@@ -2620,6 +2642,7 @@ module.exports = {
   runRollupJob,
   upsertRollups,
   computeRollupBuckets,
+  rollupRowsToResult,
   startOfLocalDayMs,
   buildZoneExportCsv,
   RAW_CSV_COLUMNS,

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-history-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-history-helper/index.js
@@ -962,6 +962,7 @@ function aggregateRows(rows, options = {}) {
   if (startMs === null || endMs === null || endMs <= startMs) throw new Error('aggregateRows requires a valid start/end range for bucketed aggregation');
 
   const buckets = aggregationBuckets(startMs, endMs, aggregation, bucketSeconds, options.timezone);
+  const nowMs = toFiniteNumber(options.nowMs) ?? Date.now();
 
   for (const bucket of buckets) {
     const bucketRows = sortedRows.filter((entry) => entry.recordedAtMs >= bucket.bucketStartMs && entry.recordedAtMs < bucket.bucketEndMs);
@@ -978,7 +979,12 @@ function aggregateRows(rows, options = {}) {
       };
       bucket.sampleCount += bucket.series[channel.id].sampleCount;
     }
-    const coverage = coverageForBucket(bucketRows, channels, sourceCadences, (bucket.bucketEndMs - bucket.bucketStartMs) / 1000);
+    // Coverage denominator counts only elapsed time: a bucket (or window)
+    // that extends past `now` cannot be "missing" samples it could not
+    // yet have received. Fully-future buckets get a zero denominator,
+    // which coverageForBucket maps to coveragePct null.
+    const elapsedBucketSeconds = Math.max(0, (Math.min(bucket.bucketEndMs, nowMs) - bucket.bucketStartMs) / 1000);
+    const coverage = coverageForBucket(bucketRows, channels, sourceCadences, elapsedBucketSeconds);
     bucket.coveragePct = coverage.coveragePct;
     bucket.coverageConfidence = coverage.coverageConfidence;
     delete bucket.bucketStartMs;
@@ -986,7 +992,7 @@ function aggregateRows(rows, options = {}) {
   }
 
   const totalSamples = buckets.reduce((sum, bucket) => sum + bucket.sampleCount, 0);
-  const totalSeconds = (endMs - startMs) / 1000;
+  const totalSeconds = Math.max(0, (Math.min(endMs, nowMs) - startMs) / 1000);
   const totalCoverage = coverageForBucket(sortedRows, channels, sourceCadences, totalSeconds);
   return {
     aggregation,
@@ -2173,26 +2179,17 @@ function buildLocalInterpretations(input = {}) {
 
   const generatedMs = parseTime(generatedAt);
   const rangeFromMs = parseTime(input.rangeFrom);
-  const rangeToMs = parseTime(input.rangeTo);
-  const windowKnown = rangeFromMs !== null && rangeToMs !== null && generatedMs !== null && rangeToMs > rangeFromMs;
-  const fullyFutureWindow = windowKnown && rangeFromMs >= generatedMs;
-  let effectiveCoveragePct = coveragePct;
-  if (coveragePct !== null && windowKnown && rangeToMs > generatedMs) {
-    const totalMs = rangeToMs - rangeFromMs;
-    const elapsedMs = generatedMs - rangeFromMs;
-    effectiveCoveragePct = elapsedMs <= 0 ? null : Math.min(100, coveragePct * (totalMs / elapsedMs));
-  }
-  const coverageGapFires = effectiveCoveragePct !== null
-    ? effectiveCoveragePct < 80
-    : (coverageConfidence === 'unknown' && !fullyFutureWindow);
-  if (coverageGapFires) {
+  // Fully-future windows have nothing to be missing yet; coverage is null
+  // there and must not trigger the unknown-confidence info banner either.
+  const fullyFutureWindow = rangeFromMs !== null && generatedMs !== null && rangeFromMs >= generatedMs;
+  if (!fullyFutureWindow && (coverageConfidence === 'unknown' || (coveragePct !== null && coveragePct < 80))) {
     items.push({
       ruleId: 'data-coverage-gap',
       severity: coverageConfidence === 'unknown' ? 'info' : 'warning',
       titleKey: 'history.interpretation.dataCoverageGap.title',
       bodyKey: 'history.interpretation.dataCoverageGap.body',
-      params: { coveragePct: effectiveCoveragePct ?? coveragePct, coverageConfidence },
-      evidence: [{ type: 'coverage', coveragePct: effectiveCoveragePct ?? coveragePct, coverageConfidence }],
+      params: { coveragePct, coverageConfidence },
+      evidence: [{ type: 'coverage', coveragePct, coverageConfidence }],
       source: 'local-rule',
     });
   }

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-history-helper/index.js
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-history-helper/index.js
@@ -1048,6 +1048,7 @@ function normalizeQueryChannels(channels) {
   return normalized;
 }
 
+/** Aggregates the UNION of scope.deveuis into one combined row per bucket/channel under scope.logicalSourceKey. */
 async function computeRollupBuckets(db, scope = {}, level, windowMs, nowMs) {
   const aggregation = String(level || '').trim();
   if (!['hourly', 'daily', 'weekly'].includes(aggregation)) throw new Error(`unsupported rollup level: ${level}`);
@@ -1132,7 +1133,28 @@ async function upsertRollups(db, rows) {
   return count;
 }
 
+/**
+ * Builds an aggregate result from history_channel_rollups rows.
+ *
+ * CONTRACT (verified live on kaba100, 2026-07-11):
+ * - Input rows MUST all belong to ONE logical_source_key. Merged cards
+ *   (soil='root-zone', environment='microclimate') store ONE combined-
+ *   aggregate row per bucket/channel — computeRollupBuckets aggregates the
+ *   UNION of the card's devices before upserting. Per-source detail exists
+ *   only in raw device_data and the CSV export path.
+ * - bucket.series is keyed by channel_id only; multi-key input would
+ *   silently drop data, hence the guard below. A future per-source rollup
+ *   scheme must extend this keying (see refactor-program open decisions).
+ * - bucket.sampleCount sums sample_count ACROSS CHANNELS (same semantics
+ *   as the live aggregateRows path).
+ */
 function rollupRowsToResult(rows, query, channels) {
+  const sourceKeys = new Set((rows || [])
+    .map((row) => row.logical_source_key)
+    .filter((value) => value !== undefined && value !== null));
+  if (sourceKeys.size > 1) {
+    throw new Error(`rollupRowsToResult requires rows from a single logical_source_key, got: ${Array.from(sourceKeys).sort().join(', ')}`);
+  }
   const channelMap = new Map(channels.map((channel) => [channel.id, channel]));
   const byBucket = new Map();
   for (const row of rows || []) {
@@ -2620,6 +2642,7 @@ module.exports = {
   runRollupJob,
   upsertRollups,
   computeRollupBuckets,
+  rollupRowsToResult,
   startOfLocalDayMs,
   buildZoneExportCsv,
   RAW_CSV_COLUMNS,

--- a/scripts/test-history-helper.js
+++ b/scripts/test-history-helper.js
@@ -2220,3 +2220,39 @@ test('rollupRowsToResult builds buckets from single-key rows', () => {
   assert.strictEqual(result.buckets[0].series.swt_1.mean, 10);
   assert.strictEqual(result.buckets[0].sampleCount, 4);
 });
+
+test('computeRollupBuckets merges a multi-device scope into ONE combined row per bucket/channel', async () => {
+  const db = createCliSqliteDb();
+  try {
+    db.runSql(`
+      INSERT INTO users(id,username,password_hash,created_at,updated_at) VALUES(1,'u','h','2026-05-31T00:00:00.000Z','2026-05-31T00:00:00.000Z');
+      INSERT INTO irrigation_zones(id,name,user_id,zone_uuid,timezone,created_at,updated_at) VALUES(7,'Z',1,'zu','UTC','2026-05-31T00:00:00.000Z','2026-05-31T00:00:00.000Z');
+      INSERT INTO devices(deveui,name,type_id,user_id,irrigation_zone_id,created_at,updated_at) VALUES
+        ('AA00000000000001','Temp A','DRAGINO_LSN50',1,7,'2026-05-31T00:00:00.000Z','2026-05-31T00:00:00.000Z'),
+        ('AA00000000000002','Temp B','DRAGINO_LSN50',1,7,'2026-05-31T00:00:00.000Z','2026-05-31T00:00:00.000Z');
+      INSERT INTO device_data(deveui,recorded_at,ext_temperature_c) VALUES
+        ('AA00000000000001','2026-06-01T08:10:00.000Z',10),
+        ('AA00000000000002','2026-06-01T08:20:00.000Z',30),
+        ('AA00000000000001','2026-06-01T08:40:00.000Z',20),
+        ('AA00000000000002','2026-06-01T08:50:00.000Z',40);
+    `);
+    const scope = {
+      zoneId: 7,
+      cardType: 'environment',
+      logicalSourceKey: 'microclimate',
+      channels: [{ id: 'ext_temperature_c', field: 'ext_temperature_c', unit: 'C' }],
+      deveuis: ['AA00000000000001', 'AA00000000000002'],
+      timezone: 'UTC',
+    };
+    const rows = await helper.computeRollupBuckets(db, scope, 'hourly', 24 * 3600 * 1000, Date.parse('2026-06-02T00:00:00.000Z'));
+    const hourRows = rows.filter((row) => row.channel_id === 'ext_temperature_c' && row.bucket_start === '2026-06-01T08:00:00.000Z');
+    assert.strictEqual(hourRows.length, 1, 'exactly ONE combined row for the merged scope');
+    assert.strictEqual(hourRows[0].logical_source_key, 'microclimate');
+    assert.strictEqual(hourRows[0].mean_value, 25);
+    assert.strictEqual(hourRows[0].min_value, 10);
+    assert.strictEqual(hourRows[0].max_value, 40);
+    assert.strictEqual(hourRows[0].sample_count, 4);
+  } finally {
+    db.close();
+  }
+});

--- a/scripts/test-history-helper.js
+++ b/scripts/test-history-helper.js
@@ -2143,12 +2143,6 @@ test('data-coverage-gap interpretation ignores future time in window', () => {
     rangeFrom: '2026-07-01T00:00:00.000Z',
     rangeTo: '2026-08-01T00:00:00.000Z',
   };
-  const fullElapsedCoverage = helper.buildLocalInterpretations({ ...base, coveragePct: 34 });
-  assert(
-    !fullElapsedCoverage.some((item) => item.ruleId === 'data-coverage-gap'),
-    'coverage gap must not fire when the elapsed part of the window is fully covered',
-  );
-
   const realGap = helper.buildLocalInterpretations({ ...base, coveragePct: 15 });
   assert(
     realGap.some((item) => item.ruleId === 'data-coverage-gap'),
@@ -2255,4 +2249,55 @@ test('computeRollupBuckets merges a multi-device scope into ONE combined row per
   } finally {
     db.close();
   }
+});
+
+test('aggregateRows clamps coverage denominators at now for in-progress windows', () => {
+  const rows = [
+    { deveui: 'AA00000000000001', recorded_at: '2026-07-11T00:10:00.000Z', ext_temperature_c: 20 },
+    { deveui: 'AA00000000000001', recorded_at: '2026-07-11T05:50:00.000Z', ext_temperature_c: 22 },
+  ];
+  const result = helper.aggregateRows(rows, {
+    aggregation: 'daily',
+    channels: [{ id: 'ext_temperature_c', field: 'ext_temperature_c', unit: 'C' }],
+    start: '2026-07-11T00:00:00.000Z',
+    end: '2026-07-12T00:00:00.000Z',
+    timezone: 'UTC',
+    nowMs: Date.parse('2026-07-11T06:00:00.000Z'),
+    expectedCadences: { AA00000000000001: { seconds: 1200, confidence: 'configured' } },
+  });
+  assert.ok(result.coveragePct > 10 && result.coveragePct < 12,
+    `coverage must be computed over elapsed time only, got ${result.coveragePct}`);
+  assert.strictEqual(result.buckets.length, 1);
+  assert.ok(result.buckets[0].coveragePct > 10 && result.buckets[0].coveragePct < 12);
+});
+
+test('aggregateRows leaves completed-window coverage unchanged by the clamp', () => {
+  const rows = [
+    { deveui: 'AA00000000000001', recorded_at: '2026-07-10T00:10:00.000Z', ext_temperature_c: 20 },
+  ];
+  const result = helper.aggregateRows(rows, {
+    aggregation: 'daily',
+    channels: [{ id: 'ext_temperature_c', field: 'ext_temperature_c', unit: 'C' }],
+    start: '2026-07-10T00:00:00.000Z',
+    end: '2026-07-11T00:00:00.000Z',
+    timezone: 'UTC',
+    nowMs: Date.parse('2026-07-12T00:00:00.000Z'),
+    expectedCadences: { AA00000000000001: { seconds: 1200, confidence: 'configured' } },
+  });
+  assert.ok(result.coveragePct < 2, `completed windows keep the full denominator, got ${result.coveragePct}`);
+});
+
+test('aggregateRows reports null coverage for fully-future windows and buckets', () => {
+  const result = helper.aggregateRows([], {
+    aggregation: 'daily',
+    channels: [{ id: 'ext_temperature_c', field: 'ext_temperature_c', unit: 'C' }],
+    start: '2026-07-12T00:00:00.000Z',
+    end: '2026-07-13T00:00:00.000Z',
+    timezone: 'UTC',
+    nowMs: Date.parse('2026-07-11T06:00:00.000Z'),
+    expectedCadences: { AA00000000000001: { seconds: 1200, confidence: 'configured' } },
+  });
+  assert.strictEqual(result.coveragePct, null);
+  assert.strictEqual(result.buckets.length, 1);
+  assert.strictEqual(result.buckets[0].coveragePct, null);
 });

--- a/scripts/test-history-helper.js
+++ b/scripts/test-history-helper.js
@@ -2184,3 +2184,39 @@ test('verify-sync-flow chains SQL-backed history helper regression tests', () =>
   assert.match(verifySource, /test-history-helper\.js/);
   assert(!/execFileSync\(process\.execPath,\s*\[path\.resolve\(__dirname,\s*['"]verify-sync-flow\.js['"]\)/.test(verifySource), 'verify-sync-flow must not recursively execute itself');
 });
+
+test('rollupRowsToResult rejects rows spanning multiple logical source keys', () => {
+  const row = (key, mean) => ({
+    bucket_start: '2026-07-01T00:00:00.000Z',
+    bucket_end: '2026-07-02T00:00:00.000Z',
+    logical_source_key: key,
+    channel_id: 'swt_1',
+    min_value: mean, max_value: mean, mean_value: mean, median_value: mean, latest_value: mean,
+    dominant_status: null, sample_count: 4, event_count: 0, threshold_crossing_count: 0,
+    coverage_pct: 100, coverage_confidence: 'configured', unit: 'kPa',
+  });
+  assert.throws(
+    () => helper.rollupRowsToResult(
+      [row('root-zone', 10), row('src-aa01', 30)],
+      { aggregation: 'daily' },
+      [{ id: 'swt_1', field: 'swt_1', fields: ['swt_1'], unit: 'kPa' }],
+    ),
+    /single logical_source_key/,
+  );
+});
+
+test('rollupRowsToResult builds buckets from single-key rows', () => {
+  const rows = [{
+    bucket_start: '2026-07-01T00:00:00.000Z',
+    bucket_end: '2026-07-02T00:00:00.000Z',
+    logical_source_key: 'root-zone',
+    channel_id: 'swt_1',
+    min_value: 5, max_value: 15, mean_value: 10, median_value: 10, latest_value: 15,
+    dominant_status: null, sample_count: 4, event_count: 0, threshold_crossing_count: 0,
+    coverage_pct: 100, coverage_confidence: 'configured', unit: 'kPa',
+  }];
+  const result = helper.rollupRowsToResult(rows, { aggregation: 'daily' }, [{ id: 'swt_1', field: 'swt_1', fields: ['swt_1'], unit: 'kPa' }]);
+  assert.strictEqual(result.buckets.length, 1);
+  assert.strictEqual(result.buckets[0].series.swt_1.mean, 10);
+  assert.strictEqual(result.buckets[0].sampleCount, 4);
+});


### PR DESCRIPTION
## Summary
- **Task 1**: `rollupRowsToResult` now guards single-`logical_source_key` invariant with runtime check + contract documentation. Exported for direct testing.
- **Task 2**: Pins multi-device merged-scope rollup union semantics — `computeRollupBuckets` merges a multi-device scope into ONE combined row per bucket/channel.
- **Task 3**: Coverage denominators clamp at `nowMs` in `aggregateRows` — in-progress windows no longer penalize coverage for samples that couldn't have arrived yet. Retires the interim interpretation-layer rescaling workaround in `buildLocalInterpretations`.

## Test plan
- [x] `node scripts/test-history-helper.js` — 6 new tests covering guard rejection, single-key buckets, multi-device merge, in-progress clamp, completed-window unchanged, fully-future null
- [x] `node scripts/verify-profile-parity.js` — both profile copies byte-identical
- [x] No `flows.json` changes — helper-only