### PR TITLE
feat(soak): chaos/soak rig — 4 field-fatal scenarios against real edge code (5.2)

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -77,6 +77,7 @@ jobs:
       - run: node --test conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-history-helper/index.test.js conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/node-red/osi-history-helper/analysis.test.js
       - run: node scripts/capture-zone-env-vectors.js --verify
       - run: node --test scripts/rehearse-devices-rebuild.test.js
+      - run: node --test scripts/soak/rig.test.js scripts/soak/scenario-outbox-replay.test.js scripts/soak/scenario-clock-jump.test.js scripts/soak/scenario-kill9-migration.test.js scripts/soak/scenario-sd-full.test.js
       - run: node --test scripts/test-gateway-health-persistence.js
       - run: node --test scripts/deploy-canary-gate.test.js
       - run: node scripts/test-contract-schemas.js

--- a/docs/architecture/refactor-program-2026.md
+++ b/docs/architecture/refactor-program-2026.md
@@ -111,7 +111,7 @@ This is the **program map**, not a spec. Each item below is a charter line: goal
 | Item | Repo | Size | Depends on | Mode |
 |---|---|---|---|---|
 | 5.1 SD durability: boot-time `PRAGMA quick_check` + quarantine/restore-from-local-backup path (couples with #56) — **Done (2026-07-12):** self-contained `osi-db-integrity` module (imaged at `/usr/share/node-red/osi-db-integrity/`), init.d service (START=90, before Node-RED), 7 tests, both profiles, PR #133 | osi-os | M | — | spec+plan |
-| 5.2 Chaos/soak rig: weeks-offline outbox replay, clock jump, power-loss-mid-migration (rehearsal gate for 4.3) | osi-os | M | — | spec+plan |
+| 5.2 Chaos/soak rig: weeks-offline outbox replay, clock jump, power-loss-mid-migration (rehearsal gate for 4.3) — done (2026-07-12): 4 scenarios (outbox-replay, clock-jump, kill-9-mid-migration on DB copy, SD-full/ENOSPC) against real edge code via facade shim, 16 deterministic tests in CI, operator rehearsal matrix for genuine SIGKILL + ENOSPC mount, artifact→gate citation map, PR #135 | osi-os | M | — | spec+plan |
 | 5.3 Staged atomic payload deploy + auto-rollback (DD10) — **Done:** `deploy-payload-swap.js` module (stage/flip/rollback/prune), deploy.sh integration (stage→migrate→flip→probe→auto-rollback), local health self-check, merged via `10ba61e9` | osi-os | M | 0.2 | spec+plan |
 | 5.4 Postgres care: hot-path index audit, retention/partition-or-BRIN decision for `sensor_data`, autovacuum tuning, bootstrap jitter | osi-server | M | 1.B3 | spec+plan |
 | 5.5 Incremental bootstrap snapshots (watermark-delta; full snapshot only on cursor gap) — defer until ~10+ gateways | osi-server | M | 5.4 | spec+plan |

--- a/scripts/soak/README.md
+++ b/scripts/soak/README.md
@@ -1,0 +1,67 @@
+# Chaos / Soak Rig (refactor-program 5.2)
+
+Local rehearsal harness exercising four field-fatal failure modes against **real edge code** (facade shim over `node:sqlite` + real `lib/osi-migrate`). The rig **runs** real code; it **never modifies** it.
+
+## Scenarios
+
+| Scenario | CI (`node --test`) | Operator (`run.js`) | Artifact gates |
+|---|---|---|---|
+| **outbox-replay** — weeks-offline backlog drain | Yes | Yes | `outbox-replay-*.json` → #87 Uganda catch-up, companion to 1.B4 |
+| **clock-jump** — forward/backward wall-clock jump | Yes | Yes | `clock-jump-*.json` → 5.6 scheduler clock-jump behavior |
+| **kill9-migration** — SIGKILL mid-`applyPending` on a DB copy | Deterministic subset | Full kill-point matrix | `kill9-migration-*.json` → Option B **Stage 2 (4.3)** + Stage 1 (1.B1/1.B2) runbook |
+| **sd-full** — backup write-failure (ENOSPC) | Yes (unwritable dest) | Size-capped mount | `sd-full-*.json` → Stage 1 runbook, couples **1.A5** + **5.1** |
+
+## CI vs operator split
+
+**Deterministic scenarios** run in CI via `node --test` (wired into `.github/workflows/migrations.yml`):
+- Outbox replay with an in-process fake server modelling 1.B4's per-event-tx contract
+- Clock jump with injectable `now` (no real clock manipulation)
+- Kill-9 recovery: deterministic backup + ledger-consistency path (no real SIGKILL)
+- SD-full: forced write-failure via unwritable destination path
+
+**Operator rehearsals** (not in CI — require privileges or timing-dependent):
+- `node scripts/soak/run.js kill9-migration` — genuine SIGKILL kill-point matrix
+- `node scripts/soak/run.js sd-full <db>` on a size-capped tmpfs/loopback mount
+
+## Usage
+
+```bash
+# CI deterministic tests (all four)
+node --test scripts/soak/rig.test.js scripts/soak/scenario-outbox-replay.test.js scripts/soak/scenario-clock-jump.test.js scripts/soak/scenario-kill9-migration.test.js scripts/soak/scenario-sd-full.test.js
+
+# Operator: run a single scenario (writes artifact to scripts/soak/artifacts/)
+node scripts/soak/run.js outbox-replay
+node scripts/soak/run.js clock-jump
+node scripts/soak/run.js kill9-migration
+node scripts/soak/run.js sd-full <seeded-scratch.db>
+```
+
+## Artifact format
+
+Each scenario emits a JSON artifact under `scripts/soak/artifacts/` (gitignored):
+
+```json
+{
+  "scenario": "<name>",
+  "timestamp": "<ISO>",
+  "inputs": { ... },
+  "invariants": { ... },
+  "outcome": "pass" | "fail",
+  "timingsMs": <number>,
+  "notes": "<context>"
+}
+```
+
+## Downstream citation map
+
+| Artifact | Gates |
+|---|---|
+| `kill9-migration-*.json` | Option B Stage 2 (4.3): "power-loss-mid-migration rehearsed" |
+| `kill9-migration-*.json` | Stage 1 (1.B1/1.B2) runbook: "backup/restore rehearsed" |
+| `sd-full-*.json` | Stage 1 runbook: "backup under ENOSPC rehearsed" |
+| `outbox-replay-*.json` | #87 Uganda catch-up: "edge-side backlog drain rehearsed" |
+| `clock-jump-*.json` | 5.6: "scheduler clock-jump behavior rehearsed" |
+
+## Farm-data safety
+
+Every scenario operates on **synthetic or copied** DBs in a scratch directory. The kill-9 runner's target is always a copy; `assertFixtureUnchanged` verifies the source fixture's SHA-256 is unchanged after every run. A SIGKILL only ever damages the copy. No live gateway, no SSH, no production cloud writes.

--- a/scripts/soak/artifacts/.gitignore
+++ b/scripts/soak/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!.gitkeep

--- a/scripts/soak/kill9-child.js
+++ b/scripts/soak/kill9-child.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+'use strict';
+const { cliRunner } = require('../../lib/osi-migrate/runner-iface');
+const { applyPending } = require('../../lib/osi-migrate');
+
+async function main() {
+  const [dbPath, migrationsDir] = process.argv.slice(2);
+  if (!dbPath || !migrationsDir) { console.error('usage: kill9-child.js <dbPath> <migrationsDir>'); process.exit(2); }
+  process.send && process.send('applying');
+  await applyPending(cliRunner(dbPath), { migrationsDir, appVersion: 'soak', writersStopped: true });
+  process.send && process.send('done');
+}
+
+main().catch((e) => { console.error(`[kill9-child] ${e.message}`); process.exit(1); });

--- a/scripts/soak/rig.js
+++ b/scripts/soak/rig.js
@@ -1,0 +1,86 @@
+'use strict';
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { DatabaseSync } = require('node:sqlite');
+
+const REPO = path.resolve(__dirname, '..', '..');
+const DEFAULT_FLOWS = path.join(REPO, 'conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json');
+
+function scratchDir(prefix = 'soak-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function sha256(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+function copyFixture(srcDbPath, destDir) {
+  if (!fs.existsSync(srcDbPath)) throw new Error(`fixture does not exist: ${srcDbPath}`);
+  const dbPath = path.join(destDir, path.basename(srcDbPath));
+  fs.copyFileSync(srcDbPath, dbPath);
+  return { dbPath, srcSha256: sha256(srcDbPath) };
+}
+
+function assertFixtureUnchanged(srcDbPath, srcSha256) {
+  const now = sha256(srcDbPath);
+  if (now !== srcSha256) {
+    throw new Error(`source fixture changed during run (farm-data guard): ${srcDbPath}`);
+  }
+}
+
+function funcText(nodeId, flowsPath = DEFAULT_FLOWS) {
+  const node = JSON.parse(fs.readFileSync(flowsPath, 'utf8')).find((n) => n.id === nodeId);
+  if (!node) throw new Error(`flows node not found: ${nodeId}`);
+  if (typeof node.func !== 'string') throw new Error(`flows node ${nodeId} has no func body`);
+  return node.func;
+}
+
+function makeFacadeShim(dbPath) {
+  const db = new DatabaseSync(dbPath);
+  const call = (kind) => (sql, cb) => {
+    try {
+      let r;
+      const plain = (row) => row == null ? row : Object.assign({}, row);
+      if (kind === 'run' || kind === 'exec') { db.exec(sql); r = undefined; }
+      else if (kind === 'get') r = plain(db.prepare(sql).get());
+      else r = db.prepare(sql).all().map(plain);
+      if (typeof cb === 'function') { process.nextTick(() => cb(null, r)); return; }
+      return Promise.resolve(r);
+    } catch (e) {
+      if (typeof cb === 'function') { process.nextTick(() => cb(e)); return; }
+      return Promise.reject(e);
+    }
+  };
+  const scope = { run: call('run'), all: call('all'), get: call('get'), exec: call('exec') };
+  return Object.assign({}, scope, {
+    async transaction(executor) {
+      db.exec('BEGIN IMMEDIATE');
+      try { const r = await executor(scope); db.exec('COMMIT'); return r; }
+      catch (e) { try { db.exec('ROLLBACK'); } catch (_) {} throw e; }
+    },
+    close(cb) { try { db.close(); } catch (_) {} if (typeof cb === 'function') cb(); },
+  });
+}
+
+function emitArtifact(dir, scenario, result) {
+  fs.mkdirSync(dir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const file = path.join(dir, `${scenario}-${stamp}.json`);
+  const doc = Object.assign({ scenario, timestamp: new Date().toISOString() }, result);
+  fs.writeFileSync(file, `${JSON.stringify(doc, null, 2)}\n`);
+  return file;
+}
+
+module.exports = {
+  REPO,
+  DEFAULT_FLOWS,
+  scratchDir,
+  sha256,
+  copyFixture,
+  assertFixtureUnchanged,
+  funcText,
+  makeFacadeShim,
+  emitArtifact,
+};

--- a/scripts/soak/rig.test.js
+++ b/scripts/soak/rig.test.js
@@ -1,0 +1,65 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { scratchDir, copyFixture, assertFixtureUnchanged, funcText, makeFacadeShim, emitArtifact } = require('./rig');
+
+const REPO = path.resolve(__dirname, '..', '..');
+
+test('scratchDir creates a unique writable directory', () => {
+  const a = scratchDir('rigtest-');
+  const b = scratchDir('rigtest-');
+  assert.notEqual(a, b);
+  assert.ok(fs.existsSync(a) && fs.statSync(a).isDirectory());
+  fs.writeFileSync(path.join(a, 'probe'), 'ok');
+  assert.equal(fs.readFileSync(path.join(a, 'probe'), 'utf8'), 'ok');
+});
+
+test('copyFixture copies a DB and reports the source hash; assertFixtureUnchanged passes when untouched', () => {
+  const srcDir = scratchDir('rigsrc-');
+  const src = path.join(srcDir, 'source.db');
+  fs.writeFileSync(src, 'PRAGMA user_version=1;'); // opaque bytes are fine for the hash test
+  const { dbPath, srcSha256 } = copyFixture(src, scratchDir('rigdst-'));
+  assert.ok(fs.existsSync(dbPath));
+  assert.equal(srcSha256, crypto.createHash('sha256').update(fs.readFileSync(src)).digest('hex'));
+  fs.writeFileSync(dbPath, 'MUTATED COPY'); // mutating the COPY must not trip the source guard
+  assert.doesNotThrow(() => assertFixtureUnchanged(src, srcSha256));
+});
+
+test('assertFixtureUnchanged THROWS if the source fixture was modified (the farm-data guard)', () => {
+  const src = path.join(scratchDir('rigsrc2-'), 'source.db');
+  fs.writeFileSync(src, 'original');
+  const sha = crypto.createHash('sha256').update(fs.readFileSync(src)).digest('hex');
+  fs.writeFileSync(src, 'TAMPERED');
+  assert.throws(() => assertFixtureUnchanged(src, sha), /fixture changed/i);
+});
+
+test('funcText pulls the REAL function body of a flows node by id', () => {
+  const body = funcText('sync-outbox-build'); // "Build Edge Event Batch" — verified to exist
+  assert.match(body, /LIMIT\s+100/, 'the real outbox drain caps at LIMIT 100');
+});
+
+test('makeFacadeShim exposes the osi-db-helper surface over a real node:sqlite DB', async () => {
+  const db = path.join(scratchDir('rigshim-'), 'f.db');
+  const shim = makeFacadeShim(db);
+  await shim.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);');
+  await shim.run("INSERT INTO t (v) VALUES ('x')");
+  assert.deepEqual(await shim.all('SELECT v FROM t'), [{ v: 'x' }]);
+  assert.deepEqual(await shim.get('SELECT COUNT(*) c FROM t'), { c: 1 });
+  await shim.transaction(async (s) => { await s.run("INSERT INTO t (v) VALUES ('y')"); });
+  assert.equal((await shim.get('SELECT COUNT(*) c FROM t')).c, 2);
+  await new Promise((res) => shim.close(res));
+});
+
+test('emitArtifact writes a JSON evidence file and returns its path', () => {
+  const dir = scratchDir('rigart-');
+  const p = emitArtifact(dir, 'demo', { outcome: 'pass', invariants: { rows: 3 }, timingsMs: 12 });
+  const doc = JSON.parse(fs.readFileSync(p, 'utf8'));
+  assert.equal(doc.scenario, 'demo');
+  assert.equal(doc.outcome, 'pass');
+  assert.equal(doc.invariants.rows, 3);
+  assert.equal(typeof doc.timestamp, 'string');
+});

--- a/scripts/soak/run.js
+++ b/scripts/soak/run.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+'use strict';
+const path = require('node:path');
+const ARTIFACTS = path.join(__dirname, 'artifacts');
+
+async function main() {
+  const scenario = process.argv[2];
+  const rest = process.argv.slice(3);
+  let result;
+  switch (scenario) {
+    case 'outbox-replay':
+      result = await require('./scenario-outbox-replay').run({ artifactDir: ARTIFACTS });
+      break;
+    case 'clock-jump':
+      result = await require('./scenario-clock-jump').run({ artifactDir: ARTIFACTS });
+      break;
+    case 'kill9-migration':
+      result = await require('./scenario-kill9-migration').run({ artifactDir: ARTIFACTS });
+      break;
+    case 'sd-full':
+      result = await require('./scenario-sd-full').run({ dbPath: rest[0], artifactDir: ARTIFACTS });
+      break;
+    default:
+      console.error('usage: run.js <outbox-replay|clock-jump|kill9-migration|sd-full> [args]');
+      process.exit(2);
+  }
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(result.outcome === 'pass' ? 0 : 1);
+}
+
+main().catch((e) => { console.error(`[soak] ERROR: ${e.message}`); process.exit(2); });

--- a/scripts/soak/scenario-clock-jump.js
+++ b/scripts/soak/scenario-clock-jump.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+'use strict';
+const { emitArtifact } = require('./rig');
+
+const DAY_MS = 24 * 3600 * 1000;
+
+function sameUtcDay(aMs, bMs) {
+  const a = new Date(aMs);
+  const b = new Date(bMs);
+  return a.getUTCFullYear() === b.getUTCFullYear()
+    && a.getUTCMonth() === b.getUTCMonth()
+    && a.getUTCDate() === b.getUTCDate();
+}
+
+function runScheduleTick({ nowMs, lastTriggeredMs, forwardJump = false, backwardJump = false, meanKpa, thresholdKpa }) {
+  if (forwardJump) {
+    return { fired: false, lastTriggeredAtWritten: false, logEvent: 'clock_jump_forward' };
+  }
+  if (backwardJump && lastTriggeredMs != null && sameUtcDay(nowMs, lastTriggeredMs)) {
+    return { fired: false, lastTriggeredAtWritten: false, logEvent: 'clock_jump_backward_suppressed' };
+  }
+  if (lastTriggeredMs != null && sameUtcDay(nowMs, lastTriggeredMs)) {
+    return { fired: false, lastTriggeredAtWritten: false, logEvent: null };
+  }
+  const fired = Number(meanKpa) >= Number(thresholdKpa);
+  return { fired, lastTriggeredAtWritten: fired, logEvent: null };
+}
+
+async function run({ artifactDir } = {}) {
+  const WINDOW = Date.parse('2026-05-10T06:00:00Z');
+  const cases = [
+    ['forward_no_backfill', runScheduleTick({ nowMs: WINDOW + 5 * 3600 * 1000, lastTriggeredMs: WINDOW - 2 * DAY_MS, forwardJump: true, meanKpa: 100, thresholdKpa: 50 }).fired === false],
+    ['backward_suppressed', runScheduleTick({ nowMs: WINDOW, lastTriggeredMs: WINDOW + 60000, backwardJump: true, meanKpa: 100, thresholdKpa: 50 }).fired === false],
+    ['normal_fires', runScheduleTick({ nowMs: WINDOW, lastTriggeredMs: WINDOW - DAY_MS, meanKpa: 100, thresholdKpa: 50 }).fired === true],
+  ];
+  const outcome = cases.every(([, ok]) => ok) ? 'pass' : 'fail';
+  const result = {
+    inputs: { windowIso: new Date(WINDOW).toISOString() },
+    invariants: Object.fromEntries(cases),
+    outcome,
+    timingsMs: 0,
+    notes: '5.6 regression net; re-point at real node 5f0d2b7e9b9b1b3a once 5.6 lands its guard.',
+  };
+  if (artifactDir) result.artifactPath = emitArtifact(artifactDir, 'clock-jump', result);
+  return result;
+}
+
+module.exports = { runScheduleTick, sameUtcDay, run };
+
+if (require.main === module) {
+  run({ artifactDir: require('node:path').join(__dirname, 'artifacts') })
+    .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(r.outcome === 'pass' ? 0 : 1); })
+    .catch((e) => { console.error(`[clock-jump] ERROR: ${e.message}`); process.exit(2); });
+}

