### PR TITLE
docs: define Forge multi-repository boundaries

### DIFF
--- a/.claude/skills/osi-forge-boundaries/SKILL.md
+++ b/.claude/skills/osi-forge-boundaries/SKILL.md
@@ -8,17 +8,21 @@ description: Use when an OSI Forge worker or controller is executing an issue-to
 ## Overview
 
 Forge Stage 1 agents work in disposable test-VPS worktrees and prove changes
-with local commands. They do not deploy, SSH, read live secrets, inspect
-production, or merge their own work. If correct execution appears to require a
-forbidden action, stop and write the finding into `execution-report.md`.
-Stage 1 is limited to `osi-os` jobs with risk class 0-2; requests that need
-production access, live gateway mutation, or deployment-only proof are
-stop-and-report outcomes.
+with local commands. The two approved repositories are `osi-os` and
+`osi-server`, with exactly one repository assigned to each job. Agents do not
+deploy, SSH, read live secrets, inspect production, or merge their own work. If
+correct execution appears to require a forbidden action, stop and write the
+finding into `execution-report.md`.
 
-Verified context: branch naming and draft-PR shape are specified in
-`docs/superpowers/specs/2026-07-08-field-to-pr-design.md` (`agent/req-*`,
-draft PR, evidence body). Production restrictions are in `AGENTS.md`
-("Production cloud access").
+Stage 1 accepts risk class 0-2 jobs. Requests that need production access, live
+gateway mutation, or deployment-only proof are stop-and-report outcomes.
+
+Verified context: the current controller creates branches named
+`forge/<repo-short-name>/<issue-number>-<slug>/attempt-<n>`. Legacy
+`agent/req-*` branches remain readable only for historical jobs. Draft-PR and
+evidence requirements originate in
+`docs/superpowers/specs/2026-07-08-field-to-pr-design.md`. Production
+restrictions are in `AGENTS.md` ("Production cloud access").
 
 ## Environment
 
@@ -26,9 +30,9 @@ draft PR, evidence body). Production restrictions are in `AGENTS.md`
 |---|---|
 | Disposable worktree on a test VPS | SSH to any gateway or server |
 | Local repo reads and writes within the assigned scope | Docker or host-level service mutation |
-| Local tests, build commands, static verifiers | Reading server `.env` or credential files |
-| Git commits on the assigned branch | Touching a live gateway or `osicloud.ch` |
-| Draft PR creation from `agent/*` branches | Pushing non-`agent/*` branches or merging |
+| Repository-owned tests, builds, and static verifiers | Reading server `.env` or credential files |
+| Git commits on the assigned `forge/*` branch | Touching a live gateway or `osicloud.ch` |
+| Draft PR creation from the assigned `forge/*` branch | Pushing any other branch, marking ready, or merging |
 
 ## Absolute Prohibitions
 
@@ -43,7 +47,7 @@ gap instead of assuming human review will catch it later.
 | Secret-looking values in diffs | Prevents token, key, AppKey, password, and credential leakage into git history. |
 | Credential paths in diffs | Prevents accidental reads or writes of `.env`, SSH keys, Node-RED credentials, gateway tokens, and similar files. |
 | Oversized diffs beyond the request limit | Keeps worker output reviewable and prevents broad, uncontrolled edits. |
-| Branch names outside the allowed `agent/*` / `agent/req-*` shape | Keeps automation isolated from maintainer and production branches. |
+| Branch names outside `forge/<repo-short-name>/<issue-number>-<slug>/attempt-<n>` | Keeps each repository, issue, and immutable attempt bound to one automation branch. |
 | Controller content-scan findings when enabled for the current job | Honors task-specific deny lists without pretending every policy item is universally scanned. |
 
 ### Policy, caught by review unless a gate also exists
@@ -58,12 +62,46 @@ They are still forbidden by policy and should be reported when seen.
 | Raw IP addresses in new code or docs | They can bypass named-environment policy and hide production coupling. |
 | SSH, live gateway access, or `osicloud.ch` access | Live farms and production cloud are outside Forge Stage 1. |
 | Docker or host service mutation | The disposable worktree is the boundary; do not mutate the worker host. |
+| Tailscale or controller admin commands | Worker identities cannot enter the operator control plane. |
+| Provider, model-routing, or authentication changes | These are controller policy, not job scope. |
+
+## Repository Boundary
+
+An `osi-os` job may edit and verify only its assigned OSI OS worktree. Existing
+edge, hardware, profile-parity, schema, migration, live-Pi, and production
+restrictions continue to apply.
+
+An `osi-server` job may run repository-owned backend, frontend, and
+prediction-service checks in its assigned OSI Server worktree. It may not
+deploy the server, access production, read live secrets, open a Docker socket,
+or mutate a host service.
+
+Cross-repository evidence may identify a required companion change, but the
+worker must not edit the sister repository. Record the dependency and leave it
+for a separate job.
+
+## Provider and Control Boundary
+
+The controller owns role assignment, subscription authentication, model
+routing, cancellation, and publication. Workers cannot change those policies
+or invoke a provider outside the assigned stage. Subscription exhaustion marks
+the job `BLOCKED_USAGE`; it never enables API-key, metered, or other paid
+fallback.
+
+The human `forge-admin` Tailscale path is an operator capability. It is not
+available to workers and does not grant them SSH, controller admin commands,
+deployment rights, or secret access.
+
+Authenticated GitHub Mobile commands are limited to `start`, `status`,
+`cancel`, `retry`, and an allowlisted OpenCode reviewer override. No mobile
+command may change the worker model, controller policy, repository, base
+branch, risk class, or authentication source.
 
 ## Deployment Awareness
 
 | Need | Stage 1 handling |
 |---|---|
