### PR TITLE
docs(playbook): a check that cannot fail is not a check

### DIFF
--- a/docs/engineering-playbook.md
+++ b/docs/engineering-playbook.md
@@ -157,6 +157,14 @@ down where the next person will trip.
   match count, where `-c` overrides `-o` and silently counts *lines*. Both exited 0.
   Before trusting a check, make it fail on purpose: run it against a known-bad input
   and confirm it goes red. If it cannot be made to fail, it is not a check.
+- **A contrast ratio must be same-theme, and measured against the surface the thing
+  actually renders on.** Both halves have been got wrong here, in one ruling: a
+  *light* token hex was measured against the *dark* card (giving a token's opposite
+  a fabricated 5.34 and its correct answer a fabricated 1.02), and the element turned
+  out to render on `--surface`, not `--card`, because nobody walked the parent chain.
+  A cross-theme figure is not an inaccurate number, it is a meaningless one — and it
+  reads as authoritative. Read the token's value for the theme you are measuring, and
+  `grep` the ancestors for the background that is really behind the pixel.
 - **Stacked PRs:** merge the base *without* deleting its branch (GitHub auto-CLOSES
   children on base-branch deletion and they cannot be reopened) → rebase the child
   `--onto origin/main <old-base-sha>` → force-push → retarget → merge child → then

--- a/docs/engineering-playbook.md
+++ b/docs/engineering-playbook.md
@@ -150,6 +150,13 @@ down where the next person will trip.
 - **Never assert success on text you didn't produce.** Check exit codes directly;
   in pipelines the last command wins. In fish, `$status`; in scripts, `set -eu` and
   explicit `ls-remote --exit-code`-style confirmation for remote effects.
+- **A verification command that can pass without examining anything is worse than
+  none** — it manufactures confidence and survives review. Two in one slice: a
+  "no mutating handlers changed" proof used bare `git diff` with no rev-range, which
+  post-commit inspects zero lines and always passes; and `grep -coE` was used for a
+  match count, where `-c` overrides `-o` and silently counts *lines*. Both exited 0.
+  Before trusting a check, make it fail on purpose: run it against a known-bad input
+  and confirm it goes red. If it cannot be made to fail, it is not a check.
 - **Stacked PRs:** merge the base *without* deleting its branch (GitHub auto-CLOSES
   children on base-branch deletion and they cannot be reopened) → rebase the child
   `--onto origin/main <old-base-sha>` → force-push → retarget → merge child → then


### PR DESCRIPTION
Follow-up to #154, which merged before this commit was pushed — the lesson below was left stranded on the branch.

A seventh failure mode from the same program, and distinct from the `Never assert success on text you didn't produce` bullet already in §4. There, the command runs and its output is misread. Here, the command runs, exits 0, and inspects **nothing at all**.

## Two instances in one slice, both of which passed review

**A "no mutating handlers were changed" proof used bare `git diff` with no rev-range.** Run after committing, that returns empty, so the check passed without examining a single line. The underlying claim happened to be true — which is exactly why nobody noticed the proof was worthless. It was caught only because a reviewer re-ran it scoped to `04315827..265c123c` out of habit.

**`grep -coE` used to count matches**, where `-c` overrides `-o` and counts *lines* instead. Eight expected match counts were being compared against line counts, and would have disagreed on every run.

## The remedy

Make the check fail on purpose before trusting it: run it against a known-bad input and confirm it goes red. If it cannot be made to fail, it is not a check.

This is the discipline the repo already applies to tests — write the failing test, watch it fail *for the stated reason*, then implement — extended to the ad-hoc commands that gate a task's done-condition. Those commands currently get less scrutiny than test code despite carrying the same evidentiary weight.

+10 lines in §4, adjacent to the existing exit-code bullet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for validating verification commands with known-bad inputs.
  * Documented safeguards against false-positive checks caused by empty diff ranges or invalid search options.
  * Requires confirming that verification checks fail when expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->