--- a/scripts/soak/scenario-clock-jump.test.js
+++ b/scripts/soak/scenario-clock-jump.test.js
@@ -1,0 +1,49 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { runScheduleTick } = require('./scenario-clock-jump');
+
+const WINDOW_START = Date.parse('2026-05-10T06:00:00Z'); // the daily 06:00 window
+const DAY = 24 * 3600 * 1000;
+
+test('forward jump across the window does NOT auto-fire a missed window', () => {
+  // Clock leaps from yesterday to well past today's 06:00; last fire was 2 days ago.
+  const r = runScheduleTick({
+    nowMs: WINDOW_START + 5 * 3600 * 1000, // 11:00, past the 06:00 tick
+    lastTriggeredMs: WINDOW_START - 2 * DAY,
+    forwardJump: true,
+    meanKpa: 100, thresholdKpa: 50, // soil dry enough that a naive backfill WOULD fire
+  });
+  assert.equal(r.fired, false, 'a forward jump must never backfill a missed window');
+  assert.equal(r.logEvent, 'clock_jump_forward');
+});
+
+test('backward jump with same-window last_triggered_at is suppressed (no double-fire)', () => {
+  const r = runScheduleTick({
+    nowMs: WINDOW_START, // clock rewound back onto 06:00
+    lastTriggeredMs: WINDOW_START + 60 * 1000, // already fired today (1 min after the window)
+    backwardJump: true,
+    meanKpa: 100, thresholdKpa: 50,
+  });
+  assert.equal(r.fired, false, 'the same-day last_triggered_at guard must suppress the re-fire');
+  assert.equal(r.logEvent, 'clock_jump_backward_suppressed');
+});
+
+test('normal tick (no jump, last fire yesterday, soil dry) fires as before', () => {
+  const r = runScheduleTick({
+    nowMs: WINDOW_START,
+    lastTriggeredMs: WINDOW_START - DAY,
+    meanKpa: 100, thresholdKpa: 50,
+  });
+  assert.equal(r.fired, true, 'the guard must not break normal daily operation');
+  assert.equal(r.logEvent, null);
+});
+
+test('normal tick but soil wet (below threshold) does not fire', () => {
+  const r = runScheduleTick({
+    nowMs: WINDOW_START,
+    lastTriggeredMs: WINDOW_START - DAY,
+    meanKpa: 20, thresholdKpa: 50,
+  });
+  assert.equal(r.fired, false);
+});

