### PR TITLE
feat(4.1): LSN50 writer cutover — normalize + device-writer with kill-switch

### DIFF
--- a/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2709/files/usr/share/flows.json
@@ -4078,7 +4078,7 @@
     "y": 200,
     "wires": [
       [
-        "lsn50-sql-fn"
+        "460e0bfd95f89e67"
       ]
     ]
   },
@@ -11034,6 +11034,34 @@
     "y": 260,
     "wires": [
       []
+    ]
+  },
+  {
+    "id": "460e0bfd95f89e67",
+    "type": "function",
+    "z": "lsn50-tab",
+    "name": "LSN50 Normalize + Write",
+    "func": "var d = msg.formattedData;\nif (!d || !d.devEui) { node.error(\"formattedData missing\", msg); return null; }\n\nif (env.get(\"LSN50_WRITER_DISABLE\")) {\n  node.status({ fill: \"yellow\", shape: \"ring\", text: \"kill-switch active\" });\n  return [null, msg];\n}\n\nvar normRes = osiLib.require(\"lsn50-normalize\");\nif (!normRes.ok) { node.warn(\"lsn50-normalize quarantined: \" + normRes.error); return [null, msg]; }\n\nvar writerRes = osiLib.require(\"device-writer\");\nif (!writerRes.ok) { node.warn(\"device-writer quarantined: \" + writerRes.error); return [null, msg]; }\n\nvar deveui = String(d.devEui).toUpperCase().trim();\nif (!deveui) { node.error(\"LSN50: empty devEui\"); return null; }\n\nvar fs = global.get(\"fs\");\nvar edgeManifest;\ntry { edgeManifest = JSON.parse(fs.readFileSync(\"/srv/node-red/edge-channels.json\", \"utf8\")); }\ncatch (e) { node.error(\"edge-channels.json load failed: \" + e.message); return [null, msg]; }\n\nvar decoded = {\n  devEui: d.devEui, timestamp: d.timestamp, detectedMode: d.detectedMode,\n  tempC1: d.tempC1, batV: d.batV,\n  adcV: d.adcV, adcCh1V: d.adcCh1V,\n  swt1Kpa: d.swt1Kpa, swt2Kpa: d.swt2Kpa, swt3Kpa: d.swt3Kpa,\n  dendroRatio: d.dendroRatio, dendroModeUsed: d.dendroModeUsed,\n  positionRawMm: d.positionRawMm, positionMm: d.positionMm,\n  dendroValid: d.dendroValid, deltaMm: d.deltaMm,\n  dendroStemChangeUm: d.dendroStemChangeUm,\n  dendroSaturated: d.dendroSaturated, dendroSaturationSide: d.dendroSaturationSide,\n  rainCountCumulative: d.rainCountCumulative, rainTipsDelta: d.rainTipsDelta,\n  rainMmDelta: d.rainMmDelta, rainMmPerHour: d.rainMmPerHour,\n  rainMmPer10Min: d.rainMmPer10Min, rainMmToday: d.rainMmToday,\n  rainDeltaStatus: d.rainDeltaStatus,\n  flowCountCumulative: d.flowCountCumulative, flowPulsesDelta: d.flowPulsesDelta,\n  flowLitersDelta: d.flowLitersDelta, flowLitersPerMin: d.flowLitersPerMin,\n  flowLitersPer10Min: d.flowLitersPer10Min, flowLitersToday: d.flowLitersToday,\n  flowDeltaStatus: d.flowDeltaStatus,\n  counterIntervalSeconds: d.counterIntervalSeconds,\n  modeCodeToStore: d.modeCodeToStore, modeLabelToStore: d.modeLabelToStore,\n  observedModeObservedAt: d.observedModeObservedAt\n};\n\nvar normalizeResult = normRes.value.normalize(decoded, { recordedAt: d.timestamp });\n\nvar db = new osiDb.Database(\"/data/db/farming.db\");\ntry {\n  var result = writerRes.value.writeDeviceData(db, edgeManifest, normalizeResult, { deveui: deveui }, { node: node });\n  if (result.deadLettered.length > 0) {\n    node.warn(\"LSN50 dead-lettered \" + result.deadLettered.length + \" channels for \" + deveui);\n  }\n  node.status({ fill: \"green\", shape: \"dot\", text: \"LSN50 \" + deveui + \" cols=\" + result.columns.length });\n} catch (e) {\n  node.error(\"LSN50 write failed: \" + e.message);\n  return [null, msg];\n} finally {\n  db.close();\n}\n\nreturn [msg, null];",
+    "outputs": 2,
+    "libs": [
+      {
+        "var": "osiDb",
+        "module": "osi-db-helper"
+      },
+      {
+        "var": "osiLib",
+        "module": "osi-lib"
+      }
+    ],
+    "x": 820,
+    "y": 200,
+    "wires": [
+      [
+        "lsn50-zone-agg-fn"
+      ],
+      [
+        "lsn50-sql-fn"
+      ]
     ]
   }
 ]

