### PR TITLE
docs(playbook): six failure modes from the AgroLink S3 slice

### DIFF
--- a/docs/engineering-playbook.md
+++ b/docs/engineering-playbook.md
@@ -131,6 +131,22 @@ down where the next person will trip.
   mobile grid, an auth block), write a static guard test that fails when someone
   changes it casually. When you *intend* the change, update the pin in the same
   commit with a message saying why.
+- **A guard proves only what it scans — its scope silently becomes the fix's scope.**
+  A page-shell guard that globbed `src/pages` went green while the reported defect
+  was still live in `src/components`, because the page rendered a *second* viewport
+  shell inside itself. After a guard passes, confirm the defect is gone in the
+  rendered artifact, not just in the files the glob happened to reach. State a
+  guard's blind spot in a comment next to its predicate.
+- **Guards belong in the canonical repo first.** Three token guards lived only in the
+  mirror (osi-server) while the thing they guard is authored in osi-os; porting them
+  back surfaced 18 defects the mirror had already fixed, including two pages
+  referencing a token that does not exist. Enforcement weaker at the source than
+  downstream means the source can author defects and vendor them outward.
+- **Audit the shared primitive, not only its callers.** Every consumer can be
+  individually correct while the thing they all compose is wrong: one hardcoded
+  `bg-white` in a shared form field made every input in both GUIs unreadable in dark
+  theme. Sibling-grepping (§6) finds copies of a bug; it does not find the one place
+  that makes all the correct copies wrong.
 - **Never assert success on text you didn't produce.** Check exit codes directly;
   in pipelines the last command wins. In fish, `$status`; in scripts, `set -eu` and
   explicit `ls-remote --exit-code`-style confirmation for remote effects.
@@ -193,6 +209,22 @@ down where the next person will trip.
 - **Verify agent reports.** Trust structure, not claims: clean tree, expected commit
   list, gates re-run by the verifier. Agents (and engineers) sincerely report
   successes that didn't happen — the report is a hypothesis, the repo is the truth.
+  This includes *reviewers*: recompute any measured value before shipping it. A
+  review supplied a contrast ratio as 5.57:1 that measured 2.77:1 — the implementer
+  refused the instruction and reported, which is the behaviour to reward.
+- **Reviewers who see one artifact cannot see relations between artifacts.** Diff
+  review is blind to page-A-disagrees-with-page-B by construction, so eleven task
+  reviews and a whole-branch review all missed defects the maintainer found by
+  looking at the running app. Any property that lives *between* artifacts —
+  cross-page cohesion, cross-repo parity, whole-surface accessibility — needs a
+  review whose unit is the whole surface, scheduled as work, not as a final glance.
+- **A self-contradicting plan is normal at scale; make reporting cheaper than
+  forcing.** Ten instructions in one 12-task plan turned out to be wrong (a type
+  required elsewhere marked for deletion, a prescribed enum value that does not
+  compile, a test asserting on ordering rather than content). Every time, the
+  implementer that stopped and reported was right. Say so in the brief explicitly —
+  "if an instruction does not fit the code, report rather than force it" — and treat
+  a documented deviation as a success, not a defect.
 - **Expect interruption.** Quota walls and network flaps killed agents mid-write
   this month. Design work to be resumable: plans on disk, commits early, state in
   the branch — then inspect leftovers before resuming (the half-executed worktree
@@ -202,9 +234,11 @@ down where the next person will trip.
 
 A change is done when: the issue's claim was re-verified against reality; the plan
 and its review live in the repo; tests exist that fail without the change; every
-gate is green *as re-run by a non-author*; both profiles/seeds are in parity where
-applicable; the PR body carries root cause, tradeoffs, and evidence; stale docs and
-memory touched by the change are corrected; and follow-ups you chose not to do are
-filed as issues, not left as silences.
+gate is green *as re-run by a non-author*; **a user can actually reach the
+behaviour** — a fully-tested component that nothing mounts is zero delivered
+capability, and its suite is green precisely because nothing exercises it; both
+profiles/seeds are in parity where applicable; the PR body carries root cause,
+tradeoffs, and evidence; stale docs and memory touched by the change are corrected;
+and follow-ups you chose not to do are filed as issues, not left as silences.
 
 Anything less is work in progress wearing a green checkmark.


### PR DESCRIPTION
Six process failure modes, all paid for during a single 12-task slice, none covered by the existing playbook. Added to §4 (prevention), §7 (orchestration), §8 (definition of done). +38 lines on a referenced-not-auto-loaded file.

## Why these six

Each traces to a concrete incident in the AgroLink GUI-parity S3 slice, in keeping with the playbook's rule that every entry cost something real.

### §4 — guards

**A guard proves only what it scans.** A page-shell guard globbing `src/pages` went green while the maintainer's originally-reported defect was still live on phones — `HistoryDashboard` renders a *second* viewport shell from `src/components` that still painted a hardcoded background. The guard's scope had silently become the fix's scope.

**Guards belong in the canonical repo first.** All three token guards lived only in osi-server, while the thing they guard (`ui-core`) is authored in osi-os. Porting them back immediately surfaced 18 edge-only defects the mirror had already fixed — including two admin pages referencing `--background`, a token that does not exist, so they rendered with no page background at all. Enforcement weaker at the source than downstream lets the source author defects and vendor them outward.

**Audit the shared primitive, not only its callers.** `ui-core/FormField` hardcoded `bg-white`, byte-identical in both repos, making every form input in both GUIs render at 1.08:1 in dark theme — login, registration, pairing, journal capture. Every consuming component was individually correct. Sibling-grepping (§6) finds copies of a bug; it does not find the one place that makes all the correct copies wrong.

### §7 — review and delegation

**Verifying agent reports extends to reviewers.** A review supplied a contrast ratio as 5.57:1 that actually measured 2.77:1 — an AA failure. The implementer recomputed it, refused the instruction, and reported. That is the behaviour to reward.

**Reviewers who see one artifact cannot see relations between artifacts.** Eleven task reviews and a whole-branch review all missed defects the maintainer found by looking at the running app, because page-A-disagrees-with-page-B is invisible to diff review by construction. Properties that live *between* artifacts need a review whose unit is the whole surface, scheduled as work rather than as a final glance.

**A self-contradicting plan is normal at scale.** Ten instructions in one 12-task plan turned out to be wrong — a type required elsewhere marked for deletion, a prescribed enum value that does not compile, a test asserting on ordering rather than content. Every time, the implementer that stopped and reported was right. Briefs should say so explicitly and treat a documented deviation as a success.

### §8 — definition of done

**Reachability.** T10 shipped a fully-built, fully-tested `DetailPanel` that nothing mounted: correction, copy-an-entry and void were unreachable, every test passed, and the suite was green *precisely because nothing exercised it*. Wiring it up then immediately exposed a real bug (stale edit state carrying between entries) that could not exist while the component was unmounted.

## Placement

The playbook rather than AGENTS.md: AGENTS.md is auto-loaded and holds operational facts, so process lessons there are pure token tax on every session. The playbook is referenced on demand and already framed as "the failure modes this repo has already paid for." No AGENTS.md pointer change needed — its line 7 framing already covers this.

Verified `docs/engineering-playbook.md` is byte-identical on `main` and `AgroLink`, so this applies cleanly to both; branched from `origin/main` so mainline work gets it rather than it being stranded on the deploy branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded engineering guidance for documenting guard scope, limitations, ownership, and validation.
  * Added review expectations for independently verified measurements and complete cross-artifact checks.
  * Clarified that conflicting instructions should be reported explicitly.
  * Updated completion criteria to ensure users can access implemented behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->