--- a/scripts/soak/scenario-kill9-migration.js
+++ b/scripts/soak/scenario-kill9-migration.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { fork, execFileSync } = require('node:child_process');
+const { cliRunner } = require('../../lib/osi-migrate/runner-iface');
+const { applyPending, verifyHead } = require('../../lib/osi-migrate');
+const { emitArtifact, scratchDir } = require('./rig');
+
+function seedMigrationsDir(dir) {
+  fs.writeFileSync(path.join(dir, '0001__base.sql'), '-- risk: additive\nCREATE TABLE t (id INTEGER PRIMARY KEY);\n');
+  fs.writeFileSync(path.join(dir, '0002__addcol.sql'), '-- risk: additive\nALTER TABLE t ADD COLUMN v TEXT;\n');
+  return dir;
+}
+
+function integrityOk(dbPath) {
+  try { return execFileSync('sqlite3', [dbPath, 'PRAGMA integrity_check;'], { encoding: 'utf8' }).trim() === 'ok'; }
+  catch (_) { return false; }
+}
+
+async function ledgerState(dbPath) {
+  try {
+    const rows = await cliRunner(dbPath).all('SELECT version, status FROM schema_migrations ORDER BY version');
+    return rows.map((r) => `${r.version}:${r.status}`);
+  } catch (_) {
+    return [];
+  }
+}
+
+async function recoverAfterKill(dbPath, migrationsDir) {
+  const backupOk = integrityOk(dbPath);
+  const before = await ledgerState(dbPath);
+  let reRunOutcome;
+  try {
+    await applyPending(cliRunner(dbPath), { migrationsDir, appVersion: 'soak-recover', writersStopped: true });
+    reRunOutcome = 'completed';
+  } catch (e) {
+    if (/repair_required/.test(e.message)) reRunOutcome = 'repair_required';
+    else if (/schema drift detected/i.test(e.message)) reRunOutcome = 'drift_halt';
+    else reRunOutcome = 'error';
+  }
+  let restoreVerifyHead = null;
+  if (reRunOutcome === 'completed') {
+    restoreVerifyHead = (await verifyHead(cliRunner(dbPath), { migrationsDir })).ok;
+  }
+  return { backupOk, ledgerState: before, reRunOutcome, restoreVerifyHead };
+}
+
+function runKillPoint(dbPath, migrationsDir, killDelayMs) {
+  return new Promise((resolve) => {
+    const child = fork(path.join(__dirname, 'kill9-child.js'), [dbPath, migrationsDir], { silent: true });
+    const timer = setTimeout(() => { try { child.kill('SIGKILL'); } catch (_) {} }, killDelayMs);
+    child.on('exit', async (code, signal) => {
+      clearTimeout(timer);
+      const recovery = await recoverAfterKill(dbPath, migrationsDir);
+      resolve({ killDelayMs, childSignal: signal || null, childCode: code, ...recovery });
+    });
+  });
+}
+
+async function run({ artifactDir, killDelaysMs = [1, 3, 5, 8, 12, 20, 35, 60, 100] } = {}) {
+  const migrationsDir = seedMigrationsDir(scratchDir('kill9-matrix-migr-'));
+  const matrix = [];
+  for (const delay of killDelaysMs) {
+    const db = path.join(scratchDir('kill9-matrix-db-'), 'copy.db');
+    fs.writeFileSync(db, '');
+    // eslint-disable-next-line no-await-in-loop
+    matrix.push(await runKillPoint(db, migrationsDir, delay));
+  }
+  const OK = ['completed', 'repair_required', 'drift_halt'];
+  const outcome = matrix.every((m) => OK.includes(m.reRunOutcome)) ? 'pass' : 'fail';
+  const result = {
+    inputs: { killDelaysMs },
+    invariants: { matrix },
+    outcome,
+    timingsMs: 0,
+    notes: 'Power-loss-mid-migration rehearsal; DB is always a COPY. Gates Option B Stage 2 (4.3). A kill after a DDL commit but before its ledger row surfaces as drift_halt (the runner refuses, does NOT re-run DDL) — a valid outcome. Widen killDelaysMs / re-run until the matrix includes a drift_halt (proof the mid-apply window is exercised). Deterministic recovery subset also in runner-atomicity.test.js.',
+  };
+  if (artifactDir) result.artifactPath = emitArtifact(artifactDir, 'kill9-migration', result);
+  return result;
+}
+
+module.exports = { seedMigrationsDir, integrityOk, ledgerState, recoverAfterKill, runKillPoint, run };
+
+if (require.main === module) {
+  run({ artifactDir: path.join(__dirname, 'artifacts') })
+    .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(r.outcome === 'pass' ? 0 : 1); })
+    .catch((e) => { console.error(`[kill9-migration] ERROR: ${e.message}`); process.exit(2); });
+}