--- a/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
+++ b/conf/full_raspberrypi_bcm27xx_bcm2712/files/usr/share/flows.json
@@ -4078,7 +4078,7 @@
     "y": 200,
     "wires": [
       [
-        "lsn50-sql-fn"
+        "460e0bfd95f89e67"
       ]
     ]
   },
@@ -11034,6 +11034,34 @@
     "y": 260,
     "wires": [
       []
+    ]
+  },
+  {
+    "id": "460e0bfd95f89e67",
+    "type": "function",
+    "z": "lsn50-tab",
+    "name": "LSN50 Normalize + Write",
+    "func": "var d = msg.formattedData;\nif (!d || !d.devEui) { node.error(\"formattedData missing\", msg); return null; }\n\nif (env.get(\"LSN50_WRITER_DISABLE\")) {\n  node.status({ fill: \"yellow\", shape: \"ring\", text: \"kill-switch active\" });\n  return [null, msg];\n}\n\nvar normRes = osiLib.require(\"lsn50-normalize\");\nif (!normRes.ok) { node.warn(\"lsn50-normalize quarantined: \" + normRes.error); return [null, msg]; }\n\nvar writerRes = osiLib.require(\"device-writer\");\nif (!writerRes.ok) { node.warn(\"device-writer quarantined: \" + writerRes.error); return [null, msg]; }\n\nvar deveui = String(d.devEui).toUpperCase().trim();\nif (!deveui) { node.error(\"LSN50: empty devEui\"); return null; }\n\nvar fs = global.get(\"fs\");\nvar edgeManifest;\ntry { edgeManifest = JSON.parse(fs.readFileSync(\"/srv/node-red/edge-channels.json\", \"utf8\")); }\ncatch (e) { node.error(\"edge-channels.json load failed: \" + e.message); return [null, msg]; }\n\nvar decoded = {\n  devEui: d.devEui, timestamp: d.timestamp, detectedMode: d.detectedMode,\n  tempC1: d.tempC1, batV: d.batV,\n  adcV: d.adcV, adcCh1V: d.adcCh1V,\n  swt1Kpa: d.swt1Kpa, swt2Kpa: d.swt2Kpa, swt3Kpa: d.swt3Kpa,\n  dendroRatio: d.dendroRatio, dendroModeUsed: d.dendroModeUsed,\n  positionRawMm: d.positionRawMm, positionMm: d.positionMm,\n  dendroValid: d.dendroValid, deltaMm: d.deltaMm,\n  dendroStemChangeUm: d.dendroStemChangeUm,\n  dendroSaturated: d.dendroSaturated, dendroSaturationSide: d.dendroSaturationSide,\n  rainCountCumulative: d.rainCountCumulative, rainTipsDelta: d.rainTipsDelta,\n  rainMmDelta: d.rainMmDelta, rainMmPerHour: d.rainMmPerHour,\n  rainMmPer10Min: d.rainMmPer10Min, rainMmToday: d.rainMmToday,\n  rainDeltaStatus: d.rainDeltaStatus,\n  flowCountCumulative: d.flowCountCumulative, flowPulsesDelta: d.flowPulsesDelta,\n  flowLitersDelta: d.flowLitersDelta, flowLitersPerMin: d.flowLitersPerMin,\n  flowLitersPer10Min: d.flowLitersPer10Min, flowLitersToday: d.flowLitersToday,\n  flowDeltaStatus: d.flowDeltaStatus,\n  counterIntervalSeconds: d.counterIntervalSeconds,\n  modeCodeToStore: d.modeCodeToStore, modeLabelToStore: d.modeLabelToStore,\n  observedModeObservedAt: d.observedModeObservedAt\n};\n\nvar normalizeResult = normRes.value.normalize(decoded, { recordedAt: d.timestamp });\n\nvar db = new osiDb.Database(\"/data/db/farming.db\");\ntry {\n  var result = writerRes.value.writeDeviceData(db, edgeManifest, normalizeResult, { deveui: deveui }, { node: node });\n  if (result.deadLettered.length > 0) {\n    node.warn(\"LSN50 dead-lettered \" + result.deadLettered.length + \" channels for \" + deveui);\n  }\n  node.status({ fill: \"green\", shape: \"dot\", text: \"LSN50 \" + deveui + \" cols=\" + result.columns.length });\n} catch (e) {\n  node.error(\"LSN50 write failed: \" + e.message);\n  return [null, msg];\n} finally {\n  db.close();\n}\n\nreturn [msg, null];",
+    "outputs": 2,
+    "libs": [
+      {
+        "var": "osiDb",
+        "module": "osi-db-helper"
+      },
+      {
+        "var": "osiLib",
+        "module": "osi-lib"
+      }
+    ],
+    "x": 820,
+    "y": 200,
+    "wires": [
+      [
+        "lsn50-zone-agg-fn"
+      ],
+      [
+        "lsn50-sql-fn"
+      ]
     ]
   }
 ]