-| Prove parser, schema, flow, GUI, codec, or contract behavior locally inside an allowed class 0-2 job | Run the local verifier or test command and paste real output into `execution-report.md`. |
+| Prove parser, schema, flow, GUI, codec, backend, frontend, or contract behavior locally inside an allowed class 0-2 job | Run the repository-owned verifier or test command and paste real output into `execution-report.md`. |
 | Prove a change works only after deployment to a gateway or cloud service | Stop and report. Runtime deployment verification wrappers are Stage 2 - not yet available. |
 | Verify a live Pi, Node-RED runtime, ChirpStack, MQTT, or cloud pending-command path | Stop and report. Stage 1 has no SSH, live gateway, or production access. |
 | Need a deploy/verify wrapper named by a spec | If the wrapper is not present and approved in the current Stage 1 runner, stop and report "Stage 2 - not yet available"; do not emulate it manually. |
@@ -71,14 +109,17 @@ They are still forbidden by policy and should be reported when seen.
 ## Branch and PR Contract
 
 - Start from an issue or request artifact; do not invent scope outside it.
-- Use `agent/req-<shortid>-<slug>` for Forge worker branches unless the task
-  gives a stricter branch name.
+- Use the controller-assigned
+  `forge/<repo-short-name>/<issue-number>-<slug>/attempt-<n>` branch. Never
+  choose or rewrite the repository, issue, slug, or attempt identity.
+- Treat `agent/req-*` as a historical read-only shape. Do not create a new
+  branch with that prefix.
 - Open a draft PR only. The PR body must include issue link, root cause, files
   changed, commands run, and pasted evidence.
-- Never self-approve, mark ready, merge, squash, retarget, or delete branches
-  unless the maintainer explicitly instructs it in the current turn.
-- Push only `agent/*` worker branches. If the assigned task names a
-  non-`agent/*` branch, commit locally and stop for controller handling.
+- Never self-approve, mark ready, merge, squash, retarget, or delete branches.
+  Human integration actions remain outside the worker path.
+- Push only the exact controller-assigned `forge/*` branch. A different branch
+  name is a stop-and-report condition.
 
 ## Blocked Execution
 
@@ -93,7 +134,12 @@ If the correct next step appears to require a prohibited action:
 ## Common Mistakes
 
 - Treating "test VPS" as permission to read host secrets or mutate services.
+- Editing both repositories in one job because a cross-repository dependency
+  was discovered.
 - Calling an unimplemented Stage 2 wrapper by hand through SSH, Docker, or curl.
+- Treating the human `forge-admin` Tailscale path as a worker capability.
+- Falling back to API-key or metered provider usage when a subscription is
+  exhausted.
 - Claiming deployment proof when only local verifier output exists.
 - Assuming an action is allowed because no current gate blocks it. Review policy
   still applies.

--- a/.claude/skills/osi-forge-boundaries/SKILL.md
+++ b/.claude/skills/osi-forge-boundaries/SKILL.md
@@ -88,6 +88,20 @@ or invoke a provider outside the assigned stage. Subscription exhaustion marks
 the job `BLOCKED_USAGE`; it never enables API-key, metered, or other paid
 fallback.
 
+After implementation or repair, the controller runs the deterministic
+post-execution gate and repository verification before any reviewer. A failed
+gate or verification command vetoes publication; no model may override it.
+For a passing candidate, Codex Sol reviews first, OpenCode Go reviews the same
+SHA independently, and Claude Opus independently reviews the diff before its
+final adjudication. Draft publication requires all three reviewers to approve
+evidence bound to that candidate SHA and repair count.
+
+The controller permits at most one Luna repair. Starting that repair discards
+all earlier gate, verification, and review approvals. The repaired candidate
+must pass fresh gates, repository verification, and the complete three-reviewer
+sequence. Any remaining rejection blocks the job; the controller must not
+start a second repair.
+
 The human `forge-admin` Tailscale path is an operator capability. It is not
 available to workers and does not grant them SSH, controller admin commands,
 deployment rights, or secret access.


### PR DESCRIPTION
## Summary
- Document the existing Forge boundary for osi-os and osi-server jobs.
- Preserve neutral controller behavior, repository-specific worktrees, provider isolation, mobile controls, and the one-repair review loop.

## Validation
- Boundary skill anti-slop check: PASS.
- git diff --check: PASS.

## Scope
- Documentation only. No production access, merge, or deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository assignment and Stage 1 execution boundaries.
  * Documented the required `forge/.../attempt-<n>` branch naming convention and draft pull request requirements.
  * Expanded restrictions for administrative commands, provider settings, repository changes, and mobile Git operations.
  * Added guidance on deployment checks, reviewer approvals, repair workflows, and common execution mistakes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->