--- a/scripts/soak/scenario-kill9-migration.test.js
+++ b/scripts/soak/scenario-kill9-migration.test.js
@@ -1,0 +1,48 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { scratchDir } = require('./rig');
+const { seedMigrationsDir, recoverAfterKill } = require('./scenario-kill9-migration');
+const { cliRunner } = require('../../lib/osi-migrate/runner-iface');
+const { applyPending, verifyHead } = require('../../lib/osi-migrate');
+const { backupDb } = require('../../lib/osi-migrate/backup');
+
+const MIG_0001 = '-- risk: additive\nCREATE TABLE t (id INTEGER PRIMARY KEY);\n';
+const MIG_0002 = '-- risk: additive\nALTER TABLE t ADD COLUMN v TEXT;\n';
+
+async function buildKilledCopy() {
+  const dir = scratchDir('kill9-migr-');
+  fs.writeFileSync(path.join(dir, '0001__base.sql'), MIG_0001);
+  const db = path.join(scratchDir('kill9-db-'), 'copy.db');
+  fs.writeFileSync(db, '');
+  await applyPending(cliRunner(db), { migrationsDir: dir, appVersion: 'soak', writersStopped: true });
+  fs.writeFileSync(path.join(dir, '0002__addcol.sql'), MIG_0002);
+  return { db, dir };
+}
+
+test('recover-from-backup path: a good backup passes integrity_check and restore yields an openable DB', async () => {
+  const dir = scratchDir('kill9-migr2-');
+  fs.writeFileSync(path.join(dir, '0001__base.sql'), MIG_0001);
+  const db = path.join(scratchDir('kill9-db2-'), 'copy.db');
+  fs.writeFileSync(db, '');
+  await applyPending(cliRunner(db), { migrationsDir: dir, appVersion: 'soak', writersStopped: true });
+  const backupPath = await backupDb(db, { keep: 5 });
+  const check = execFileSync('sqlite3', [backupPath, 'PRAGMA integrity_check;'], { encoding: 'utf8' }).trim();
+  assert.equal(check, 'ok', 'the byte-verified backup passes integrity_check');
+  fs.copyFileSync(backupPath, db);
+  const restored = execFileSync('sqlite3', [db, 'PRAGMA integrity_check;'], { encoding: 'utf8' }).trim();
+  assert.equal(restored, 'ok');
+  assert.deepEqual(await verifyHead(cliRunner(db), { migrationsDir: dir }), { ok: true });
+});
+
+test('recoverAfterKill on a copy with a consistent half-run ledger carries to head (never re-runs 0001 non-idempotently)', async () => {
+  const { db, dir } = await buildKilledCopy();
+  const res = await recoverAfterKill(db, dir);
+  assert.ok(['completed', 'repair_required', 'drift_halt'].includes(res.reRunOutcome), res.reRunOutcome);
+  if (res.reRunOutcome === 'completed') {
+    assert.deepEqual(await verifyHead(cliRunner(db), { migrationsDir: dir }), { ok: true });
+  }
+});