### PR DESCRIPTION
## Summary
- **Replaces** the hand-built SQL INSERT path (`lsn50-sql-fn` → `lsn50-sqlite`) with the same `osi-lsn50-normalize` + `osi-device-writer` pattern used by UC512 (3.1)
- **New node** "LSN50 Normalize + Write" (`460e0bfd95f89e67`) sits between `lsn50-apply-config` and `lsn50-zone-agg-fn`
- **UCI kill-switch** (DD8): set `LSN50_WRITER_DISABLE=1` in Node-RED env to fall back to old SQL path; delete after convergence
- Old nodes preserved as kill-switch fallback (not orphaned)

## Architecture

```
lsn50-apply-config
  → [NEW] LSN50 Normalize + Write
    output 0 → lsn50-zone-agg-fn (new writer path)
    output 1 → lsn50-sql-fn → lsn50-sqlite → lsn50-zone-agg-fn (kill-switch fallback)
```

The new node:
1. Reads `msg.formattedData` from the decode+config chain
2. Builds a filtered `decoded` object (sensor channels + envelope only; downstream-only metadata like chameleon flags excluded)
3. Calls `lsn50-normalize` → `device-writer.writeDeviceData()` through osi-lib
4. Passes `msg` through with `formattedData` intact for downstream nodes (zone-agg, chameleon, dendro)
5. On any failure or kill-switch, falls back to output 1 (old path)

## Evidence bar (DD7)
Validated on kaba100 (prior to this PR):
- 621 LSN50 uplinks via shadow-compare, 0 column diffs
- 0 quarantine entries
- 4+ weeks of live data

## Test plan
- [x] Roundtrip byte-check on both profiles
- [x] Profile parity (`verify-profile-parity.js`): passed
- [x] Flows wiring guards (`test-flows-wiring.js`): all PASS (osiDb close, libs, STREGA, WS2/WS3)
- [x] Sync flow verification (`verify-sync-flow.js`): passed
- [x] MQTT topic check: passed
- [x] Helper registration: passed
- [x] Migration tests: 7/7 passed
- [x] Normalizer→manifest mapping: 19 channels (default) + 20 channels (mode 9), all mapped, 0 unknowns
- [ ] Deploy to kaba100 demo gateway — verify new writer produces same data as old path
- [ ] Kill-switch test: set `LSN50_WRITER_DISABLE=1`, verify fallback to old SQL path
- [ ] Remove kill-switch after convergence window (DD8 cleanup, separate PR)

## Known: dendro double-insert (pre-existing)
The `sync_dendro_to_readings` trigger on `device_data` AND the downstream `dendro-readings-insert-fn` both insert into `dendrometer_readings` — this exists on the old path too and is not changed by this PR. Tracked for separate cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated normalization and storage of incoming device data.
  - Added validation to prevent incomplete or invalid device records from being written.
  - Added configurable writer disable control for maintenance or troubleshooting.
  - Added clear success, warning, and error status reporting.

- **Bug Fixes**
  - Improved handling of unavailable components, malformed configuration, and database write failures.
  - Ensured failed records are routed for review instead of being silently discarded.
  - Added cleanup handling to prevent lingering database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->