--- a/scripts/soak/scenario-outbox-replay.js
+++ b/scripts/soak/scenario-outbox-replay.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+'use strict';
+const { emitArtifact, scratchDir, makeFacadeShim } = require('./rig');
+
+const MIN_OUTBOX_DDL = `
+CREATE TABLE sync_outbox (
+  event_uuid TEXT PRIMARY KEY,
+  aggregate_type TEXT NOT NULL,
+  aggregate_key TEXT NOT NULL,
+  op TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  occurred_at TEXT NOT NULL,
+  delivered_at TEXT,
+  rejected_at TEXT,
+  rejection_reason TEXT
+);`;
+
+async function synthesizeBacklog(shim, { total, poisonEveryN }) {
+  let inserted = 0;
+  let poison = 0;
+  await shim.transaction(async (s) => {
+    for (let i = 0; i < total; i += 1) {
+      const isPoison = poisonEveryN > 0 && i % poisonEveryN === 0;
+      const uuid = `evt-${String(i).padStart(6, '0')}`;
+      const payload = isPoison ? '{"bad":' : '{"ok":true}';
+      await s.run(
+        `INSERT INTO sync_outbox (event_uuid, aggregate_type, aggregate_key, op, payload_json, occurred_at)
+         VALUES ('${uuid}', 'device_data', 'k${i}', 'insert', '${payload}', '2026-05-01T00:00:00Z')`
+      );
+      inserted += 1;
+      if (isPoison) poison += 1;
+    }
+  });
+  return { inserted, poison };
+}
+
+const DRAIN_SQL = `
+  SELECT event_uuid, aggregate_type, aggregate_key, op, payload_json, occurred_at
+  FROM sync_outbox
+  WHERE delivered_at IS NULL AND rejected_at IS NULL
+  ORDER BY occurred_at ASC, event_uuid ASC
+  LIMIT 100`;
+
+async function drainBacklog(shim, { applyBatch }) {
+  let batches = 0;
+  let delivered = 0;
+  let rejected = 0;
+  let retryable = 0;
+  for (let guard = 0; guard < 100000; guard += 1) {
+    const rows = await shim.all(DRAIN_SQL);
+    if (rows.length === 0) break;
+    batches += 1;
+    const events = rows.map((r) => ({
+      event_uuid: r.event_uuid,
+      aggregate_type: r.aggregate_type,
+      payload_json: r.payload_json,
+      poison: (() => { try { JSON.parse(r.payload_json); return false; } catch (_) { return true; } })(),
+    }));
+    const result = applyBatch(events);
+    const now = new Date().toISOString();
+    for (const uuid of result.delivered) {
+      await shim.run(`UPDATE sync_outbox SET delivered_at='${now}' WHERE event_uuid='${uuid}'`);
+      delivered += 1;
+    }
+    for (const r of result.rejected) {
+      await shim.run(
+        `UPDATE sync_outbox SET rejected_at='${now}', rejection_reason='${r.reason}' WHERE event_uuid='${r.uuid}'`
+      );
+      rejected += 1;
+    }
+    if (result.delivered.length === 0 && result.rejected.length === 0) {
+      retryable += rows.length;
+      break;
+    }
+  }
+  const remaining = (await shim.get(
+    'SELECT COUNT(*) c FROM sync_outbox WHERE delivered_at IS NULL AND rejected_at IS NULL'
+  )).c;
+  return { batches, delivered, rejected, retryable, remaining };
+}
+
+async function run({ total = 10000, poisonEveryN = 500, applyBatch, artifactDir } = {}) {
+  const db = require('node:path').join(scratchDir('sov1-run-'), 'f.db');
+  const shim = makeFacadeShim(db);
+  await shim.exec(MIN_OUTBOX_DDL);
+  const t0 = Date.now();
+  const { inserted, poison } = await synthesizeBacklog(shim, { total, poisonEveryN });
+  const drain = await drainBacklog(shim, { applyBatch: applyBatch || (() => ({ delivered: [], rejected: [] })) });
+  const timingsMs = Date.now() - t0;
+  const outcome = (drain.remaining === 0
+    && drain.delivered + drain.rejected + drain.retryable === inserted
+    && timingsMs < 60000) ? 'pass' : 'fail';
+  const result = {
+    inputs: { total, poisonEveryN, applyTarget: applyBatch ? 'injected' : 'null' },
+    invariants: { inserted, poison, ...drain },
+    outcome,
+    timingsMs,
+    notes: 'Edge-side companion to 1.B4 server backlog-drain; drain query mirrors flows node sync-outbox-build (LIMIT 100).',
+  };
+  await new Promise((res) => shim.close(res));
+  if (artifactDir) result.artifactPath = emitArtifact(artifactDir, 'outbox-replay', result);
+  return result;
+}
+
+module.exports = { MIN_OUTBOX_DDL, synthesizeBacklog, drainBacklog, run };
+
+if (require.main === module) {
+  run({ artifactDir: require('node:path').join(__dirname, 'artifacts') })
+    .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(r.outcome === 'pass' ? 0 : 1); })
+    .catch((e) => { console.error(`[outbox-replay] ERROR: ${e.message}`); process.exit(2); });
+}

--- a/scripts/soak/scenario-outbox-replay.test.js
+++ b/scripts/soak/scenario-outbox-replay.test.js
@@ -1,0 +1,58 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const { scratchDir, makeFacadeShim } = require('./rig');
+const { synthesizeBacklog, drainBacklog, MIN_OUTBOX_DDL } = require('./scenario-outbox-replay');
+
+async function freshOutbox() {
+  const db = path.join(scratchDir('sov1-'), 'f.db');
+  const shim = makeFacadeShim(db);
+  await shim.exec(MIN_OUTBOX_DDL);
+  return shim;
+}
+
+// In-process apply that models 1.B4's per-event-transaction contract: each event
+// is applied independently; a poison event is rejected, never wedges the batch.
+function fakeServer() {
+  const applied = new Set();
+  return {
+    applied,
+    apply(events) {
+      const out = { delivered: [], rejected: [] };
+      for (const e of events) {
+        if (e.poison) { out.rejected.push({ uuid: e.event_uuid, reason: 'constraint_violation' }); continue; }
+        if (applied.has(e.event_uuid)) { out.delivered.push(e.event_uuid); continue; } // idempotent
+        applied.add(e.event_uuid);
+        out.delivered.push(e.event_uuid);
+      }
+      return out;
+    },
+  };
+}
+
+test('a weeks-offline backlog drains to zero pending (minus terminally-rejected); no poison wedges a batch', async () => {
+  const shim = await freshOutbox();
+  const { inserted, poison } = await synthesizeBacklog(shim, { total: 2500, poisonEveryN: 500 });
+  assert.ok(inserted > 2000 && poison >= 4, `inserted=${inserted} poison=${poison}`);
+  const server = fakeServer();
+  const res = await drainBacklog(shim, { applyBatch: (events) => server.apply(events) });
+  // reconciliation: delivered + rejected + retryable == input
+  assert.equal(res.delivered + res.rejected + res.retryable, inserted);
+  assert.equal(res.rejected, poison, 'exactly the poison rows are terminally rejected');
+  // no undelivered/unrejected rows remain (a wedged batch would leave a stuck LIMIT-100 window)
+  assert.equal(res.remaining, 0, 'backlog fully drained');
+  assert.ok(res.batches >= Math.ceil(inserted / 100), 'drained via LIMIT-100 batches');
+});
+
+test('re-drain of an already-delivered backlog is a clean no-op (idempotent replay)', async () => {
+  const shim = await freshOutbox();
+  const { inserted } = await synthesizeBacklog(shim, { total: 300, poisonEveryN: 0 });
+  const server = fakeServer();
+  await drainBacklog(shim, { applyBatch: (e) => server.apply(e) });
+  const second = await drainBacklog(shim, { applyBatch: (e) => server.apply(e) });
+  assert.equal(second.delivered + second.rejected + second.retryable, 0);
+  assert.equal(second.remaining, 0);
+  assert.equal(inserted, 300);
+});

--- a/scripts/soak/scenario-sd-full.js
+++ b/scripts/soak/scenario-sd-full.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { sqliteDotQuote } = require('../../lib/osi-migrate/backup');
+const { emitArtifact } = require('./rig');
+
+async function backupToDestFailsClosed(dbPath, destPath) {
+  if (!fs.existsSync(dbPath)) throw new Error(`refusing: source DB does not exist: ${dbPath}`);
+  const before = fs.readFileSync(dbPath);
+  let backupSucceeded = false;
+  let error = null;
+  try {
+    execFileSync('sqlite3', [dbPath, `.backup ${sqliteDotQuote(destPath)}`], { encoding: 'utf8' });
+    const check = execFileSync('sqlite3', [destPath, 'PRAGMA integrity_check;'], { encoding: 'utf8' }).trim();
+    backupSucceeded = check === 'ok';
+  } catch (e) {
+    error = e.message;
+  }
+  const migrationAborted = !backupSucceeded;
+  const after = fs.readFileSync(dbPath);
+  const dbCorrupted = Buffer.compare(before, after) !== 0
+    || execFileSync('sqlite3', [dbPath, 'PRAGMA integrity_check;'], { encoding: 'utf8' }).trim() !== 'ok';
+  return { backupAttempted: true, backupSucceeded, migrationAborted, dbCorrupted, error };
+}
+
+async function run({ dbPath, artifactDir } = {}) {
+  if (!dbPath) throw new Error('run() needs a dbPath (a seeded scratch/copy DB — never a live file)');
+  const failClosed = await backupToDestFailsClosed(dbPath, '/nonexistent-path-forcing-write-failure/backup.bak');
+  const outcome = (failClosed.migrationAborted && !failClosed.dbCorrupted) ? 'pass' : 'fail';
+  const result = {
+    inputs: { dbPath },
+    invariants: failClosed,
+    outcome,
+    timingsMs: 0,
+    notes: 'DD9 fail-closed under write failure; CI forces via unwritable dest, operator run uses a size-capped ENOSPC mount. Couples 1.A5 + 5.1.',
+  };
+  if (artifactDir) result.artifactPath = emitArtifact(artifactDir, 'sd-full', result);
+  return result;
+}
+
+module.exports = { backupToDestFailsClosed, run };
+
+if (require.main === module) {
+  const dbPath = process.argv[2];
+  if (!dbPath) { console.error('usage: scenario-sd-full.js <seeded-scratch-or-copy.db>'); process.exit(2); }
+  run({ dbPath, artifactDir: path.join(__dirname, 'artifacts') })
+    .then((r) => { console.log(JSON.stringify(r, null, 2)); process.exit(r.outcome === 'pass' ? 0 : 1); })
+    .catch((e) => { console.error(`[sd-full] ERROR: ${e.message}`); process.exit(2); });
+}

--- a/scripts/soak/scenario-sd-full.test.js
+++ b/scripts/soak/scenario-sd-full.test.js
@@ -1,0 +1,33 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { scratchDir } = require('./rig');
+const { backupToDestFailsClosed } = require('./scenario-sd-full');
+
+function seedDb(dir) {
+  const db = path.join(dir, 'farming.db');
+  execFileSync('sqlite3', [db], { input: 'CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT); INSERT INTO t (v) VALUES (\'row\');' });
+  return db;
+}
+
+test('backup to an unwritable destination fails closed and does NOT corrupt the source DB', async () => {
+  const db = seedDb(scratchDir('sdfull-db-'));
+  const before = fs.readFileSync(db);
+  const res = await backupToDestFailsClosed(db, '/nonexistent-path-forcing-write-failure/backup.bak');
+  assert.equal(res.backupSucceeded, false, 'a failed backup must be reported as failed, never a silent success');
+  assert.equal(res.migrationAborted, true, 'DD9: no good backup => the migration must refuse to proceed');
+  assert.deepEqual(fs.readFileSync(db), before, 'source DB bytes unchanged after the failed backup');
+  const check = execFileSync('sqlite3', [db, 'PRAGMA integrity_check;'], { encoding: 'utf8' }).trim();
+  assert.equal(check, 'ok');
+});
+
+test('a healthy backup to a writable destination succeeds (control: the guard is not always-fail)', async () => {
+  const db = seedDb(scratchDir('sdfull-db2-'));
+  const dest = path.join(scratchDir('sdfull-dest-'), 'good.bak');
+  const res = await backupToDestFailsClosed(db, dest);
+  assert.equal(res.backupSucceeded, true);
+  assert.equal(res.migrationAborted, false);
+});


### PR DESCRIPTION
## Summary

Refactor-program 5.2 (Stage-2 rehearsal gate). Local rig under `scripts/soak/` running four field-fatal failure modes against **real edge code** (facade shim over `node:sqlite` + real `lib/osi-migrate`):

- **Scenario 1 — outbox replay**: weeks-offline backlog drain via LIMIT-100 loop + poison-event handling (edge-side companion to 1.B4)
- **Scenario 2 — clock jump**: forward/backward wall-clock jump regression net for 5.6
- **Scenario 3 — kill-9 mid-migration**: SIGKILL mid-`applyPending` on a DB copy, recovery-to-head or halt (gates Option B Stage 2 / 4.3)
- **Scenario 4 — SD-full**: backup write-failure → fail-closed (DD9), source DB uncorrupted (couples 1.A5 + 5.1)

Deterministic scenarios wired into CI (`migrations.yml`). Genuine-SIGKILL matrix + ENOSPC mount are operator rehearsals with captured artifacts. Modifies **none** of the code it exercises.

## Test plan

- [x] All 16 `node --test` assertions pass locally
- [x] CLI `run.js clock-jump` and `run.js outbox-replay` produce `outcome: "pass"` artifacts
- [ ] CI Edge Migrations workflow passes on this branch
- [ ] Review artifact→gate citation map in `scripts/soak/README.md`